### PR TITLE
feat: task update に --body オプションを追加

### DIFF
--- a/packages/cli/src/__tests__/task-commands.test.ts
+++ b/packages/cli/src/__tests__/task-commands.test.ts
@@ -121,6 +121,26 @@ describe("applyTaskUpdate", () => {
     expect(result.task.title).toBe("New title");
   });
 
+  it("updates body", () => {
+    const task = makeTask();
+    const result = applyTaskUpdate(task, { body: "New description" }, config);
+    expect(result.error).toBeUndefined();
+    expect(result.task.body).toBe("New description");
+  });
+
+  it("clears body with empty string", () => {
+    const task = makeTask({ body: "Existing body" });
+    const result = applyTaskUpdate(task, { body: "" }, config);
+    expect(result.error).toBeUndefined();
+    expect(result.task.body).toBe("");
+  });
+
+  it("does not change body when not specified", () => {
+    const task = makeTask({ body: "Keep this" });
+    const result = applyTaskUpdate(task, { title: "New title" }, config);
+    expect(result.task.body).toBe("Keep this");
+  });
+
   it("updates type", () => {
     const task = makeTask();
     const result = applyTaskUpdate(task, { type: "epic" }, config);

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -9,6 +9,7 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export interface TaskUpdateOptions {
   title?: string;
+  body?: string;
   type?: string;
   state?: "open" | "closed";
   status?: string;
@@ -49,6 +50,7 @@ export function applyTaskUpdate(
   const updated = { ...task };
 
   if (opts.title) updated.title = opts.title;
+  if (opts.body !== undefined) updated.body = opts.body;
   if (opts.type) {
     // Remove old type's github_label, add new type's github_label
     const oldTypeDef = config.task_types[task.type];
@@ -157,6 +159,7 @@ export const taskUpdateCommand = new Command("update")
   .description("Update a task (single or bulk)")
   .argument("[id]", "Task ID (e.g. 6, #6, owner/repo#6). Omit for bulk update with filters.")
   .option("--title <title>", "Set title")
+  .option("--body <body>", "Set body/description")
   .option("--type <type>", "Set task type")
   .option("--state <state>", "Set state (open/closed)")
   .option("--start-date <date>", "Set start date (YYYY-MM-DD or 'none' to clear)")
@@ -183,6 +186,7 @@ export const taskUpdateCommand = new Command("update")
 
       const updateOpts: TaskUpdateOptions = {
         title: opts.title,
+        body: opts.body,
         type: opts.type,
         state: opts.state,
         status: opts.status,


### PR DESCRIPTION
## Summary

- `gh-gantt task update` に `--body` オプションを追加し、タスクの説明（body）を CLI から更新可能にした
- `TaskUpdateOptions` に `body` フィールドを追加、`applyTaskUpdate` で処理
- body の更新・クリア・未指定時の3テストを追加

Closes #40

## Test plan

- [x] `pnpm --filter @gh-gantt/cli exec vitest run src/__tests__/task-commands.test.ts` — 50テスト全通過
- [x] `gh-gantt task update <id> --body "description"` で body が更新されること
- [x] `gh-gantt push` 後に GitHub Issue の body に反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)