### PR TITLE
docs: workflow SKILL.md のフォールバック注記を明確化

### DIFF
--- a/skills/gh-gantt-progress/references/next-task.md
+++ b/skills/gh-gantt-progress/references/next-task.md
@@ -12,6 +12,8 @@ gh-gantt list --state open --unblocked --sort end_date
 
 ブロッカーが解消済みで期限が近い順にタスクを表示する。
 
+注: `--unblocked` や `--sort` がエラーになる場合は、これらのオプションを外した `gh-gantt list --state open` にフォールバックする。
+
 ### 2. 候補タスクの詳細確認
 
 上位の候補について `gh-gantt show <id>` で body・blocked_by・priority を確認する。

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -26,7 +26,7 @@ Evidence: コマンド出力をそのまま提示する。
 2. **OPTIONAL:** `gh-gantt-progress` でタスクの状態を確認
 3. タスク確認 — `gh-gantt list --state open` を実行する。
    件数が多い場合は CLI でサポートされているフィルタ（例: `--backlog`, `--scheduled`, `--type`, `--sort`）の併用を提案する。
-   注: `--unblocked` および `--sort` オプションが利用中の `gh-gantt` のバージョンで利用可能な場合はそれらを使用し、利用できない場合はフォールバックとして `gh-gantt list --state open` を使用する。
+   注: `--unblocked` および `--sort` オプションが利用中の `gh-gantt` のバージョンで利用可能な場合はそれらを使用し、利用できない場合（コマンドがエラーになる場合）はこれらのオプションを外した `gh-gantt list --state open` にフォールバックする。
    **CLI の出力をそのまま表示すること。要約・再フォーマット・独自テーブルへの変換・一部タスクの省略は一切禁止。**
    ユーザーに選択を促す。
 4. タスクのステータスを作業中に更新 — config に `statuses` が定義されていれば `gh-gantt update <number> --status <作業中ステータス>`（`done: false` のステータスを使用）。未定義ならスキップ


### PR DESCRIPTION
## Summary
- `--unblocked`/`--sort` がエラーになる場合に「オプションを外した」コマンドにフォールバックする旨を明記
- `gh-gantt-progress` の `next-task.md` にも同様のフォールバック注記を追加

## Test plan
- [x] ドキュメント変更のみ、ビルド・テストへの影響なし

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `gh-gantt` の旧バージョンで `--unblocked` および `--sort` オプションがサポートされていない場合のフォールバック動作を明確化しました。エラーが発生した場合、システムはこれらのオプションを除いたコマンドで自動的に再実行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->