### PR TITLE
feat(ui): タスクタイプ凡例（レジェンド）の追加

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -583,6 +583,7 @@ export function App() {
         redoCount={redoCount}
         undoRedoBusy={undoRedoBusy}
         taskTypes={config?.task_types ?? {}}
+        sprints={config?.sprints}
         enabledTypes={enabled}
         onToggleType={toggleType}
       />

--- a/packages/ui/src/__tests__/legend-group.test.tsx
+++ b/packages/ui/src/__tests__/legend-group.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { LegendGroup } from "../components/toolbar/LegendGroup.js";
 import type { TaskType } from "../types/index.js";
+import type { SprintConfig } from "@gh-gantt/shared";
 
 const taskTypes: Record<string, TaskType> = {
   epic: {
@@ -31,6 +32,21 @@ const taskTypes: Record<string, TaskType> = {
   },
 };
 
+const sprints: SprintConfig[] = [
+  {
+    name: "Sprint 1",
+    start_date: "2020-01-01",
+    end_date: "2020-01-14",
+    color: "#3b82f6",
+  },
+  {
+    name: "Sprint Current",
+    start_date: "2025-01-01",
+    end_date: "2099-12-31",
+    color: "#10b981",
+  },
+];
+
 describe("LegendGroup", () => {
   it("renders the legend button", () => {
     const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} />);
@@ -38,19 +54,40 @@ describe("LegendGroup", () => {
     expect(html).toContain("Legend");
   });
 
-  it("includes all task type labels in markup when expanded by default state", () => {
-    // The component starts collapsed, so the panel is not in the initial render
+  it("starts collapsed and does not render the dialog panel", () => {
     const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} />);
     expect(html).not.toContain('role="dialog"');
   });
 
-  it("renders the palette icon for each display type", () => {
+  it("renders a single palette icon in the toggle button", () => {
     const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} />);
     expect(html).toContain("lucide-palette");
+    // Only one Palette icon in the button, not one per type
+    const matches = html.match(/lucide-palette/g);
+    expect(matches).toHaveLength(1);
   });
 
   it("renders with empty task types", () => {
     const html = renderToStaticMarkup(<LegendGroup taskTypes={{}} />);
     expect(html).toContain("Legend");
+  });
+
+  it("includes aria-haspopup on the toggle button", () => {
+    const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} />);
+    expect(html).toContain('aria-haspopup="dialog"');
+  });
+
+  it("renders sprint legends when sprints are provided", () => {
+    // Use a wrapper that forces open state via click simulation is not possible
+    // in SSR, so we test that the component accepts the sprints prop without error
+    const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} sprints={sprints} />);
+    // Panel is collapsed by default, sprints should not appear
+    expect(html).not.toContain("Sprint 1");
+  });
+
+  it("renders without sprints when prop is omitted", () => {
+    const html = renderToStaticMarkup(<LegendGroup taskTypes={taskTypes} />);
+    expect(html).toContain("Legend");
+    expect(html).not.toContain("Sprints");
   });
 });

--- a/packages/ui/src/components/toolbar/IconButton.tsx
+++ b/packages/ui/src/components/toolbar/IconButton.tsx
@@ -8,6 +8,8 @@ interface IconButtonProps {
   disabled?: boolean;
   badge?: number;
   children?: React.ReactNode;
+  "aria-haspopup"?: "dialog" | "menu" | "listbox" | "tree" | "grid" | boolean;
+  "aria-expanded"?: boolean;
 }
 
 const baseStyle: React.CSSProperties = {
@@ -57,6 +59,8 @@ export function IconButton({
   disabled = false,
   badge,
   children,
+  "aria-haspopup": ariaHasPopup,
+  "aria-expanded": ariaExpanded,
 }: IconButtonProps) {
   const isActive = !!active;
 
@@ -68,6 +72,8 @@ export function IconButton({
       title={title}
       aria-label={title}
       aria-pressed={active === undefined ? undefined : active}
+      aria-haspopup={ariaHasPopup}
+      aria-expanded={ariaExpanded}
       style={{ ...baseStyle, ...(isActive ? activeStyle : {}), ...(disabled ? disabledStyle : {}) }}
     >
       {icon}

--- a/packages/ui/src/components/toolbar/LegendGroup.tsx
+++ b/packages/ui/src/components/toolbar/LegendGroup.tsx
@@ -1,12 +1,14 @@
 // packages/ui/src/components/toolbar/LegendGroup.tsx
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Palette } from "lucide-react";
+import type { SprintConfig } from "@gh-gantt/shared";
 import type { TaskType } from "../../types/index.js";
 import { ToolbarGroup } from "./ToolbarGroup.js";
 import { IconButton } from "./IconButton.js";
 
 interface LegendGroupProps {
   taskTypes: Record<string, TaskType>;
+  sprints?: SprintConfig[];
 }
 
 function DisplayIcon({ display }: { display: TaskType["display"] }) {
@@ -56,18 +58,39 @@ const itemStyle: React.CSSProperties = {
   color: "var(--color-text-secondary, #555)",
 };
 
-export function LegendGroup({ taskTypes }: LegendGroupProps) {
+function isCurrentSprint(sprint: SprintConfig): boolean {
+  const now = new Date();
+  const start = new Date(sprint.start_date);
+  const end = new Date(sprint.end_date);
+  return now >= start && now <= end;
+}
+
+export function LegendGroup({ taskTypes, sprints }: LegendGroupProps) {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const entries = Object.entries(taskTypes);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
 
   return (
     <ToolbarGroup label="Legend">
-      <div style={{ position: "relative" }}>
+      <div ref={wrapperRef} style={{ position: "relative" }}>
         <IconButton
           icon={<Palette size={14} />}
           title="Task Type Legend"
           onClick={() => setOpen((prev) => !prev)}
           active={open}
+          aria-haspopup="dialog"
+          aria-expanded={open}
         />
         {open && (
           <div role="dialog" aria-label="Task type legend" style={panelStyle}>
@@ -87,6 +110,40 @@ export function LegendGroup({ taskTypes }: LegendGroupProps) {
                 <span>{def.label}</span>
               </div>
             ))}
+            {sprints && sprints.length > 0 && (
+              <>
+                <div
+                  style={{
+                    borderTop: "1px solid var(--color-border, #ddd)",
+                    margin: "6px 0",
+                  }}
+                />
+                <div style={{ ...itemStyle, fontWeight: 600, marginBottom: 6 }}>
+                  <span>Sprints</span>
+                </div>
+                {sprints.map((sprint, i) => {
+                  const current = isCurrentSprint(sprint);
+                  return (
+                    <div key={`${sprint.name}-${i}`} style={itemStyle}>
+                      <span
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: 2,
+                          background: sprint.color ?? "#3b82f6",
+                          opacity: current ? 1 : 0.3,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span style={{ opacity: current ? 1 : 0.6 }}>
+                        {sprint.name}
+                        {current ? " (current)" : ""}
+                      </span>
+                    </div>
+                  );
+                })}
+              </>
+            )}
           </div>
         )}
       </div>

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { Keyboard } from "lucide-react";
 import type { DisplayOption } from "../../hooks/useDisplayOptions.js";
+import type { SprintConfig } from "@gh-gantt/shared";
 import type { TaskType } from "../../types/index.js";
 import { ZoomGroup } from "./ZoomGroup.js";
 import { DisplayGroup } from "./DisplayGroup.js";
@@ -25,6 +26,7 @@ interface ToolbarProps {
   hideClosed: boolean;
   onToggleHideClosed: () => void;
   taskTypes: Record<string, TaskType>;
+  sprints?: SprintConfig[];
   enabledTypes: Set<string>;
   onToggleType: (typeName: string) => void;
   selectedAssignee: string | null;
@@ -106,7 +108,7 @@ export function Toolbar(props: ToolbarProps) {
         redoCount={props.redoCount}
         undoRedoBusy={props.undoRedoBusy}
       />
-      <LegendGroup taskTypes={props.taskTypes} />
+      <LegendGroup taskTypes={props.taskTypes} sprints={props.sprints} />
       <div style={{ flex: 1 }} />
       <SyncGroup
         onPull={props.onPull}


### PR DESCRIPTION
## Summary
- Toolbar にタスクタイプの凡例（レジェンド）パネルを追加
- 各タスクタイプの色ドット・表示スタイルアイコン（bar/summary/milestone）・ラベルを表示
- 折りたたみ可能で画面スペースを節約

Closes #84

## Test plan
- [x] LegendGroup コンポーネントのレンダリングテスト（4件）
- [x] pnpm build / test (78 passed) / lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ツールバーに凡例パネルを追加。パレットアイコンで開閉し、タスクタイプごとの視覚説明（サマリー／マイルストーン／バー等）を表示できます。sprintsデータがある場合は「Sprints」セクションを表示。
* **アクセシビリティ**
  * トグル操作に必要なARIA属性を付与し、キーボードやスクリーンリーダーでの操作性を改善。
* **テスト**
  * 凡例のサーバー側レンダリング／初期状態／アイコン表示などを検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->