### PR TITLE
fix(cli): push 時の partial failure で snapshot が不整合になる問題を修正 (#129)

### DIFF
--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { executePush } from "../sync/push-executor.js";
 import { extractSyncFields, hashTask } from "../sync/hash.js";
+import { computeLocalDiff } from "../sync/diff.js";
 import type { Task, TasksFile, SyncState, Config } from "@gh-gantt/shared";
 
 function makeTask(id: string, overrides: Partial<Task> = {}): Task {
@@ -911,7 +912,7 @@ describe("executePush", () => {
     expect(Math.max(start5, start6)).toBeLessThan(Math.min(end5, end6));
   });
 
-  it("relation failure preserves old syncFields for retry (Fix partial-failure)", async () => {
+  it("relation failure preserves old syncFields and enables retry via computeLocalDiff", async () => {
     const parentTask = makeTask("o/r#10", { github_issue: 10 });
     const task = makeTask("o/r#1", {
       github_issue: 1,
@@ -964,6 +965,11 @@ describe("executePush", () => {
       const snap = newSyncState.snapshots["o/r#1"];
       expect(snap).toBeDefined();
       expect(snap!.syncFields?.parent).toBe(oldSyncFields.parent);
+
+      // Hash must differ from hashTask(task) so computeLocalDiff detects the diff for retry
+      expect(snap!.hash).not.toBe(hashTask(task));
+      const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+      expect(retryDiffs.some((d) => d.id === "o/r#1")).toBe(true);
     } finally {
       warnSpy.mockRestore();
     }
@@ -1014,9 +1020,13 @@ describe("executePush", () => {
     const snap = newSyncState.snapshots["o/r#1"];
     expect(snap).toBeDefined();
     expect(snap!.syncFields?.parent).toBe("o/r#10");
+
+    // No diff should remain — relation was fully synced
+    const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+    expect(retryDiffs.some((d) => d.id === "o/r#1")).toBe(false);
   });
 
-  it("blocked_by failure preserves old syncFields.blocked_by for retry", async () => {
+  it("blocked_by failure preserves old syncFields.blocked_by and enables retry", async () => {
     const blocker = makeTask("o/r#5", { github_issue: 5 });
     const task = makeTask("o/r#1", {
       github_issue: 1,
@@ -1069,6 +1079,167 @@ describe("executePush", () => {
       const snap = newSyncState.snapshots["o/r#1"];
       expect(snap).toBeDefined();
       expect(snap!.syncFields?.blocked_by).toEqual(oldSyncFields.blocked_by);
+
+      // Hash must enable retry
+      expect(snap!.hash).not.toBe(hashTask(task));
+      const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+      expect(retryDiffs.some((d) => d.id === "o/r#1")).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("parent-only failure preserves parent but updates blocked_by (per-field tracking)", async () => {
+    const parentTask = makeTask("o/r#10", { github_issue: 10 });
+    const blocker = makeTask("o/r#5", { github_issue: 5 });
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      parent: "o/r#10",
+      blocked_by: [{ task: "o/r#5", type: "finish-to-start" as const, lag: 0 }],
+    });
+    const tasksFile: TasksFile = {
+      tasks: [parentTask, blocker, task],
+      cache: { comments: {}, reactions: {} },
+    };
+    const syncState: SyncState = {
+      last_synced_at: "",
+      project_node_id: "PVT_1",
+      id_map: {
+        "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        "o/r#5": { issue_number: 5, issue_node_id: "ISSUE_5", project_item_id: "ITEM_5" },
+        "o/r#10": { issue_number: 10, issue_node_id: "ISSUE_10", project_item_id: "ITEM_10" },
+      },
+      field_ids: {},
+      snapshots: {
+        "o/r#1": {
+          hash: "stale-hash",
+          synced_at: "",
+          syncFields: extractSyncFields(makeTask("o/r#1", { github_issue: 1 })),
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+        "o/r#5": {
+          hash: hashTask(blocker),
+          synced_at: "",
+          syncFields: extractSyncFields(blocker),
+        },
+        "o/r#10": {
+          hash: hashTask(parentTask),
+          synced_at: "",
+          syncFields: extractSyncFields(parentTask),
+        },
+      },
+    };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const mockGql = makeMockGql({
+        addSubIssue: () => {
+          throw new Error("sub-issue API error");
+        },
+        // addBlockedBy succeeds (default handler)
+      });
+
+      const { syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        syncState,
+      );
+
+      const snap = newSyncState.snapshots["o/r#1"];
+      expect(snap).toBeDefined();
+      // Parent should be rolled back to baseline (null)
+      expect(snap!.syncFields?.parent).toBeNull();
+      // blocked_by should reflect the successfully synced new value
+      expect(snap!.syncFields?.blocked_by).toEqual(task.blocked_by);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("newly created task relation failure uses correct baseline (not saveProgress snapshot)", async () => {
+    const parentTask = makeTask("o/r#10", { github_issue: 10 });
+    const draftTask = makeTask("o/r#draft-1", {
+      github_issue: null,
+      parent: "o/r#10",
+      title: "New task",
+    });
+    const tasksFile: TasksFile = {
+      tasks: [parentTask, draftTask],
+      cache: { comments: {}, reactions: {} },
+    };
+    const syncState: SyncState = {
+      last_synced_at: "",
+      project_node_id: "PVT_1",
+      id_map: {
+        "o/r#10": { issue_number: 10, issue_node_id: "ISSUE_10", project_item_id: "ITEM_10" },
+      },
+      field_ids: {},
+      snapshots: {
+        "o/r#10": {
+          hash: hashTask(parentTask),
+          synced_at: "",
+          syncFields: extractSyncFields(parentTask),
+        },
+      },
+    };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const mockGql = vi.fn().mockImplementation(async (query: string, _vars?: any) => {
+        // createIssue (mutation)
+        if (query.includes("createIssue")) {
+          return { createIssue: { issue: { id: "NEW_ISSUE_1", number: 99 } } };
+        }
+        // addProjectItem (mutation)
+        if (query.includes("addProjectV2ItemById")) {
+          return { addProjectV2ItemById: { item: { id: "NEW_ITEM_1" } } };
+        }
+        // addSubIssue — fail (mutation)
+        if (query.includes("addSubIssue")) {
+          throw new Error("sub-issue API error");
+        }
+        // updateProjectV2ItemFieldValue (mutation)
+        if (query.includes("updateProjectV2ItemFieldValue")) {
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        }
+        // fetchRepositoryMetadata (labels + milestones) — must check before repositoryId
+        if (query.includes("labels") || query.includes("milestones")) {
+          return { repository: { id: "REPO_1", labels: { nodes: [] }, milestones: { nodes: [] } } };
+        }
+        // fetchRepositoryId
+        if (query.includes("repository(")) {
+          return { repository: { id: "REPO_1" } };
+        }
+        // batch updatedAt
+        if (query.includes("issue(number:")) {
+          const numbers = extractBatchIssueNumbers(query);
+          return makeBatchIssueResponse(numbers);
+        }
+        return {};
+      });
+
+      const { syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        syncState,
+        {
+          saveProgress: async () => {},
+        },
+      );
+
+      // The new task should have been converted to o/r#99
+      const snap = newSyncState.snapshots["o/r#99"];
+      expect(snap).toBeDefined();
+      // Parent should be rolled back to null (pre-relation baseline for new tasks)
+      expect(snap!.syncFields?.parent).toBeNull();
+
+      // computeLocalDiff should detect the diff for retry
+      const newTask = tasksFile.tasks.find((t) => t.id === "o/r#99");
+      expect(newTask).toBeDefined();
+      const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+      expect(retryDiffs.some((d) => d.id === "o/r#99")).toBe(true);
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/cli/src/sync/hash.ts
+++ b/packages/cli/src/sync/hash.ts
@@ -32,7 +32,10 @@ export function extractSyncFields(task: Task): SyncFields {
  * should not trigger a sync diff.
  */
 export function hashTask(task: Task): string {
-  const syncFields = extractSyncFields(task);
-  const json = JSON.stringify(syncFields);
+  return hashSyncFields(extractSyncFields(task));
+}
+
+export function hashSyncFields(fields: SyncFields): string {
+  const json = JSON.stringify(fields);
   return createHash("sha256").update(json).digest("hex");
 }

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -1,7 +1,7 @@
 import type { graphql } from "@octokit/graphql";
 import type { Config, Task, SyncState, TasksFile, TaskType } from "@gh-gantt/shared";
 import { computeLocalDiff } from "./diff.js";
-import { hashTask, extractSyncFields } from "./hash.js";
+import { hashTask, hashSyncFields, extractSyncFields } from "./hash.js";
 import {
   isDraftTask,
   isMilestoneSyntheticTask,
@@ -104,8 +104,17 @@ export async function executePush(
   // Track which tasks were actually pushed (by their current ID after push)
   const pushedTaskIds = new Set<string>();
   const replacedDraftIds = new Set<string>();
-  // Track tasks where relationship mutations failed (partial failure)
-  const failedRelationTaskIds = new Set<string>();
+  // Track per-field relationship mutation failures for accurate partial retry
+  interface RelationFailure {
+    parentFailed: boolean;
+    blockedByFailed: boolean;
+  }
+  const failedRelations = new Map<string, RelationFailure>();
+  // Pre-relation baseline: remote state before relation mutations were attempted
+  const preRelationBaseline = new Map<
+    string,
+    Pick<import("@gh-gantt/shared").SyncFields, "parent" | "blocked_by">
+  >();
 
   // Filter out synthetic milestone tasks (read-only, managed by pull)
   const nonSyntheticDiffs = diffs.filter((d) => !isMilestoneSyntheticTask(d.id));
@@ -291,10 +300,16 @@ export async function executePush(
     }
 
     // Set up relationships for newly created issues (parallel)
+    // Newly created issues have no relations on remote yet, so baseline is always null/empty
     const taskMap = new Map(tasksFile.tasks.map((t) => [t.id, t]));
-    const relationMutations: Promise<{ taskId: string; ok: boolean }>[] = [];
+    const relationMutations: Promise<{
+      taskId: string;
+      field: "parent" | "blocked_by";
+      ok: boolean;
+    }>[] = [];
 
     for (const id of createdTaskIds) {
+      preRelationBaseline.set(id, { parent: null, blocked_by: [] });
       const task = taskMap.get(id);
       if (task?.parent) {
         const childEntry = syncState.id_map[task.id];
@@ -302,10 +317,10 @@ export async function executePush(
         if (childEntry?.issue_node_id && parentEntry?.issue_node_id) {
           relationMutations.push(
             addSubIssue(gql, parentEntry.issue_node_id, childEntry.issue_node_id).then(
-              () => ({ taskId: task.id, ok: true }),
+              () => ({ taskId: task.id, field: "parent" as const, ok: true }),
               (err) => {
                 console.warn(`  ⚠ sub-issue 関係の設定に失敗 (${task.id}): ${formatError(err)}`);
-                return { taskId: task.id, ok: false };
+                return { taskId: task.id, field: "parent" as const, ok: false };
               },
             ),
           );
@@ -320,12 +335,12 @@ export async function executePush(
             if (blockerEntry?.issue_node_id) {
               relationMutations.push(
                 addBlockedByIssue(gql, taskEntry.issue_node_id, blockerEntry.issue_node_id).then(
-                  () => ({ taskId: task.id, ok: true }),
+                  () => ({ taskId: task.id, field: "blocked_by" as const, ok: true }),
                   (err) => {
                     console.warn(
                       `  ⚠ blocked-by 関係の設定に失敗 (${task.id} ← ${dep.task}): ${formatError(err)}`,
                     );
-                    return { taskId: task.id, ok: false };
+                    return { taskId: task.id, field: "blocked_by" as const, ok: false };
                   },
                 ),
               );
@@ -338,7 +353,15 @@ export async function executePush(
     if (relationMutations.length > 0) {
       const results = await Promise.all(relationMutations);
       for (const r of results) {
-        if (!r.ok) failedRelationTaskIds.add(r.taskId);
+        if (!r.ok) {
+          const existing = failedRelations.get(r.taskId) ?? {
+            parentFailed: false,
+            blockedByFailed: false,
+          };
+          if (r.field === "parent") existing.parentFailed = true;
+          else existing.blockedByFailed = true;
+          failedRelations.set(r.taskId, existing);
+        }
       }
     }
   } else if (draftDiffs.length > 0) {
@@ -430,7 +453,14 @@ export async function executePush(
 
       const snapshot = syncState.snapshots[task.id];
       if (idEntry.issue_node_id) {
-        let relationFailed = false;
+        // Capture pre-mutation baseline for rollback on failure
+        preRelationBaseline.set(task.id, {
+          parent: snapshot?.syncFields?.parent ?? null,
+          blocked_by: snapshot?.syncFields?.blocked_by ?? [],
+        });
+
+        let parentFailed = false;
+        let blockedByFailed = false;
         const oldParent = snapshot?.syncFields?.parent ?? null;
         const newParent = task.parent;
 
@@ -443,7 +473,7 @@ export async function executePush(
                 await removeSubIssue(gql, oldParentEntry.issue_node_id, idEntry.issue_node_id);
               } catch (err) {
                 console.warn(`  ⚠ sub-issue 関係の削除に失敗 (${task.id}): ${formatError(err)}`);
-                relationFailed = true;
+                parentFailed = true;
               }
             }
           }
@@ -454,7 +484,7 @@ export async function executePush(
                 await addSubIssue(gql, newParentEntry.issue_node_id, idEntry.issue_node_id);
               } catch (err) {
                 console.warn(`  ⚠ sub-issue 関係の設定に失敗 (${task.id}): ${formatError(err)}`);
-                relationFailed = true;
+                parentFailed = true;
               }
             }
           }
@@ -506,10 +536,12 @@ export async function executePush(
 
         if (blockerMutations.length > 0) {
           const results = await Promise.all(blockerMutations);
-          if (results.some((r) => !r.ok)) relationFailed = true;
+          if (results.some((r) => !r.ok)) blockedByFailed = true;
         }
 
-        if (relationFailed) failedRelationTaskIds.add(task.id);
+        if (parentFailed || blockedByFailed) {
+          failedRelations.set(task.id, { parentFailed, blockedByFailed });
+        }
       }
 
       pushedTaskIds.add(task.id);
@@ -532,25 +564,32 @@ export async function executePush(
     const task = tasksFile.tasks.find((t) => t.id === id);
     if (task) {
       const existing = newSnapshots[id];
-      const newHash = hashTask(task);
       let syncFields = extractSyncFields(task);
 
-      // If relationship mutations failed, preserve old parent/blocked_by in syncFields
-      // so that computeLocalDiff detects the diff and retries on next push
-      if (failedRelationTaskIds.has(id) && existing?.syncFields) {
-        syncFields = {
-          ...syncFields,
-          parent: existing.syncFields.parent,
-          blocked_by: existing.syncFields.blocked_by,
-        };
+      // If relationship mutations partially failed, roll back only the failed fields
+      // to the pre-mutation baseline so computeLocalDiff detects the diff on next push
+      const failure = failedRelations.get(id);
+      if (failure) {
+        const baseline = preRelationBaseline.get(id);
+        if (baseline) {
+          if (failure.parentFailed) {
+            syncFields = { ...syncFields, parent: baseline.parent };
+          }
+          if (failure.blockedByFailed) {
+            syncFields = { ...syncFields, blocked_by: baseline.blocked_by };
+          }
+        }
       }
 
+      // Hash must match syncFields so diff detection works correctly
+      const snapshotHash = failure ? hashSyncFields(syncFields) : hashTask(task);
+
       newSnapshots[id] = {
-        hash: newHash,
+        hash: snapshotHash,
         synced_at: new Date().toISOString(),
         syncFields,
         updated_at: freshUpdatedAt.get(id) ?? existing?.updated_at,
-        remoteHash: newHash,
+        remoteHash: snapshotHash,
       };
     }
   }


### PR DESCRIPTION
## Summary

- リレーション mutation (addSubIssue, addBlockedByIssue, removeBlockedByIssue) 失敗時に、snapshot の syncFields.parent / syncFields.blocked_by を旧値のまま保持
- これにより computeLocalDiff が差分を検出し、次回 push で自動的に再試行される
- fetchBatchUpdatedAt の silent catch に warn ログ追加でデバッグ可能に

## Test plan

- [x] `pnpm --filter @gh-gantt/cli test` 全 285 テスト通過
- [x] partial failure テスト追加: relation 失敗時に syncFields.parent が旧値を保持
- [x] positive テスト追加: relation 成功時に syncFields.parent が新値に更新
- [ ] 実環境で relation 失敗シナリオの動作確認

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * リレーション更新が部分的に失敗した場合、失敗したフィールドのみを元の状態に戻して次回再試行できるように改善しました（親 / blocked_by の個別ロールバック対応）。
  * 新規下書きタスクでのリレーション失敗時に、正しい基準値でロールバックし再試行用の差分を残すよう修正しました。
  * バッチ更新取得失敗時に詳細な警告ログを出力するように変更しました。

* **テスト**
  * 上記の成功・失敗パターン（部分成功・全成功・新規タスクの失敗）と警告出力を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->