### PR TITLE
fix(e2e): Zoom In/Out ボタン廃止に伴う toolbar E2E テスト修正

### DIFF
--- a/e2e/toolbar.spec.ts
+++ b/e2e/toolbar.spec.ts
@@ -90,9 +90,13 @@ test("search input filters tasks by title", async ({ page }) => {
   await expect(page.locator("[data-task-id='task-3']")).not.toBeVisible();
 });
 
-test("zoom controls are rendered", async ({ page }) => {
-  await expect(page.getByRole("button", { name: "Zoom In" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Zoom Out" })).toBeVisible();
+test("スケール切替ボタン (Week/Month/Quarter/Year) と Scroll to Today が表示される", async ({
+  page,
+}) => {
+  await expect(page.getByRole("button", { name: "Week" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Month" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Quarter" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Year" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Scroll to Today" })).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary

- main ブランチの E2E が #117 以降 6日間 failure 状態だったのを修正
- Zoom In/Out ボタンが Week/Month/Quarter/Year のスケール切替ボタンに置き換わっていたが E2E テストが追従していなかった
- テスト名を日本語規約に合わせて統一

## 背景

[#117 タイムラインヘッダーをGitHub Projects風の2段構成に改善](https://github.com/stanah/gh-gantt/pull/117) で、タイムラインの +/- Zoom ボタンがスケール切替ボタン [Week|Month|Quarter|Year] に置き換えられた。しかし `e2e/toolbar.spec.ts` の `zoom controls are rendered` テストが古いボタン名 (`Zoom In` / `Zoom Out`) を参照したままだった。

E2E は main ブランチでのみ実行されるため、PR レビュー時には検知できず、6日間にわたり main の E2E が赤い状態が続いていた。

## Changes

- `zoom controls are rendered` → `スケール切替ボタン (Week/Month/Quarter/Year) と Scroll to Today が表示される` に変更
- アサーションを Week / Month / Quarter / Year の4つのボタンと Scroll to Today に更新

## Test plan

- [x] `pnpm test:e2e` でローカル実行 → 全 23 テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ツールバーのコントロールが更新されました。ズーム機能が時間スケール切り替えボタン（週、月、四半期、年）に置き換わりました。
  * 「今日へスクロール」ボタンが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->