### PR TITLE
fix(lint): init.ts の no-useless-fallback-in-spread 警告を修正

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -49,7 +49,7 @@ function applyTypeSources(
           display: defaults.display,
           color: defaults.color,
           github_label: null,
-          ...(taskTypes[key] ?? {}),
+          ...taskTypes[key],
           [bindingKey]: source.name,
         };
       }
@@ -64,7 +64,7 @@ function applyTypeSources(
         display: "bar",
         color: "#95A5A6",
         github_label: null,
-        ...(taskTypes[key] ?? {}),
+        ...taskTypes[key],
         [bindingKey]: source.name,
       };
     }


### PR DESCRIPTION
## Summary

- `init.ts` の `...(taskTypes[key] ?? {})` から不要な `?? {}` フォールバックを除去
- Oxlint の `no-useless-fallback-in-spread` 警告の解消（`vp check --fix` で自動修正された内容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)