### PR TITLE
fix(sync): skip non-Issue project items (PullRequest, DraftIssue)

### DIFF
--- a/packages/cli/src/__tests__/fetch-project.test.ts
+++ b/packages/cli/src/__tests__/fetch-project.test.ts
@@ -46,8 +46,8 @@ function makePullRequestItem() {
   return {
     id: "item-pr",
     fieldValues: { nodes: [] },
-    // GraphQL returns only __typename for non-matching fragments.
-    // Issue-specific fields (state, assignees, etc.) are absent.
+    // GraphQL は一致しないフラグメントに対して __typename のみ返す。
+    // Issue 固有のフィールド（state, assignees など）は存在しない。
     content: {
       __typename: "PullRequest",
     },
@@ -65,7 +65,7 @@ function makeDraftIssueItem() {
 }
 
 describe("fetchProject", () => {
-  it("returns Issue items with lowercase state", async () => {
+  it("[Issue #159] Issue 項目の state を小文字で返す", async () => {
     const gql = vi.fn().mockResolvedValueOnce(makeProjectResponse([makeIssueItem()])) as any;
     const result = await fetchProject(gql, "stanah", 5, "user");
     expect(result.items).toHaveLength(1);
@@ -73,26 +73,26 @@ describe("fetchProject", () => {
     expect(result.items[0].content?.number).toBe(1);
   });
 
-  it("skips PullRequest items instead of crashing", async () => {
+  it("[Issue #159] PullRequest 項目をクラッシュさせずスキップする", async () => {
     const gql = vi
       .fn()
       .mockResolvedValueOnce(makeProjectResponse([makeIssueItem(), makePullRequestItem()])) as any;
     const result = await fetchProject(gql, "stanah", 5, "user");
-    // Only the Issue should be kept; PR should be filtered out.
+    // Issue のみ残り、PR はフィルタアウトされること。
     expect(result.items).toHaveLength(1);
     expect(result.items[0].content?.number).toBe(1);
   });
 
-  it("skips DraftIssue items", async () => {
+  it("[Issue #159] DraftIssue 項目をスキップする", async () => {
     const gql = vi
       .fn()
       .mockResolvedValueOnce(makeProjectResponse([makeIssueItem(), makeDraftIssueItem()])) as any;
     const result = await fetchProject(gql, "stanah", 5, "user");
     expect(result.items).toHaveLength(1);
-    expect(result.items[0].content?.__typename ?? "Issue").toBe("Issue");
+    expect(result.items[0].content?.number).toBe(1);
   });
 
-  it("handles a project with only PullRequests gracefully", async () => {
+  it("[Issue #159] PullRequest のみのプロジェクトを正常に処理する", async () => {
     const gql = vi.fn().mockResolvedValueOnce(makeProjectResponse([makePullRequestItem()])) as any;
     const result = await fetchProject(gql, "stanah", 5, "user");
     expect(result.items).toHaveLength(0);

--- a/packages/cli/src/__tests__/fetch-project.test.ts
+++ b/packages/cli/src/__tests__/fetch-project.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchProject } from "../github/projects.js";
+
+function makeProjectResponse(items: any[]) {
+  return {
+    user: {
+      projectV2: {
+        id: "PVT_x",
+        title: "Test Project",
+        fields: { nodes: [] },
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: items,
+        },
+      },
+    },
+  };
+}
+
+function makeIssueItem(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "item-issue",
+    fieldValues: { nodes: [] },
+    content: {
+      __typename: "Issue",
+      id: "I_1",
+      number: 1,
+      title: "Issue Title",
+      body: "body",
+      state: "OPEN",
+      stateReason: null,
+      issueType: null,
+      assignees: { nodes: [] },
+      labels: { nodes: [] },
+      milestone: null,
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+      closedAt: null,
+      repository: { nameWithOwner: "owner/repo" },
+      ...overrides,
+    },
+  };
+}
+
+function makePullRequestItem() {
+  return {
+    id: "item-pr",
+    fieldValues: { nodes: [] },
+    // GraphQL returns only __typename for non-matching fragments.
+    // Issue-specific fields (state, assignees, etc.) are absent.
+    content: {
+      __typename: "PullRequest",
+    },
+  };
+}
+
+function makeDraftIssueItem() {
+  return {
+    id: "item-draft",
+    fieldValues: { nodes: [] },
+    content: {
+      __typename: "DraftIssue",
+    },
+  };
+}
+
+describe("fetchProject", () => {
+  it("returns Issue items with lowercase state", async () => {
+    const gql = vi.fn().mockResolvedValueOnce(makeProjectResponse([makeIssueItem()])) as any;
+    const result = await fetchProject(gql, "stanah", 5, "user");
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].content?.state).toBe("open");
+    expect(result.items[0].content?.number).toBe(1);
+  });
+
+  it("skips PullRequest items instead of crashing", async () => {
+    const gql = vi
+      .fn()
+      .mockResolvedValueOnce(makeProjectResponse([makeIssueItem(), makePullRequestItem()])) as any;
+    const result = await fetchProject(gql, "stanah", 5, "user");
+    // Only the Issue should be kept; PR should be filtered out.
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].content?.number).toBe(1);
+  });
+
+  it("skips DraftIssue items", async () => {
+    const gql = vi
+      .fn()
+      .mockResolvedValueOnce(makeProjectResponse([makeIssueItem(), makeDraftIssueItem()])) as any;
+    const result = await fetchProject(gql, "stanah", 5, "user");
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].content?.__typename ?? "Issue").toBe("Issue");
+  });
+
+  it("handles a project with only PullRequests gracefully", async () => {
+    const gql = vi.fn().mockResolvedValueOnce(makeProjectResponse([makePullRequestItem()])) as any;
+    const result = await fetchProject(gql, "stanah", 5, "user");
+    expect(result.items).toHaveLength(0);
+    expect(result.projectTitle).toBe("Test Project");
+  });
+});

--- a/packages/cli/src/github/projects.ts
+++ b/packages/cli/src/github/projects.ts
@@ -77,6 +77,9 @@ export async function fetchProject(
     for (const item of project.items.nodes) {
       if (!item.content) continue;
       const content = item.content;
+      // Skip non-Issue content (PullRequest, DraftIssue) — gh-gantt only tracks Issues.
+      // Without this guard, Issue-only fields like `state` are undefined and crash later.
+      if (content.__typename && content.__typename !== "Issue") continue;
       const fieldMap: Record<string, unknown> = {};
       for (const fv of item.fieldValues.nodes) {
         if (fv.field?.name) {

--- a/packages/cli/src/github/projects.ts
+++ b/packages/cli/src/github/projects.ts
@@ -77,8 +77,8 @@ export async function fetchProject(
     for (const item of project.items.nodes) {
       if (!item.content) continue;
       const content = item.content;
-      // Skip non-Issue content (PullRequest, DraftIssue) — gh-gantt only tracks Issues.
-      // Without this guard, Issue-only fields like `state` are undefined and crash later.
+      // Issue 以外の content（PullRequest, DraftIssue）はスキップする（gh-gantt は Issue のみを対象）。
+      // このガードがないと、`state` など Issue 専用フィールド参照で後続処理がクラッシュする。
       if (content.__typename && content.__typename !== "Issue") continue;
       const fieldMap: Record<string, unknown> = {};
       for (const fv of item.fieldValues.nodes) {

--- a/packages/cli/src/github/queries.ts
+++ b/packages/cli/src/github/queries.ts
@@ -49,6 +49,7 @@ const PROJECT_V2_FRAGMENT = `
               }
             }
             content {
+              __typename
               ... on Issue {
                 id
                 number


### PR DESCRIPTION
## Summary

GitHub Projects が Issues に加えて PullRequests や DraftIssues を含む場合、\`gh-gantt pull\` / \`status\` が次のエラーでクラッシュしていました:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at fetchProject (packages/cli/src/github/projects.ts:94)
\`\`\`

## Root Cause

\`PROJECT_V2_FRAGMENT\` (queries.ts) は \`... on Issue\` フラグメントだけを含んでおり、PullRequest / DraftIssue の \`content\` は \`state\`, \`assignees\`, \`labels\` 等の Issue 専用フィールドを欠いた状態で返ってきます。コードはその判定をせずに \`content.state.toLowerCase()\` を呼んでいたため、プロジェクトに PR が自動追加されているケースで必ず落ちていました (GitHub Projects の auto-add automation を使っている利用者でよくある構成)。

## Fix

- \`PROJECT_V2_FRAGMENT\` に \`__typename\` を追加して content の型を識別可能に
- \`fetchProject\` のループで \`content.__typename !== "Issue"\` のアイテムをスキップ
- gh-gantt のデータモデルは Issue ベースなので、PR / DraftIssue は意図的に対象外

## Tests

\`fetch-project.test.ts\` を新規追加。全 4 ケース pass:

- [x] Issue items pass through with lowercase state
- [x] PullRequest items are skipped instead of crashing
- [x] DraftIssue items are skipped
- [x] A project containing only PRs returns empty items without crashing

\`pnpm --filter @gh-gantt/cli test\` → **328 tests passed** (既存 324 + 新規 4)

## Verified In The Wild

stanah/tokachi プロジェクト (#5) に PR #6-#9 が自動追加された状態で再現していました。本修正後は \`gh-gantt status\` / \`pull\` が正常動作することを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プロジェクト取得時に Issue 以外のアイテム（例: PR や DraftIssue）がスキップされ、これらが原因のエラーや不正な変換を防止するようになりました。
  * プロジェクトに Issue が含まれない場合でも、空のアイテム配列を返しつつプロジェクトタイトルは維持されます。

* **Tests**
  * プロジェクト取得の挙動を検証するテストスイートを追加しました（Issue/PR/Draft のケースを含む）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->