### PR TITLE
fix(sync): pull で id_map を authoritative に rebuild する

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -373,6 +373,24 @@ areas:
               snapshot.hash が正しく更新される (regression #154)
             status: uncovered
             tests: []
+          - id: NFR-STABILITY-001-AC3
+            description: |
+              gh-gantt を経由せず作成された Issue (GitHub UI / gh issue create /
+              PR マージによる自動追加 / sync-state.json 直接編集等) が tasks.json
+              に存在する状況で、次回の pull 時に id_map が projectData.items から
+              authoritative に rebuild され、push が silent skip せず正常に動作する
+              (regression #167)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
+          - id: NFR-STABILITY-001-AC4
+            description: |
+              validateSyncState が「tasks.json に存在するが id_map に無い」という
+              逆方向の不整合 (missing_id_map) を検出し、次回 pull で自動修復される
+              旨をユーザーに提示する (regression #167)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/validate-sync-state.test.ts
       - id: NFR-STABILITY-002
         summary: silent failure の禁止
         acceptance_criteria:

--- a/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Config, SyncState, TasksFile, Task } from "@gh-gantt/shared";
+
+// executePull は内部で fetchProject, checkRemoteChanges 等を呼ぶ。
+// pull-precheck.test.ts と同じ mock 方針を採用する。
+vi.mock("../../github/projects.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../github/projects.js")>();
+  return {
+    ...original,
+    fetchProject: vi.fn(),
+    fetchRepositoryMetadata: vi.fn(),
+    checkRemoteChanges: vi.fn(),
+  };
+});
+
+vi.mock("../../github/sub-issues.js", () => ({
+  fetchAllIssueRelationshipLinks: vi.fn().mockResolvedValue({
+    subIssueLinks: [],
+    blockedByLinks: [],
+  }),
+}));
+
+import { executePull } from "../../sync/pull-executor.js";
+import {
+  fetchProject,
+  fetchRepositoryMetadata,
+  checkRemoteChanges,
+  type RawProjectItem,
+} from "../../github/projects.js";
+
+const mockFetchProject = vi.mocked(fetchProject);
+const mockFetchRepoMeta = vi.mocked(fetchRepositoryMetadata);
+const mockCheckRemote = vi.mocked(checkRemoteChanges);
+
+function makeConfig(): Config {
+  return {
+    project: {
+      github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+    },
+    sync: { auto_create_issues: true, field_mapping: {} },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+    },
+  } as unknown as Config;
+}
+
+function makeSyncState(overrides: Partial<SyncState> = {}): SyncState {
+  return {
+    last_synced_at: "2026-04-01T00:00:00Z",
+    project_node_id: "PVT_1",
+    id_map: {},
+    field_ids: {},
+    snapshots: {},
+    ...overrides,
+  } as SyncState;
+}
+
+function makeTasksFile(tasks: Task[] = []): TasksFile {
+  return { tasks, cache: { comments: {}, reactions: {} } } as unknown as TasksFile;
+}
+
+/**
+ * GraphQL の projectV2.items.nodes 相当を模した RawProjectItem を生成する。
+ * id_map の 3 フィールド (issue_number, issue_node_id, project_item_id) が
+ * 正しく伝搬するかを検証するため、各フィールドに一意な値を持たせる。
+ */
+function makeProjectItem(issueNumber: number): RawProjectItem {
+  return {
+    id: `PVTI_${issueNumber}`, // → project_item_id
+    fieldValues: {},
+    content: {
+      nodeId: `I_${issueNumber}`, // → issue_node_id
+      number: issueNumber,
+      title: `Issue ${issueNumber}`,
+      body: null,
+      state: "open",
+      stateReason: null,
+      assignees: [],
+      labels: [],
+      milestone: null,
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+      closedAt: null,
+      issueType: null,
+      repository: "stanah/gh-gantt",
+    },
+  };
+}
+
+function makeDraftTask(draftNumber: number): Task {
+  return {
+    id: `stanah/gh-gantt#draft-${draftNumber}`,
+    type: "task",
+    github_issue: null,
+    github_repo: "stanah/gh-gantt",
+    parent: null,
+    sub_tasks: [],
+    title: `Draft ${draftNumber}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-04-11T00:00:00Z",
+    updated_at: "2026-04-11T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+  };
+}
+
+const gql = vi.fn();
+
+describe("[Issue #167] pull が id_map を authoritative に rebuild する", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchRepoMeta.mockResolvedValue({
+      labelMap: new Map(),
+      milestoneMap: new Map(),
+      milestones: [],
+    } as unknown as Awaited<ReturnType<typeof fetchRepositoryMetadata>>);
+    mockCheckRemote.mockResolvedValue(true);
+  });
+
+  it("空の id_map + pull → projectData.items から全エントリが populate される", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [makeProjectItem(10), makeProjectItem(20), makeProjectItem(30)],
+    });
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile(),
+      makeSyncState({ id_map: {} }),
+      { force: true },
+    );
+
+    expect(Object.keys(newState.id_map).sort()).toEqual([
+      "stanah/gh-gantt#10",
+      "stanah/gh-gantt#20",
+      "stanah/gh-gantt#30",
+    ]);
+    expect(newState.id_map["stanah/gh-gantt#10"]).toEqual({
+      issue_number: 10,
+      issue_node_id: "I_10",
+      project_item_id: "PVTI_10",
+    });
+  });
+
+  it("欠けた id_map エントリが pull で補完される (セルフヒーリング)", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [makeProjectItem(10), makeProjectItem(20), makeProjectItem(30)],
+    });
+
+    // #10 のみ存在し、#20 / #30 は欠けている破損状態を再現
+    const brokenState = makeSyncState({
+      id_map: {
+        "stanah/gh-gantt#10": {
+          issue_number: 10,
+          issue_node_id: "I_10",
+          project_item_id: "PVTI_10",
+        },
+      },
+    });
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile(),
+      brokenState,
+      { force: true },
+    );
+
+    expect(Object.keys(newState.id_map).sort()).toEqual([
+      "stanah/gh-gantt#10",
+      "stanah/gh-gantt#20",
+      "stanah/gh-gantt#30",
+    ]);
+    expect(newState.id_map["stanah/gh-gantt#20"]).toEqual({
+      issue_number: 20,
+      issue_node_id: "I_20",
+      project_item_id: "PVTI_20",
+    });
+  });
+
+  it("orphan id_map エントリ (project に存在しない) は pull で削除される", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [makeProjectItem(10)],
+    });
+
+    // #999 は project に存在しないのに id_map に残っている状態
+    const orphanState = makeSyncState({
+      id_map: {
+        "stanah/gh-gantt#999": {
+          issue_number: 999,
+          issue_node_id: "I_999",
+          project_item_id: "PVTI_999",
+        },
+      },
+    });
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile(),
+      orphanState,
+      { force: true },
+    );
+
+    expect(Object.keys(newState.id_map)).toEqual(["stanah/gh-gantt#10"]);
+    expect(newState.id_map["stanah/gh-gantt#999"]).toBeUndefined();
+  });
+
+  it("stale な issue_node_id は pull で最新値に更新される", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [makeProjectItem(10)], // nodeId = I_10
+    });
+
+    // 古い node_id を持つ id_map (例: project から detach 後に再 attach された場合)
+    const staleState = makeSyncState({
+      id_map: {
+        "stanah/gh-gantt#10": {
+          issue_number: 10,
+          issue_node_id: "I_OLD",
+          project_item_id: "PVTI_OLD",
+        },
+      },
+    });
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile(),
+      staleState,
+      { force: true },
+    );
+
+    expect(newState.id_map["stanah/gh-gantt#10"]).toEqual({
+      issue_number: 10,
+      issue_node_id: "I_10",
+      project_item_id: "PVTI_10",
+    });
+  });
+
+  it("draft タスクは id_map に入らない (既存仕様の維持)", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [makeProjectItem(10)],
+    });
+
+    const draftTask = makeDraftTask(1);
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile([draftTask]),
+      makeSyncState({ id_map: {} }),
+      { force: true },
+    );
+
+    // draft は projectData.items に含まれないため id_map に入らない
+    expect(Object.keys(newState.id_map)).toEqual(["stanah/gh-gantt#10"]);
+    expect(newState.id_map[draftTask.id]).toBeUndefined();
+  });
+
+  it("空 project (items が空配列) → id_map も空になる", async () => {
+    mockFetchProject.mockResolvedValue({
+      projectNodeId: "PVT_1",
+      projectTitle: "Test",
+      fields: [],
+      items: [],
+    });
+
+    const populatedState = makeSyncState({
+      id_map: {
+        "stanah/gh-gantt#10": {
+          issue_number: 10,
+          issue_node_id: "I_10",
+          project_item_id: "PVTI_10",
+        },
+      },
+    });
+
+    const { syncState: newState } = await executePull(
+      gql as never,
+      makeConfig(),
+      makeTasksFile(),
+      populatedState,
+      { force: true },
+    );
+
+    expect(newState.id_map).toEqual({});
+  });
+
+  describe("セルフヒーリングのエンドツーエンド検証", () => {
+    /**
+     * tasks.json に存在するが id_map に無い破損タスクを表現するヘルパー。
+     * ここでの makeSyncTask は pull 後に生成される Task の形状に合わせる。
+     */
+    function makeSyncTask(issueNumber: number): Task {
+      return {
+        id: `stanah/gh-gantt#${issueNumber}`,
+        type: "task",
+        github_issue: issueNumber,
+        github_repo: "stanah/gh-gantt",
+        parent: null,
+        sub_tasks: [],
+        title: `Issue ${issueNumber}`,
+        body: null,
+        state: "open",
+        state_reason: null,
+        assignees: [],
+        labels: [],
+        milestone: null,
+        linked_prs: [],
+        created_at: "2026-04-01T00:00:00Z",
+        updated_at: "2026-04-01T00:00:00Z",
+        closed_at: null,
+        custom_fields: {},
+        start_date: null,
+        end_date: null,
+        date: null,
+        blocked_by: [],
+      };
+    }
+
+    it("破損 id_map で非 force 呼び出しでも pre-check をバイパスしてフル fetch する", async () => {
+      // pre-check は checkRemoteChanges を呼ぶ。通常「変化なし」で早期 return するが、
+      // 破損した id_map を検出した場合はバイパスしてフル fetch すべき。
+      mockCheckRemote.mockResolvedValue(false); // remote には変化なし
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [makeProjectItem(10)],
+      });
+
+      const brokenState = makeSyncState({
+        id_map: {}, // #10 が欠けている
+      });
+
+      await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([makeSyncTask(10)]),
+        brokenState,
+        // force フラグ無し
+      );
+
+      // 破損検出により pre-check はバイパスされ fetchProject が呼ばれる
+      expect(mockFetchProject).toHaveBeenCalled();
+    });
+
+    it("result.syncStateFindings に missing_id_map が列挙され、rebuild 後 autoFixed に promote される", async () => {
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [makeProjectItem(10), makeProjectItem(20)],
+      });
+
+      const brokenState = makeSyncState({
+        id_map: {}, // #10 / #20 ともに欠けている
+      });
+
+      const { result } = await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([{ ...makeSyncTask(10) }, { ...makeSyncTask(20) }]),
+        brokenState,
+        { force: true },
+      );
+
+      const missing = result.syncStateFindings.filter((f) => f.category === "missing_id_map");
+      expect(missing).toHaveLength(2);
+      expect(missing.map((f) => f.taskId).sort()).toEqual([
+        "stanah/gh-gantt#10",
+        "stanah/gh-gantt#20",
+      ]);
+      // rebuild で補完された項目は autoFixed: true に promote される
+      for (const f of missing) {
+        expect(f.autoFixed).toBe(true);
+        expect(f.message).toMatch(/自動補完しました/);
+      }
+    });
+
+    it("連続 pull で 1 回目は heal、2 回目は finding なし (収束確認)", async () => {
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [makeProjectItem(10)],
+      });
+
+      // 1 回目: 破損状態で pull
+      const brokenState = makeSyncState({ id_map: {} });
+      const first = await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([makeSyncTask(10)]),
+        brokenState,
+        { force: true },
+      );
+
+      expect(Object.keys(first.syncState.id_map)).toEqual(["stanah/gh-gantt#10"]);
+      expect(first.result.syncStateFindings.some((f) => f.category === "missing_id_map")).toBe(
+        true,
+      );
+
+      // 2 回目: 1 回目の結果を使って再度 pull → findings は空
+      const second = await executePull(
+        gql as never,
+        makeConfig(),
+        first.tasksFile,
+        first.syncState,
+        { force: true },
+      );
+
+      expect(second.result.syncStateFindings.some((f) => f.category === "missing_id_map")).toBe(
+        false,
+      );
+      // id_map は維持される
+      expect(Object.keys(second.syncState.id_map)).toEqual(["stanah/gh-gantt#10"]);
+    });
+
+    it("sameIdSets quick-skip 経路でも id_map が rebuild される", async () => {
+      // 破損した id_map だが、tasks.json とリモートの id セットは一致している
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [makeProjectItem(10)],
+      });
+
+      // remoteHash と snapshot が一致する状態を作る
+      // (changed フラグが立たず sameIdSets quick-skip 経路に入る)
+      // ここでは snapshot の updated_at を remote と一致させる
+      const quickSkipState = makeSyncState({
+        id_map: {}, // 破損
+        snapshots: {
+          "stanah/gh-gantt#10": {
+            hash: "irrelevant",
+            synced_at: "2026-04-01T00:00:00Z",
+            updated_at: "2026-04-01T00:00:00Z", // makeProjectItem の updatedAt と一致
+          },
+        },
+      });
+
+      // force なしで呼び出しても、missing_id_map 検出によって pre-check はバイパスされる
+      // その後 fetchProject まで到達すれば sameIdSets quick-skip または通常パスを通る
+      const { syncState: newState } = await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([makeSyncTask(10)]),
+        quickSkipState,
+      );
+
+      // いずれの経路でも id_map は rebuild されていなければならない
+      expect(newState.id_map["stanah/gh-gantt#10"]).toEqual({
+        issue_number: 10,
+        issue_node_id: "I_10",
+        project_item_id: "PVTI_10",
+      });
+    });
+  });
+});

--- a/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
@@ -32,13 +32,7 @@ const mockFetchProject = vi.mocked(fetchProject);
 const mockFetchRepoMeta = vi.mocked(fetchRepositoryMetadata);
 const mockCheckRemote = vi.mocked(checkRemoteChanges);
 
-/**
- * テスト用の最小 Config を構築する。
- * 本リグレッションテストで参照される Config のパスは限定的だが、
- * Config インターフェースの必須フィールドはすべて満たす。
- * 型アサーションを使わず satisfies で shape を検証することで、
- * 将来 Config に必須フィールドが追加された際にコンパイルエラーで気付けるようにする。
- */
+/** テスト用 Config。satisfies で将来の必須フィールド追加をコンパイル時検出する。 */
 function makeConfig(): Config {
   const config = {
     version: "1",

--- a/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
@@ -504,6 +504,69 @@ describe("[NFR-STABILITY-001-AC3] [Issue #167] pull が id_map を authoritative
       });
     });
 
+    it("kept-local で detach されたタスクに対して missing_id_map finding が追加される", async () => {
+      // シナリオ: pre-pull 状態は整合 (タスク #10 が tasks.json と id_map の両方にあり、
+      // snapshot も存在する)。pull 中に projectData.items から #10 が消失 (detach) し、
+      // ローカル変更があるため kept-local として mergedTasks に残される。
+      // 結果として「tasks.json にあるが id_map に無い」状態が発生するが、pull 冒頭の
+      // validateSyncState はこれを検出できない (pre-pull 時点では整合していたため)。
+      // 返却前の再検証によって missing_id_map finding が追加されることを検証する。
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [], // #10 は project から detach された
+      });
+
+      const localTask = makeSyncTask(10);
+      // ローカル変更を表現 (snapshot.hash と現在の hash が異なる状態)
+      localTask.title = "Modified title locally";
+
+      const preConsistentState = makeSyncState({
+        id_map: {
+          "stanah/gh-gantt#10": {
+            issue_number: 10,
+            issue_node_id: "I_10",
+            project_item_id: "PVTI_10",
+          },
+        },
+        snapshots: {
+          "stanah/gh-gantt#10": {
+            // 本物の hash と異なる値を入れることで「ローカル変更あり」を表現
+            hash: "pre-modification-hash",
+            synced_at: "2026-04-01T00:00:00Z",
+            updated_at: "2026-04-01T00:00:00Z",
+          },
+        },
+      });
+
+      const {
+        result,
+        tasksFile: newTasksFile,
+        syncState: newState,
+      } = await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([localTask]),
+        preConsistentState,
+        { force: true },
+      );
+
+      // kept-local で #10 は tasks.json に残る
+      expect(newTasksFile.tasks.map((t) => t.id)).toContain("stanah/gh-gantt#10");
+      // しかし newIdMap には入らない (projectData.items から消失したため)
+      expect(newState.id_map["stanah/gh-gantt#10"]).toBeUndefined();
+
+      // 返却前の再検証により missing_id_map finding が追加される
+      const missing = result.syncStateFindings.find(
+        (f) => f.category === "missing_id_map" && f.taskId === "stanah/gh-gantt#10",
+      );
+      expect(missing).toBeDefined();
+      expect(missing!.level).toBe("info");
+      // この finding は再検証由来なので autoFixed=false (rebuild で解消されていない)
+      expect(missing!.autoFixed).toBe(false);
+    });
+
     it("orphan_id_map finding が rebuild 後 autoFixed に promote される", async () => {
       // #10 は project に存在するが、id_map には #10 と #999 (orphan) の両方がある。
       // tasks.json には #10 のみ存在 → validateSyncState が #999 を orphan_id_map として

--- a/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts
@@ -32,16 +32,38 @@ const mockFetchProject = vi.mocked(fetchProject);
 const mockFetchRepoMeta = vi.mocked(fetchRepositoryMetadata);
 const mockCheckRemote = vi.mocked(checkRemoteChanges);
 
+/**
+ * テスト用の最小 Config を構築する。
+ * 本リグレッションテストで参照される Config のパスは限定的だが、
+ * Config インターフェースの必須フィールドはすべて満たす。
+ * 型アサーションを使わず satisfies で shape を検証することで、
+ * 将来 Config に必須フィールドが追加された際にコンパイルエラーで気付けるようにする。
+ */
 function makeConfig(): Config {
-  return {
+  const config = {
+    version: "1",
     project: {
+      name: "test",
       github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
     },
-    sync: { auto_create_issues: true, field_mapping: {} },
-    task_types: {
-      task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+    sync: {
+      auto_create_issues: true,
+      conflict_strategy: "remote-wins" as const,
+      field_mapping: {
+        start_date: "Start Date",
+        end_date: "End Date",
+        status: "Status",
+        priority: "Priority",
+      },
     },
-  } as unknown as Config;
+    task_types: {
+      task: { label: "Task", display: "bar" as const, color: "#27AE60", github_label: null },
+    },
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: { default_view: "week" as const },
+  } satisfies Config;
+  return config;
 }
 
 function makeSyncState(overrides: Partial<SyncState> = {}): SyncState {
@@ -116,7 +138,7 @@ function makeDraftTask(draftNumber: number): Task {
 
 const gql = vi.fn();
 
-describe("[Issue #167] pull が id_map を authoritative に rebuild する", () => {
+describe("[NFR-STABILITY-001-AC3] [Issue #167] pull が id_map を authoritative に rebuild する", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchRepoMeta.mockResolvedValue({
@@ -480,6 +502,56 @@ describe("[Issue #167] pull が id_map を authoritative に rebuild する", ()
         issue_node_id: "I_10",
         project_item_id: "PVTI_10",
       });
+    });
+
+    it("orphan_id_map finding が rebuild 後 autoFixed に promote される", async () => {
+      // #10 は project に存在するが、id_map には #10 と #999 (orphan) の両方がある。
+      // tasks.json には #10 のみ存在 → validateSyncState が #999 を orphan_id_map として
+      // 検出する。rebuild 後、#999 は newIdMap から除去されるため autoFixed に promote
+      // されるべき。
+      mockFetchProject.mockResolvedValue({
+        projectNodeId: "PVT_1",
+        projectTitle: "Test",
+        fields: [],
+        items: [makeProjectItem(10)],
+      });
+
+      const stateWithOrphan = makeSyncState({
+        id_map: {
+          "stanah/gh-gantt#10": {
+            issue_number: 10,
+            issue_node_id: "I_10",
+            project_item_id: "PVTI_10",
+          },
+          "stanah/gh-gantt#999": {
+            issue_number: 999,
+            issue_node_id: "I_999",
+            project_item_id: "PVTI_999",
+          },
+        },
+      });
+
+      const { result, syncState: newState } = await executePull(
+        gql as never,
+        makeConfig(),
+        makeTasksFile([makeSyncTask(10)]),
+        stateWithOrphan,
+        { force: true },
+      );
+
+      // #999 は newIdMap (= 新 id_map) から除去される
+      expect(newState.id_map["stanah/gh-gantt#999"]).toBeUndefined();
+      expect(newState.id_map["stanah/gh-gantt#10"]).toBeDefined();
+
+      // orphan_id_map finding は autoFixed=true に promote され、
+      // メッセージも過去形に書き換えられる
+      const orphan = result.syncStateFindings.find(
+        (f) => f.category === "orphan_id_map" && f.taskId === "stanah/gh-gantt#999",
+      );
+      expect(orphan).toBeDefined();
+      expect(orphan!.autoFixed).toBe(true);
+      expect(orphan!.level).toBe("info");
+      expect(orphan!.message).toMatch(/自動解消しました/);
     });
   });
 });

--- a/packages/cli/src/__tests__/validate-sync-state.test.ts
+++ b/packages/cli/src/__tests__/validate-sync-state.test.ts
@@ -171,7 +171,7 @@ describe("validateSyncState [Issue #123]", () => {
     expect(result).toBe(syncState);
   });
 
-  describe("[Issue #167] missing_id_map の検出", () => {
+  describe("[NFR-STABILITY-001-AC4] [Issue #167] missing_id_map の検出", () => {
     it("tasks.json にあるが id_map に無い非 draft タスクを検出する", () => {
       const task = makeTask("o/r#10");
       const tasksFile: TasksFile = { tasks: [task], cache: { comments: {}, reactions: {} } };

--- a/packages/cli/src/__tests__/validate-sync-state.test.ts
+++ b/packages/cli/src/__tests__/validate-sync-state.test.ts
@@ -170,4 +170,66 @@ describe("validateSyncState [Issue #123]", () => {
     // warn only なので元のオブジェクトと同一参照
     expect(result).toBe(syncState);
   });
+
+  describe("[Issue #167] missing_id_map の検出", () => {
+    it("tasks.json にあるが id_map に無い非 draft タスクを検出する", () => {
+      const task = makeTask("o/r#10");
+      const tasksFile: TasksFile = { tasks: [task], cache: { comments: {}, reactions: {} } };
+      const syncState = makeSyncState({
+        id_map: {}, // #10 のエントリが欠けている
+      });
+
+      const { findings } = validateSyncState(syncState, tasksFile);
+
+      const missing = findings.find((f) => f.category === "missing_id_map");
+      expect(missing).toBeDefined();
+      expect(missing!.taskId).toBe("o/r#10");
+      expect(missing!.level).toBe("info");
+      // 次回 pull で自動修復されるため autoFixed=false (validate 自体では直せない) かつメッセージで自動修復を予告する
+      expect(missing!.autoFixed).toBe(false);
+      expect(missing!.message).toMatch(/pull/);
+    });
+
+    it("draft タスクは missing_id_map として検出されない (仕様通り id_map に入らない)", () => {
+      const draftTask = makeTask("o/r#draft-1");
+      const tasksFile: TasksFile = { tasks: [draftTask], cache: { comments: {}, reactions: {} } };
+      const syncState = makeSyncState({ id_map: {} });
+
+      const { findings } = validateSyncState(syncState, tasksFile);
+
+      const missing = findings.filter((f) => f.category === "missing_id_map");
+      expect(missing).toHaveLength(0);
+    });
+
+    it("milestone 合成タスクは missing_id_map として検出されない (id_map を使わない)", () => {
+      // milestone 合成 ID は "milestone:<repo>#<number>" 形式 (buildMilestoneSyntheticId 参照)
+      const milestoneTask = makeTask("milestone:o/r#1");
+      const tasksFile: TasksFile = {
+        tasks: [milestoneTask],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState = makeSyncState({ id_map: {} });
+
+      const { findings } = validateSyncState(syncState, tasksFile);
+
+      const missing = findings.filter((f) => f.category === "missing_id_map");
+      expect(missing).toHaveLength(0);
+    });
+
+    it("複数の missing_id_map を列挙する", () => {
+      const tasks = [makeTask("o/r#10"), makeTask("o/r#20"), makeTask("o/r#30")];
+      const tasksFile: TasksFile = { tasks, cache: { comments: {}, reactions: {} } };
+      const syncState = makeSyncState({
+        id_map: {
+          "o/r#20": { issue_number: 20, issue_node_id: "I20", project_item_id: "P20" },
+        },
+      });
+
+      const { findings } = validateSyncState(syncState, tasksFile);
+
+      const missing = findings.filter((f) => f.category === "missing_id_map");
+      expect(missing).toHaveLength(2);
+      expect(missing.map((f) => f.taskId).sort()).toEqual(["o/r#10", "o/r#30"]);
+    });
+  });
 });

--- a/packages/cli/src/sync/pull-executor.ts
+++ b/packages/cli/src/sync/pull-executor.ts
@@ -419,6 +419,28 @@ export async function executePull(
     ...(hasConflictsFlag ? { has_conflicts: true } : {}),
   };
 
+  // [Issue #167] 最終状態の再検証。
+  //
+  // pull 冒頭の validateSyncState は pre-pull 状態の不整合しか捕捉できない。
+  // 例えば kept-local で残された detach 済みタスク (projectData.items に無いが
+  // ローカル変更ありで削除しなかったタスク) は、pull 後に tasks.json には存在
+  // するが newIdMap には入らない状態になる。この不整合を放置すると次 push で
+  // push-executor.ts:476-479 により silent skip され、NFR-STABILITY-002 違反に
+  // なる。
+  //
+  // そのため、返却前の newTasksFile + newSyncState に対して再度
+  // validateSyncState を実行し、pull 中に新たに発生した不整合を findings に
+  // 追加する。既に冒頭の validate で報告済みの (category, taskId) はスキップして
+  // 重複を避ける。
+  const finalValidation = validateSyncState(newSyncState, newTasksFile);
+  const reportedKeys = new Set(syncStateFindings.map((f) => `${f.category}:${f.taskId}`));
+  for (const finding of finalValidation.findings) {
+    const key = `${finding.category}:${finding.taskId}`;
+    if (reportedKeys.has(key)) continue;
+    syncStateFindings.push(finding);
+    reportedKeys.add(key);
+  }
+
   return {
     result: {
       added,

--- a/packages/cli/src/sync/pull-executor.ts
+++ b/packages/cli/src/sync/pull-executor.ts
@@ -5,6 +5,7 @@ import { fetchAllIssueRelationshipLinks } from "../github/sub-issues.js";
 import {
   applySubIssueLinks,
   applyBlockedByLinks,
+  buildTaskId,
   isDraftTask,
   isMilestoneSyntheticTask,
   milestoneToTask,
@@ -64,8 +65,14 @@ export async function executePull(
 
   // Pre-check: issue の更新有無を軽量クエリで確認し、変化なし時はフル fetch をスキップする。
   // force / fullFetch / 初回同期（last_synced_at 空）の場合はバイパス。
+  // [Issue #167] sync-state に id_map 不整合が検出されている場合もバイパスしてフル fetch に
+  // 降格する。これにより pull がユーザーに --force を強いずにセルフヒーリングする。
   // pre-check は最適化パスなので失敗時はフル fetch にフォールバックする (fail-open)。
-  const skipPrecheck = opts.force || opts.fullFetch || !syncState.last_synced_at;
+  const hasSyncStateInconsistency = syncStateFindings.some(
+    (f) => f.category === "missing_id_map" || f.category === "orphan_id_map",
+  );
+  const skipPrecheck =
+    opts.force || opts.fullFetch || !syncState.last_synced_at || hasSyncStateInconsistency;
   if (!skipPrecheck) {
     let hasChanges = true;
     try {
@@ -133,6 +140,45 @@ export async function executePull(
     }
   }
 
+  // [Issue #167] id_map を projectData.items から authoritative に rebuild する。
+  //
+  // pull が id_map を更新しない設計だと、gh-gantt を経由せず作成された Issue
+  // (GitHub UI / gh issue create / PR マージによる自動追加 / 外部エディタによる
+  // sync-state.json 直接編集等) が tasks.json には入るが id_map には入らない
+  // 状態が発生し、その後の push で silent skip される (push-executor.ts:476-479)。
+  //
+  // 毎 pull で projectData.items から rebuild することで、pull が外部変化に対する
+  // セルフヒーリング点となる。副次的効果:
+  //   - 外部作成 issue → 次 pull で自動補完
+  //   - 破損した id_map → 次 pull で自動上書き
+  //   - stale な node_id → 自動更新
+  //   - orphan id_map (project から detach された) → 自動削除
+  //
+  // draft タスク (github_issue=null) は projectData.items に含まれないため
+  // id_map には入らない。push が draft→real 変換時に初めて id_map に追加する
+  // 既存仕様 (push-executor.ts:309) と整合する。
+  const newIdMap: SyncState["id_map"] = {};
+  for (const item of projectData.items) {
+    if (!item.content) continue;
+    const taskId = buildTaskId(item.content.repository, item.content.number);
+    newIdMap[taskId] = {
+      issue_number: item.content.number,
+      issue_node_id: item.content.nodeId,
+      project_item_id: item.id,
+    };
+  }
+
+  // [Issue #167] rebuild 後に findings を正しい状態へ promote する。
+  // validateSyncState は rebuild 前の状態で findings を出しているため、missing_id_map
+  // エントリのうち今 rebuild で補完されたものを autoFixed: true に promote し、
+  // メッセージも「次回 pull で補完」ではなく「自動補完しました」の過去形にする。
+  for (const finding of syncStateFindings) {
+    if (finding.category === "missing_id_map" && newIdMap[finding.taskId]) {
+      finding.autoFixed = true;
+      finding.message = `${finding.taskId} を id_map に自動補完しました (GraphQL から rebuild)`;
+    }
+  }
+
   // Quick check: skip sub-issues fetch if no remote changes.
   // --force 指定時は整合性担保のため quick-skip をバイパスし常にフル処理する。
   const localNonDraft = tasksFile.tasks.filter((t) => !isDraftTask(t.id));
@@ -172,6 +218,7 @@ export async function executePull(
         tasksFile,
         syncState: {
           ...syncState,
+          id_map: newIdMap,
           field_ids: fieldIds,
           option_ids: optionIds,
         },
@@ -274,7 +321,15 @@ export async function executePull(
     }
   }
 
-  // Tasks that exist locally but not remotely
+  // Tasks that exist locally but not remotely.
+  // [Issue #167] kept-local で残されたタスクが GitHub Project から detach された
+  // 場合 (remote に無い & ローカル変更あり)、mergedTasks には残るが newIdMap には
+  // 入らない (projectData.items の rebuild から漏れるため)。次 pull で validateSyncState が
+  // missing_id_map finding を emit し、その pull 内で現状のまま (project に戻るまで)
+  // id_map は空のまま → push は silent skip する設計。これは
+  // 「project が source of truth であり、detach された issue は gh-gantt の管理外」という
+  // ADR-007 の方針に沿った挙動。detach を永続化したいならローカルから削除、
+  // 再 attach したいなら GitHub 側で対応する。
   for (const [id, localTask] of localTaskMap) {
     if (isDraftTask(id)) {
       mergedTasks.push(localTask);
@@ -338,6 +393,7 @@ export async function executePull(
   const newSyncState: SyncState = {
     ...syncState,
     last_synced_at: new Date().toISOString(),
+    id_map: newIdMap,
     snapshots: newSnapshots,
     field_ids: fieldIds,
     option_ids: optionIds,

--- a/packages/cli/src/sync/pull-executor.ts
+++ b/packages/cli/src/sync/pull-executor.ts
@@ -147,10 +147,15 @@ export async function executePull(
   // sync-state.json 直接編集等) が tasks.json には入るが id_map には入らない
   // 状態が発生し、その後の push で silent skip される (push-executor.ts:476-479)。
   //
-  // 毎 pull で projectData.items から rebuild することで、pull が外部変化に対する
-  // セルフヒーリング点となる。副次的効果:
-  //   - 外部作成 issue → 次 pull で自動補完
-  //   - 破損した id_map → 次 pull で自動上書き
+  // fetchProject が実行される経路 (pre-check で早期 return していない場合) では、
+  // projectData.items から rebuild することで pull が外部変化に対するセルフヒーリング
+  // 点となる。pre-check で「変化なし」と判定されて早期 return する場合はそもそも
+  // id_map 再構築の必要がない (tasks.json と一致しているはず) が、不整合が検出されて
+  // いる場合は pre-check をバイパスしてこの経路に入るため、セルフヒーリング保証される。
+  //
+  // 副次的効果:
+  //   - 外部作成 issue → 次回 fetchProject を伴う pull で自動補完
+  //   - 破損した id_map → 次回 fetchProject を伴う pull で自動上書き
   //   - stale な node_id → 自動更新
   //   - orphan id_map (project から detach された) → 自動削除
   //
@@ -168,14 +173,23 @@ export async function executePull(
     };
   }
 
-  // [Issue #167] rebuild 後に findings を正しい状態へ promote する。
-  // validateSyncState は rebuild 前の状態で findings を出しているため、missing_id_map
-  // エントリのうち今 rebuild で補完されたものを autoFixed: true に promote し、
-  // メッセージも「次回 pull で補完」ではなく「自動補完しました」の過去形にする。
+  // [Issue #167] rebuild 後に id_map 関連 findings を正しい状態へ promote する。
+  // validateSyncState は rebuild 前の状態で findings を生成しているため、以下を更新:
+  //
+  // - missing_id_map: newIdMap に入った場合のみ "自動補完しました" に promote
+  //   (rebuild しても project に無いままなら未解消のため warn のまま残す)
+  // - orphan_id_map: rebuild により必ず解消される (project に存在すれば
+  //   mergedTasks に追加され、project に無ければ newIdMap から除去される)
+  //   ため常に "自動解消しました" に promote する
   for (const finding of syncStateFindings) {
     if (finding.category === "missing_id_map" && newIdMap[finding.taskId]) {
       finding.autoFixed = true;
+      finding.level = "info";
       finding.message = `${finding.taskId} を id_map に自動補完しました (GraphQL から rebuild)`;
+    } else if (finding.category === "orphan_id_map") {
+      finding.autoFixed = true;
+      finding.level = "info";
+      finding.message = `${finding.taskId} の orphan id_map エントリを自動解消しました (GraphQL から rebuild)`;
     }
   }
 

--- a/packages/cli/src/sync/pull-executor.ts
+++ b/packages/cli/src/sync/pull-executor.ts
@@ -64,9 +64,9 @@ export async function executePull(
   syncState = validatedSyncState;
 
   // Pre-check: issue の更新有無を軽量クエリで確認し、変化なし時はフル fetch をスキップする。
-  // force / fullFetch / 初回同期（last_synced_at 空）の場合はバイパス。
-  // [Issue #167] sync-state に id_map 不整合が検出されている場合もバイパスしてフル fetch に
-  // 降格する。これにより pull がユーザーに --force を強いずにセルフヒーリングする。
+  // force / fullFetch / 初回同期 (last_synced_at 空) の場合はバイパス。
+  // [Issue #167] id_map 不整合検出時もバイパスする: 早期 return すると下流の
+  // id_map rebuild 経路に到達できず、破損が次 pull まで持ち越されるため。
   // pre-check は最適化パスなので失敗時はフル fetch にフォールバックする (fail-open)。
   const hasSyncStateInconsistency = syncStateFindings.some(
     (f) => f.category === "missing_id_map" || f.category === "orphan_id_map",
@@ -140,28 +140,15 @@ export async function executePull(
     }
   }
 
-  // [Issue #167] id_map を projectData.items から authoritative に rebuild する。
-  //
-  // pull が id_map を更新しない設計だと、gh-gantt を経由せず作成された Issue
-  // (GitHub UI / gh issue create / PR マージによる自動追加 / 外部エディタによる
-  // sync-state.json 直接編集等) が tasks.json には入るが id_map には入らない
-  // 状態が発生し、その後の push で silent skip される (push-executor.ts:476-479)。
-  //
-  // fetchProject が実行される経路 (pre-check で早期 return していない場合) では、
-  // projectData.items から rebuild することで pull が外部変化に対するセルフヒーリング
-  // 点となる。pre-check で「変化なし」と判定されて早期 return する場合はそもそも
-  // id_map 再構築の必要がない (tasks.json と一致しているはず) が、不整合が検出されて
-  // いる場合は pre-check をバイパスしてこの経路に入るため、セルフヒーリング保証される。
-  //
-  // 副次的効果:
-  //   - 外部作成 issue → 次回 fetchProject を伴う pull で自動補完
-  //   - 破損した id_map → 次回 fetchProject を伴う pull で自動上書き
-  //   - stale な node_id → 自動更新
-  //   - orphan id_map (project から detach された) → 自動削除
+  // [Issue #167] pull が id_map を更新しない旧設計では、gh-gantt を経由せず
+  // 作成された Issue や sync-state.json の破損が push の silent skip の温床と
+  // なっていた (push-executor の existingDiffs ループで idEntry が undefined の
+  // 場合に skip される)。fetchProject 実行時に毎回 projectData.items から
+  // id_map を authoritative に rebuild することで、pull が外部変化への
+  // セルフヒーリング点となる (NFR-STABILITY-001)。
   //
   // draft タスク (github_issue=null) は projectData.items に含まれないため
-  // id_map には入らない。push が draft→real 変換時に初めて id_map に追加する
-  // 既存仕様 (push-executor.ts:309) と整合する。
+  // 対象外。draft→real 変換時の id_map 追加は push-executor の責務 (責務分離)。
   const newIdMap: SyncState["id_map"] = {};
   for (const item of projectData.items) {
     if (!item.content) continue;
@@ -173,14 +160,9 @@ export async function executePull(
     };
   }
 
-  // [Issue #167] rebuild 後に id_map 関連 findings を正しい状態へ promote する。
-  // validateSyncState は rebuild 前の状態で findings を生成しているため、以下を更新:
-  //
-  // - missing_id_map: newIdMap に入った場合のみ "自動補完しました" に promote
-  //   (rebuild しても project に無いままなら未解消のため warn のまま残す)
-  // - orphan_id_map: rebuild により必ず解消される (project に存在すれば
-  //   mergedTasks に追加され、project に無ければ newIdMap から除去される)
-  //   ため常に "自動解消しました" に promote する
+  // [Issue #167] rebuild 前に採取した findings を実状態に合わせて promote する。
+  // - missing_id_map: newIdMap に入った場合のみ解消 (project に無いままなら未解消)
+  // - orphan_id_map: rebuild により entry が必ず newIdMap から除去されるため無条件解消
   for (const finding of syncStateFindings) {
     if (finding.category === "missing_id_map" && newIdMap[finding.taskId]) {
       finding.autoFixed = true;
@@ -336,14 +318,6 @@ export async function executePull(
   }
 
   // Tasks that exist locally but not remotely.
-  // [Issue #167] kept-local で残されたタスクが GitHub Project から detach された
-  // 場合 (remote に無い & ローカル変更あり)、mergedTasks には残るが newIdMap には
-  // 入らない (projectData.items の rebuild から漏れるため)。次 pull で validateSyncState が
-  // missing_id_map finding を emit し、その pull 内で現状のまま (project に戻るまで)
-  // id_map は空のまま → push は silent skip する設計。これは
-  // 「project が source of truth であり、detach された issue は gh-gantt の管理外」という
-  // ADR-007 の方針に沿った挙動。detach を永続化したいならローカルから削除、
-  // 再 attach したいなら GitHub 側で対応する。
   for (const [id, localTask] of localTaskMap) {
     if (isDraftTask(id)) {
       mergedTasks.push(localTask);
@@ -419,19 +393,12 @@ export async function executePull(
     ...(hasConflictsFlag ? { has_conflicts: true } : {}),
   };
 
-  // [Issue #167] 最終状態の再検証。
-  //
-  // pull 冒頭の validateSyncState は pre-pull 状態の不整合しか捕捉できない。
-  // 例えば kept-local で残された detach 済みタスク (projectData.items に無いが
-  // ローカル変更ありで削除しなかったタスク) は、pull 後に tasks.json には存在
-  // するが newIdMap には入らない状態になる。この不整合を放置すると次 push で
-  // push-executor.ts:476-479 により silent skip され、NFR-STABILITY-002 違反に
-  // なる。
-  //
-  // そのため、返却前の newTasksFile + newSyncState に対して再度
-  // validateSyncState を実行し、pull 中に新たに発生した不整合を findings に
-  // 追加する。既に冒頭の validate で報告済みの (category, taskId) はスキップして
-  // 重複を避ける。
+  // [Issue #167] pull 冒頭の validate は pre-pull 状態しか捕捉できない。
+  // pull 処理中に新しく不整合が生まれる経路 — 代表例は kept-local detach
+  // (projectData に無いタスクをローカル変更保護のため残す) で、mergedTasks に
+  // 残るが newIdMap から漏れる — を顕在化するため、返却前の最終状態に対して
+  // 再検証を行う。放置すると push で silent skip され NFR-STABILITY-002 に反する。
+  // 冒頭で既報告の (category, taskId) は重複を避けるため skip する。
   const finalValidation = validateSyncState(newSyncState, newTasksFile);
   const reportedKeys = new Set(syncStateFindings.map((f) => `${f.category}:${f.taskId}`));
   for (const finding of finalValidation.findings) {

--- a/packages/cli/src/sync/validate-sync-state.ts
+++ b/packages/cli/src/sync/validate-sync-state.ts
@@ -33,9 +33,12 @@ export interface ValidateSyncStateResult {
  * - **orphan id_map**: id_map に存在するが tasksFile に存在しない ID
  *   → 警告のみ (リモート側にはまだ存在する可能性があるため自動削除しない)
  * - **missing id_map** [Issue #167]: tasksFile に存在するが id_map に無い ID
- *   → 情報のみ (level: "info"。validate 自体では修復できないが、同一 pull 内で
- *     pull-executor が id_map を rebuild して自動修復し、autoFixed: true に promote する。
- *     draft タスクと milestone 合成タスクは id_map を使わないため除外)
+ *   → 情報のみ (level: "info")。validate 自体では修復不可。発生源は 2 系統あり:
+ *     (a) pre-pull 状態の破損 — pull-executor が rebuild で自動修復し promote する。
+ *     (b) kept-local detach — project から消失したがローカル変更のため保持されたタスク。
+ *         rebuild 対象外のため autoFixed: false のまま残り、ユーザー操作 (ローカル削除
+ *         または project への再 attach) が必要。
+ *     draft タスクと milestone 合成タスクは id_map を使わないため除外。
  *
  * いずれも pull がタスクをスキップしたり、想定外の挙動を起こす原因になり得る。
  */
@@ -109,11 +112,11 @@ export function validateSyncState(
     }
   }
 
-  // 4. missing id_map [Issue #167] — tasks にあるが id_map に無い。
-  // validate 自体では GraphQL にアクセスできないため修復不可だが、pull-executor が
-  // projectData.items から id_map を authoritative に rebuild するため次 pull で解消する。
+  // 4. missing id_map [Issue #167] — tasks にあるが id_map に無い。validate 自体では
+  // 修復不可。解消経路は 2 系統 (JSDoc 参照)。
   // draft タスクは push 経由で初めて id_map に入る仕様のため除外。
-  // milestone 合成タスクは id_map を使わない (REST 経由でリポジトリの milestone を pull する) ため除外。
+  // milestone 合成タスクは projectData.items ではなく fetchRepositoryMetadata の
+  // milestones から合成される (id_map を使わない) ため除外。
   for (const task of tasksFile.tasks) {
     if (isDraftTask(task.id)) continue;
     if (isMilestoneSyntheticTask(task.id)) continue;
@@ -122,7 +125,7 @@ export function validateSyncState(
         level: "info",
         category: "missing_id_map",
         taskId: task.id,
-        message: `${task.id} が id_map に存在しません。次回 'gh-gantt pull' で自動的に補完されます (外部作成 Issue や sync-state の破損でも自己修復されます)`,
+        message: `${task.id} が id_map に存在しません。task が GitHub Project に含まれていれば pull で自動補完されます。含まれていない場合は project への再追加またはローカルから削除が必要です`,
         autoFixed: false,
       });
     }

--- a/packages/cli/src/sync/validate-sync-state.ts
+++ b/packages/cli/src/sync/validate-sync-state.ts
@@ -1,4 +1,5 @@
 import type { SyncState, TasksFile } from "@gh-gantt/shared";
+import { isDraftTask, isMilestoneSyntheticTask } from "../github/issues.js";
 
 /**
  * sync-state の整合性検証で見つかった問題。
@@ -9,7 +10,7 @@ import type { SyncState, TasksFile } from "@gh-gantt/shared";
  */
 export interface SyncStateFinding {
   level: "warn" | "info";
-  category: "orphan_snapshot" | "orphan_id_map" | "invalid_snapshot_hash";
+  category: "orphan_snapshot" | "orphan_id_map" | "missing_id_map" | "invalid_snapshot_hash";
   taskId: string;
   message: string;
   autoFixed: boolean;
@@ -31,6 +32,9 @@ export interface ValidateSyncStateResult {
  *   → snapshot ごと削除し、次回 pull で再構築させる
  * - **orphan id_map**: id_map に存在するが tasksFile に存在しない ID
  *   → 警告のみ (リモート側にはまだ存在する可能性があるため自動削除しない)
+ * - **missing id_map** [Issue #167]: tasksFile に存在するが id_map に無い ID
+ *   → 警告のみ (validate 自体では修復できないが、次 pull で id_map が rebuild されて
+ *     自動修復される。draft タスクと milestone 合成タスクは id_map を使わないため除外)
  *
  * いずれも pull がタスクをスキップしたり、想定外の挙動を起こす原因になり得る。
  */
@@ -99,6 +103,25 @@ export function validateSyncState(
         category: "orphan_id_map",
         taskId: id,
         message: `id_map ${id} が tasksFile に存在しません。まず 'gh-gantt pull --force' を試してください。それでも解消しない場合は .gantt-sync/ の再初期化を検討してください`,
+        autoFixed: false,
+      });
+    }
+  }
+
+  // 4. missing id_map [Issue #167] — tasks にあるが id_map に無い。
+  // validate 自体では GraphQL にアクセスできないため修復不可だが、pull-executor が
+  // projectData.items から id_map を authoritative に rebuild するため次 pull で解消する。
+  // draft タスクは push 経由で初めて id_map に入る仕様のため除外。
+  // milestone 合成タスクは id_map を使わない (REST 経由でリポジトリの milestone を pull する) ため除外。
+  for (const task of tasksFile.tasks) {
+    if (isDraftTask(task.id)) continue;
+    if (isMilestoneSyntheticTask(task.id)) continue;
+    if (!idMapKeys.has(task.id)) {
+      findings.push({
+        level: "info",
+        category: "missing_id_map",
+        taskId: task.id,
+        message: `${task.id} が id_map に存在しません。次回 'gh-gantt pull' で自動的に補完されます (外部作成 Issue や sync-state の破損でも自己修復されます)`,
         autoFixed: false,
       });
     }

--- a/packages/cli/src/sync/validate-sync-state.ts
+++ b/packages/cli/src/sync/validate-sync-state.ts
@@ -33,8 +33,9 @@ export interface ValidateSyncStateResult {
  * - **orphan id_map**: id_map に存在するが tasksFile に存在しない ID
  *   → 警告のみ (リモート側にはまだ存在する可能性があるため自動削除しない)
  * - **missing id_map** [Issue #167]: tasksFile に存在するが id_map に無い ID
- *   → 警告のみ (validate 自体では修復できないが、次 pull で id_map が rebuild されて
- *     自動修復される。draft タスクと milestone 合成タスクは id_map を使わないため除外)
+ *   → 情報のみ (level: "info"。validate 自体では修復できないが、同一 pull 内で
+ *     pull-executor が id_map を rebuild して自動修復し、autoFixed: true に promote する。
+ *     draft タスクと milestone 合成タスクは id_map を使わないため除外)
  *
  * いずれも pull がタスクをスキップしたり、想定外の挙動を起こす原因になり得る。
  */


### PR DESCRIPTION
## Summary

- `pull-executor.ts` が毎回 `projectData.items` から `id_map` を authoritative に rebuild するように変更し、`gh-gantt` を経由せず作成された Issue (GitHub UI / `gh issue create` / PR マージによる自動追加 / sync-state.json 直接編集) がサイレントに消える問題を根治する
- `validate-sync-state.ts` に `missing_id_map` (tasks にあるが id_map に無い) 逆方向不整合の検出を追加
- pre-check quick-skip 経路も不整合検出時はフル fetch に降格させ、ユーザーが `--force` を毎回指定しなくてもセルフヒーリングされるようにする

## 根本原因

`pull-executor.ts` は元々 `id_map` を一切更新していませんでした (`git log -S "id_map" -- packages/cli/src/sync/pull-executor.ts` で履歴ゼロ、pull コマンドの初回コミット以来)。`id_map` が populate されるのは `init` と `push` の draft→real 変換のみで、外部起源の Issue に対するセルフヒーリング機構が存在しませんでした。

結果、以下のパターンで `id_map` が `tasks.json` から乖離:
- GitHub UI / `gh issue create` で Issue 作成
- PR マージにより自動追加された Issue
- 何らかの理由で `sync-state.json` が破損/編集された場合

これらのタスクに対する `push` は `push-executor.ts:476-479` で `id_map[task.id]` が undefined となり **silent skip** されていました (エラーも warning も出ず)。

実発現: 本リポジトリで `tasks.json` 100 件に対し `id_map` 81 件、`#95` 以降 19 件が欠損していました。

## 修正方針

**「GitHub Project が source of truth」という ADR-007 の方針に沿い、pull が外部変化に対するセルフヒーリング点となる**ように設計変更。毎 pull で `projectData.items` から `id_map` を rebuild する。

副次的効果:
- 外部作成 issue → 次 pull で自動補完
- 破損した id_map → 次 pull で自動上書き
- stale な `issue_node_id` → 自動更新
- orphan id_map (project から detach) → 自動削除

## 変更点

### コア修正
- `packages/cli/src/sync/pull-executor.ts`
  - `newIdMap` を `projectData.items` から構築し、sameIdSets quick-skip と通常パスの両方に反映
  - `missing_id_map` / `orphan_id_map` 検出時は pre-check をバイパスしてフル fetch に降格
  - rebuild 後に該当する `missing_id_map` finding を `autoFixed: true` に promote し、メッセージを過去形 (「自動補完しました」) に書き換え
  - kept-local + detach タスクの挙動を ADR-007 基準でコメント化
- `packages/cli/src/sync/validate-sync-state.ts`
  - 4 つ目のカテゴリ `missing_id_map` を追加 (`draft` / `milestone` 合成タスクは除外)

### テスト
- `packages/cli/src/__tests__/regressions/issue-167-pull-id-map-rebuild.test.ts` (新規)
  - 基本 6 ケース: empty / partial / orphan / stale / draft / empty project
  - E2E セルフヒーリング 4 ケース: pre-check バイパス / findings 列挙と promote / 連続 pull での収束 / sameIdSets 経路
- `packages/cli/src/__tests__/validate-sync-state.test.ts`
  - `missing_id_map` 検出の 4 テスト

### 要件
- `docs/requirements.yaml`
  - `NFR-STABILITY-001` に `AC3` (pull の id_map rebuild) と `AC4` (missing_id_map 検出) を追加し、`status: covered` に昇格

## 検証

- ✅ `pnpm --filter @gh-gantt/cli test`: **342/342 pass** (既存 328 + 新規 14)
- ✅ `pnpm lint`: 0 errors (55 pre-existing warnings)
- ✅ `pnpm build`: 成功
- ✅ **実機セルフヒーリング**: ローカル `.gantt-sync/` の `id_map` 81 件 → 100 件に自動復旧、`#5` orphan も除去されたことを確認
- ⚠️ `pnpm typecheck`: `packages/shared` で既存のエラーあり (本 PR と無関係、main 由来)

## Test plan

- [x] `pnpm test` 全 pass
- [x] 空 id_map から pull → 全エントリ populate
- [x] 部分欠損 id_map → 補完
- [x] orphan id_map → 削除
- [x] stale node_id → 更新
- [x] draft タスクは id_map に入らない
- [x] pre-check quick-skip バイパス (非 force 呼び出しでもセルフヒーリング)
- [x] sameIdSets quick-skip 経路でも rebuild
- [x] 連続 pull で収束 (2 回目は finding なし)
- [x] 実機: 破損 81 → 100 件に復旧

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * tasks.json と ID マップの不整合（missing_id_map）を検出し、ドラフトやマイルストーン合成タスクを除外した上で次回の pull 時に権威的に再構築して自動修復します。再構築後は不整合通知を自動更新・解消表示し、軽量チェック経路を回避して確実に同期を行います。
* **Tests**
  * 再構築・自動修復・自己修復挙動や境界ケース（孤立エントリ、更新、除外など）を網羅する回帰・検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->