### PR TITLE
ci: lefthook に CI 再現チェックとブランチ状態チェックを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,27 @@ pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/hash.test.ts
 pnpm build && pnpm --filter @gh-gantt/cli exec pnpm link --global
 ```
 
+### CI 再現チェック
+
+`lefthook` の pre-push フックが CI (`.github/workflows/ci.yml`) と同等のチェックを自動実行する。
+push 前に以下が順に走るため、CI で落ちることを事前に検出できる。
+
+| ステップ     | コマンド                                  | 目的                                          |
+| ------------ | ----------------------------------------- | --------------------------------------------- |
+| test         | `pnpm test:json`                          | 全テスト + JSON レポーター (req:trace の入力) |
+| build        | `pnpm build`                              | ビルド検証                                    |
+| req-trace    | `pnpm req:trace` + `git diff --exit-code` | requirements.yaml のトレーサビリティ検証      |
+| req-validate | `pnpm req:validate`                       | テストタグと requirements.yaml の整合性       |
+| docs-gen     | `pnpm docs:gen` + `git diff --exit-code`  | 生成ドキュメントの drift 検出                 |
+
+pre-commit フックではブランチ状態チェック（main への直接コミット防止、マージ済みブランチへの誤コミット検出）も実行する。
+
+**手動で CI 相当のチェックを実行する場合:**
+
+```bash
+pnpm test:json && pnpm build && pnpm req:trace && git diff --exit-code docs/requirements.yaml && pnpm req:validate && pnpm docs:gen && git diff --exit-code docs/generated/
+```
+
 ## アーキテクチャ
 
 pnpm workspaces モノレポ。`packages/` 配下に3パッケージ：

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,10 +2,44 @@ no_tty: true
 
 pre-commit:
   jobs:
+    - name: branch-check
+      # マージ済み PR があるブランチへの誤コミットを防止する。
+      # main/master ブランチへの直接コミットも警告する。
+      run: |
+        branch=$(git branch --show-current)
+        if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+          echo "⚠ main ブランチへの直接コミットです。意図的な場合は --no-verify で回避してください。"
+          exit 1
+        fi
+        if command -v gh >/dev/null 2>&1; then
+          state=$(gh pr list --head "$branch" --state merged --json number --jq '.[0].number' 2>/dev/null)
+          if [ -n "$state" ]; then
+            echo "⚠ このブランチの PR #$state は既にマージ済みです。main に戻って新しいブランチを作成してください。"
+            exit 1
+          fi
+        fi
     - name: lint
       run: vp check < /dev/null
 
 pre-push:
+  # CI (.github/workflows/ci.yml) と同等のチェックをローカルで再現する。
+  # CI で落ちてから修正する手間を排除するため、push 前に全チェックを実行する。
   jobs:
     - name: test
-      run: vp run test < /dev/null
+      # test:json は test + JSON レポーター出力。req:trace の入力となる。
+      run: vp run test:json < /dev/null
+    - name: build
+      run: vp run build < /dev/null
+    - name: req-trace
+      # テスト結果 JSON から requirements.yaml のトレーサビリティを再生成し、
+      # コミット済みの requirements.yaml と差分がないことを検証する。
+      run: |
+        vp run req:trace < /dev/null
+        git diff --exit-code docs/requirements.yaml || (echo "requirements.yaml is out of date. Run 'pnpm req:trace' and commit." && exit 1)
+    - name: req-validate
+      # テストファイルの [FR-*]/[NFR-*] タグと requirements.yaml の整合性を検証する。
+      run: vp run req:validate < /dev/null
+    - name: docs-gen
+      run: |
+        vp run docs:gen < /dev/null
+        git diff --exit-code docs/generated/ || (echo "docs/generated/ is out of date. Run 'pnpm docs:gen' and commit." && exit 1)


### PR DESCRIPTION
## Summary

- lefthook の pre-push に CI と同等のチェックを追加し、push 前に全検証を自動実行する
- lefthook の pre-commit にブランチ状態チェックを追加し、main への直接コミットとマージ済みブランチへの誤コミットを防止する
- CLAUDE.md に CI 再現チェックの説明を追記し、誰が作業しても同じ規律が適用されるようにする

## 背景

PR のたびに CI 失敗やレビュー指摘が発生していた。原因は lefthook と CI の間にチェックのギャップがあり、ローカルで通っても CI で落ちるステップが存在��たこと。また、マージ済みブランチにコミットするなどの作業ミスも個人の注意力に依存していた。

## 変更点

### pre-commit に追加
- `branch-check`: main への直接コミット防止 + `gh` CLI でマージ済み PR ブランチを検出

### pre-push に追加 (CI `.github/workflows/ci.yml` と同等)
| ステップ | コマンド | 目的 |
|---|---|---|
| test | `pnpm test:json` | 全テスト + JSON レポーター (req:trace の入力) |
| build | `pnpm build` | ビルド検証 |
| req-trace | `pnpm req:trace` + `git diff --exit-code` | 要件トレーサビリティ検証 |
| req-validate | `pnpm req:validate` | テストタグと requirements.yaml の整合性 |
| docs-gen | `pnpm docs:gen` + `git diff --exit-code` | 生成ドキュメントの drift 検出 |

### CLAUDE.md
- CI 再現チェックのセクションを追記

## 検証

- ✅ pre-commit: branch-check + lint 通過
- ✅ pre-push: 5 ステップすべて通過 (合計 ~13 秒、従来比 +1 秒)
- ✅ マージ済みブランチでのコミット検出が機能することを確認

## Test plan

- [x] feature ブランチでコミット → branch-check 通過
- [x] push → test / build / req-trace / req-validate / docs-gen 全通過
- [x] requirements.yaml が最新であることを git diff --exit-code で検証
- [x] docs/generated/ が最新であることを git diff --exit-code で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * CI再現チェックとブランチ状態検証の手順をドキュメントに追加

* **チア**
  * プッシュ前の CI チェック処理を拡張（テスト、ビルド、要件検証、ドキュメント生成を自動実行）
  * コミット時のブランチ保護機能を強化（main/master への直接コミットを防止、マージ済みブランチの検出）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->