### PR TITLE
feat(cli): gh-gantt doctor コマンドを追加

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,0 +1,227 @@
+/**
+ * [NFR-STABILITY-001] doctor コマンドの整合性チェック
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Task, SyncState, TasksFile } from "@gh-gantt/shared";
+
+// doctor.ts 内部のチェック関数をテストするため、モジュールを動的にインポートする
+// ファイル読み込みと execFile をモックして純粋にロジックをテストする
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "o/r",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${id}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "",
+    updated_at: "",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeSyncState(overrides: Partial<SyncState> = {}): SyncState {
+  return {
+    last_synced_at: "",
+    project_node_id: "PVT_1",
+    id_map: {},
+    field_ids: {},
+    snapshots: {},
+    ...overrides,
+  };
+}
+
+function makeTasksFile(tasks: Task[]): TasksFile {
+  return {
+    tasks,
+    cache: { comments: {}, reactions: {} },
+  };
+}
+
+// doctor コマンドは fs と execFile に依存するため、
+// 内部ロジックのテストはチェック対象ごとに分離する
+
+describe("[NFR-STABILITY-001] doctor コマンド", () => {
+  describe("循環依存チェック", () => {
+    // detectCycles のロジックを直接テスト（doctor.ts と同じアルゴリズム）
+    function detectCycles(tasks: Task[]): string[][] {
+      const graph = new Map<string, string[]>();
+      for (const task of tasks) {
+        if (!graph.has(task.id)) graph.set(task.id, []);
+        for (const dep of task.blocked_by) {
+          if (!graph.has(dep.task)) graph.set(dep.task, []);
+          graph.get(dep.task)!.push(task.id);
+        }
+      }
+      const cycles: string[][] = [];
+      const visited = new Set<string>();
+      const inStack = new Set<string>();
+      const path: string[] = [];
+      function dfs(node: string) {
+        visited.add(node);
+        inStack.add(node);
+        path.push(node);
+        for (const neighbor of graph.get(node) ?? []) {
+          if (inStack.has(neighbor)) {
+            const cycleStart = path.indexOf(neighbor);
+            cycles.push(path.slice(cycleStart));
+          } else if (!visited.has(neighbor)) {
+            dfs(neighbor);
+          }
+        }
+        path.pop();
+        inStack.delete(node);
+      }
+      for (const node of graph.keys()) {
+        if (!visited.has(node)) dfs(node);
+      }
+      return cycles;
+    }
+
+    it("循環がない場合は空配列を返す", () => {
+      const tasks = [
+        makeTask("A"),
+        makeTask("B", { blocked_by: [{ task: "A", type: "finish-to-start", lag: 0 }] }),
+      ];
+      expect(detectCycles(tasks)).toEqual([]);
+    });
+
+    it("直接的な循環を検出する", () => {
+      const tasks = [
+        makeTask("A", { blocked_by: [{ task: "B", type: "finish-to-start", lag: 0 }] }),
+        makeTask("B", { blocked_by: [{ task: "A", type: "finish-to-start", lag: 0 }] }),
+      ];
+      const cycles = detectCycles(tasks);
+      expect(cycles.length).toBeGreaterThan(0);
+    });
+
+    it("三角形の循環を検出する", () => {
+      const tasks = [
+        makeTask("A", { blocked_by: [{ task: "C", type: "finish-to-start", lag: 0 }] }),
+        makeTask("B", { blocked_by: [{ task: "A", type: "finish-to-start", lag: 0 }] }),
+        makeTask("C", { blocked_by: [{ task: "B", type: "finish-to-start", lag: 0 }] }),
+      ];
+      const cycles = detectCycles(tasks);
+      expect(cycles.length).toBeGreaterThan(0);
+    });
+
+    it("依存関係がない場合は空配列を返す", () => {
+      const tasks = [makeTask("A"), makeTask("B"), makeTask("C")];
+      expect(detectCycles(tasks)).toEqual([]);
+    });
+  });
+
+  describe("id_map 整合性チェック", () => {
+    function checkIdMap(tasksFile: TasksFile, syncState: SyncState) {
+      const taskIds = new Set(tasksFile.tasks.map((t) => t.id));
+      const idMapKeys = new Set(Object.keys(syncState.id_map));
+      const issues: string[] = [];
+      for (const id of idMapKeys) {
+        if (!taskIds.has(id)) {
+          issues.push(`id_map に ${id} がありますが tasks.json に存在しません`);
+        }
+      }
+      for (const task of tasksFile.tasks) {
+        if (task.id.startsWith("draft-")) continue;
+        if (task.id.startsWith("milestone-")) continue;
+        if (!idMapKeys.has(task.id)) {
+          issues.push(`${task.id} が id_map に存在しません`);
+        }
+      }
+      return issues;
+    }
+
+    it("整合している場合は空配列を返す", () => {
+      const tasks = [makeTask("stanah/gh-gantt#1")];
+      const syncState = makeSyncState({
+        id_map: {
+          "stanah/gh-gantt#1": {
+            issue_number: 1,
+            issue_node_id: "I_1",
+            project_item_id: "PVTI_1",
+          },
+        },
+      });
+      expect(checkIdMap(makeTasksFile(tasks), syncState)).toEqual([]);
+    });
+
+    it("id_map に余分なエントリがある場合を検出する", () => {
+      const syncState = makeSyncState({
+        id_map: {
+          "stanah/gh-gantt#99": {
+            issue_number: 99,
+            issue_node_id: "I_99",
+            project_item_id: "PVTI_99",
+          },
+        },
+      });
+      const issues = checkIdMap(makeTasksFile([]), syncState);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain("#99");
+    });
+
+    it("tasks にあるが id_map に無いエントリを検出する", () => {
+      const tasks = [makeTask("stanah/gh-gantt#5")];
+      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain("#5");
+    });
+
+    it("draft タスクは id_map 不在でもスキップする", () => {
+      const tasks = [makeTask("draft-abc")];
+      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
+      expect(issues).toEqual([]);
+    });
+
+    it("milestone 合成タスクは id_map 不在でもスキップする", () => {
+      const tasks = [makeTask("milestone-v1")];
+      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
+      expect(issues).toEqual([]);
+    });
+  });
+
+  describe("ハッシュ整合性チェック", () => {
+    it("snapshot.hash が空文字列の場合に検出する", () => {
+      const tasks = [makeTask("stanah/gh-gantt#1")];
+      const syncState = makeSyncState({
+        snapshots: {
+          "stanah/gh-gantt#1": {
+            hash: "",
+            synced_at: "",
+          },
+        },
+      });
+      // hash が空 → 不整合
+      const snapshot = syncState.snapshots["stanah/gh-gantt#1"];
+      expect(!snapshot.hash || typeof snapshot.hash !== "string").toBe(true);
+    });
+
+    it("正常な snapshot.hash は問題なし", () => {
+      const syncState = makeSyncState({
+        snapshots: {
+          "stanah/gh-gantt#1": {
+            hash: "abc123def456",
+            synced_at: "",
+          },
+        },
+      });
+      const snapshot = syncState.snapshots["stanah/gh-gantt#1"];
+      expect(!snapshot.hash || typeof snapshot.hash !== "string").toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,11 +1,20 @@
 /**
  * [NFR-STABILITY-001] doctor コマンドの整合性チェック
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Task, SyncState, TasksFile } from "@gh-gantt/shared";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  detectCycles,
+  GANTT_DIR,
+  CONFIG_FILE,
+  TASKS_FILE,
+  SYNC_STATE_FILE,
+} from "@gh-gantt/shared";
+import type { Task, SyncState, TasksFile, Config } from "@gh-gantt/shared";
 
-// doctor.ts 内部のチェック関数をテストするため、モジュールを動的にインポートする
-// ファイル読み込みと execFile をモックして純粋にロジックをテストする
+// ── ヘルパー ──
 
 function makeTask(id: string, overrides: Partial<Task> = {}): Task {
   return {
@@ -53,46 +62,124 @@ function makeTasksFile(tasks: Task[]): TasksFile {
   };
 }
 
-// doctor コマンドは fs と execFile に依存するため、
-// 内部ロジックのテストはチェック対象ごとに分離する
+function makeConfig(): Config {
+  return {
+    version: "1",
+    project: {
+      name: "test",
+      github: { owner: "o", repo: "r", project_number: 1 },
+    },
+    sync: {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    },
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: { Done: { color: "#0f0", done: true } } },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+    },
+  };
+}
+
+async function setupProjectDir(opts: {
+  config?: Config | false;
+  tasksFile?: TasksFile | false;
+  syncState?: SyncState | false;
+}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "doctor-test-"));
+  const ganttDir = join(dir, GANTT_DIR);
+  await mkdir(ganttDir, { recursive: true });
+
+  if (opts.config !== false) {
+    await writeFile(
+      join(ganttDir, CONFIG_FILE),
+      JSON.stringify(opts.config ?? makeConfig(), null, 2),
+    );
+  }
+  if (opts.tasksFile !== false) {
+    await writeFile(
+      join(ganttDir, TASKS_FILE),
+      JSON.stringify(opts.tasksFile ?? makeTasksFile([]), null, 2),
+    );
+  }
+  if (opts.syncState !== false) {
+    await writeFile(
+      join(ganttDir, SYNC_STATE_FILE),
+      JSON.stringify(opts.syncState ?? makeSyncState(), null, 2),
+    );
+  }
+
+  return dir;
+}
+
+/**
+ * doctor コマンドを --json --offline で実行し結果オブジェクトを返す。
+ * --offline を常に付与して GitHub 認証の外部依存を排除する。
+ */
+async function runDoctorJson(
+  dir: string,
+  extraArgs: string[] = [],
+): Promise<{
+  checks: Array<{
+    name: string;
+    status: string;
+    message: string;
+    details?: string[];
+    fixed?: boolean;
+  }>;
+  summary: { pass: number; warn: number; fail: number };
+}> {
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  const origExitCode = process.exitCode;
+
+  try {
+    const { doctorCommand } = await import("../commands/doctor.js");
+    const args = ["node", "doctor", "--json"];
+    // --offline がまだ含まれていなければ追加
+    if (!extraArgs.includes("--offline")) {
+      args.push("--offline");
+    }
+    args.push(...extraArgs);
+    await doctorCommand.parseAsync(args, { from: "user" });
+    return JSON.parse(logs.join(""));
+  } finally {
+    console.log = origLog;
+    process.exitCode = origExitCode;
+    process.chdir(originalCwd);
+  }
+}
+
+// ── テスト ──
 
 describe("[NFR-STABILITY-001] doctor コマンド", () => {
-  describe("循環依存チェック", () => {
-    // detectCycles のロジックを直接テスト（doctor.ts と同じアルゴリズム）
-    function detectCycles(tasks: Task[]): string[][] {
-      const graph = new Map<string, string[]>();
-      for (const task of tasks) {
-        if (!graph.has(task.id)) graph.set(task.id, []);
-        for (const dep of task.blocked_by) {
-          if (!graph.has(dep.task)) graph.set(dep.task, []);
-          graph.get(dep.task)!.push(task.id);
-        }
-      }
-      const cycles: string[][] = [];
-      const visited = new Set<string>();
-      const inStack = new Set<string>();
-      const path: string[] = [];
-      function dfs(node: string) {
-        visited.add(node);
-        inStack.add(node);
-        path.push(node);
-        for (const neighbor of graph.get(node) ?? []) {
-          if (inStack.has(neighbor)) {
-            const cycleStart = path.indexOf(neighbor);
-            cycles.push(path.slice(cycleStart));
-          } else if (!visited.has(neighbor)) {
-            dfs(neighbor);
-          }
-        }
-        path.pop();
-        inStack.delete(node);
-      }
-      for (const node of graph.keys()) {
-        if (!visited.has(node)) dfs(node);
-      }
-      return cycles;
-    }
+  let testDir: string | undefined;
+  const safeDir = tmpdir();
 
+  beforeEach(() => {
+    process.chdir(safeDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(safeDir);
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true });
+      testDir = undefined;
+    }
+  });
+
+  // ── 単体ロジックテスト（shared の detectCycles を使用） ──
+
+  describe("循環依存チェック（shared detectCycles）", () => {
     it("循環がない場合は空配列を返す", () => {
       const tasks = [
         makeTask("A"),
@@ -126,102 +213,181 @@ describe("[NFR-STABILITY-001] doctor コマンド", () => {
     });
   });
 
-  describe("id_map 整合性チェック", () => {
-    function checkIdMap(tasksFile: TasksFile, syncState: SyncState) {
-      const taskIds = new Set(tasksFile.tasks.map((t) => t.id));
-      const idMapKeys = new Set(Object.keys(syncState.id_map));
-      const issues: string[] = [];
-      for (const id of idMapKeys) {
-        if (!taskIds.has(id)) {
-          issues.push(`id_map に ${id} がありますが tasks.json に存在しません`);
-        }
-      }
-      for (const task of tasksFile.tasks) {
-        if (task.id.startsWith("draft-")) continue;
-        if (task.id.startsWith("milestone-")) continue;
-        if (!idMapKeys.has(task.id)) {
-          issues.push(`${task.id} が id_map に存在しません`);
-        }
-      }
-      return issues;
-    }
+  // ── コマンド定義テスト ──
 
-    it("整合している場合は空配列を返す", () => {
-      const tasks = [makeTask("stanah/gh-gantt#1")];
-      const syncState = makeSyncState({
-        id_map: {
-          "stanah/gh-gantt#1": {
-            issue_number: 1,
-            issue_node_id: "I_1",
-            project_item_id: "PVTI_1",
-          },
-        },
-      });
-      expect(checkIdMap(makeTasksFile(tasks), syncState)).toEqual([]);
+  describe("コマンド定義", () => {
+    it("doctor コマンドが program に登録されている", async () => {
+      const { buildProgram } = await import("../program.js");
+      const program = buildProgram();
+      const names = program.commands.map((c) => c.name());
+      expect(names).toContain("doctor");
     });
 
-    it("id_map に余分なエントリがある場合を検出する", () => {
-      const syncState = makeSyncState({
-        id_map: {
-          "stanah/gh-gantt#99": {
-            issue_number: 99,
-            issue_node_id: "I_99",
-            project_item_id: "PVTI_99",
-          },
-        },
-      });
-      const issues = checkIdMap(makeTasksFile([]), syncState);
-      expect(issues).toHaveLength(1);
-      expect(issues[0]).toContain("#99");
-    });
-
-    it("tasks にあるが id_map に無いエントリを検出する", () => {
-      const tasks = [makeTask("stanah/gh-gantt#5")];
-      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
-      expect(issues).toHaveLength(1);
-      expect(issues[0]).toContain("#5");
-    });
-
-    it("draft タスクは id_map 不在でもスキップする", () => {
-      const tasks = [makeTask("draft-abc")];
-      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
-      expect(issues).toEqual([]);
-    });
-
-    it("milestone 合成タスクは id_map 不在でもスキップする", () => {
-      const tasks = [makeTask("milestone-v1")];
-      const issues = checkIdMap(makeTasksFile(tasks), makeSyncState());
-      expect(issues).toEqual([]);
+    it("--fix, --offline, --json オプションが定義されている", async () => {
+      const { doctorCommand } = await import("../commands/doctor.js");
+      const optionNames = doctorCommand.options.map((o) => o.long);
+      expect(optionNames).toContain("--fix");
+      expect(optionNames).toContain("--offline");
+      expect(optionNames).toContain("--json");
     });
   });
 
-  describe("ハッシュ整合性チェック", () => {
-    it("snapshot.hash が空文字列の場合に検出する", () => {
-      const tasks = [makeTask("stanah/gh-gantt#1")];
-      const syncState = makeSyncState({
-        snapshots: {
-          "stanah/gh-gantt#1": {
-            hash: "",
-            synced_at: "",
-          },
-        },
-      });
-      // hash が空 → 不整合
-      const snapshot = syncState.snapshots["stanah/gh-gantt#1"];
-      expect(!snapshot.hash || typeof snapshot.hash !== "string").toBe(true);
+  // ── 統合テスト（ファイルシステムベース） ──
+
+  describe("ファイル存在チェック", () => {
+    it("全ファイルが正常な場合 PASS を返す", async () => {
+      testDir = await setupProjectDir({});
+      const output = await runDoctorJson(testDir);
+
+      const configCheck = output.checks.find((c) => c.name === "config-schema");
+      expect(configCheck?.status).toBe("PASS");
+      const tasksCheck = output.checks.find((c) => c.name === "tasks-file");
+      expect(tasksCheck?.status).toBe("PASS");
+      const stateCheck = output.checks.find((c) => c.name === "sync-state-file");
+      expect(stateCheck?.status).toBe("PASS");
     });
 
-    it("正常な snapshot.hash は問題なし", () => {
-      const syncState = makeSyncState({
-        snapshots: {
-          "stanah/gh-gantt#1": {
-            hash: "abc123def456",
-            synced_at: "",
+    it("config が存在しない場合 FAIL を返す", async () => {
+      testDir = await setupProjectDir({ config: false });
+      const output = await runDoctorJson(testDir);
+
+      const configCheck = output.checks.find((c) => c.name === "config-schema");
+      expect(configCheck?.status).toBe("FAIL");
+      expect(configCheck?.message).toContain("見つかりません");
+    });
+
+    it("tasks.json が存在しない場合 FAIL を返す", async () => {
+      testDir = await setupProjectDir({ tasksFile: false });
+      const output = await runDoctorJson(testDir);
+
+      const tasksCheck = output.checks.find((c) => c.name === "tasks-file");
+      expect(tasksCheck?.status).toBe("FAIL");
+    });
+
+    it("sync-state.json が存在しない場合 FAIL を返す", async () => {
+      testDir = await setupProjectDir({ syncState: false });
+      const output = await runDoctorJson(testDir);
+
+      const stateCheck = output.checks.find((c) => c.name === "sync-state-file");
+      expect(stateCheck?.status).toBe("FAIL");
+    });
+  });
+
+  describe("循環依存検出（統合）", () => {
+    it("循環がなければ PASS", async () => {
+      const tasks = [
+        makeTask("o/r#1", { github_issue: 1 }),
+        makeTask("o/r#2", {
+          github_issue: 2,
+          blocked_by: [{ task: "o/r#1", type: "finish-to-start", lag: 0 }],
+        }),
+      ];
+      testDir = await setupProjectDir({
+        tasksFile: makeTasksFile(tasks),
+        syncState: makeSyncState({
+          id_map: {
+            "o/r#1": { issue_number: 1, issue_node_id: "I_1", project_item_id: "PI_1" },
+            "o/r#2": { issue_number: 2, issue_node_id: "I_2", project_item_id: "PI_2" },
           },
-        },
+          snapshots: {
+            "o/r#1": { hash: "abc", synced_at: "2026-01-01T00:00:00Z" },
+            "o/r#2": { hash: "def", synced_at: "2026-01-01T00:00:00Z" },
+          },
+        }),
       });
-      const snapshot = syncState.snapshots["stanah/gh-gantt#1"];
-      expect(!snapshot.hash || typeof snapshot.hash !== "string").toBe(false);
+
+      const output = await runDoctorJson(testDir);
+      const cycleCheck = output.checks.find((c) => c.name === "dependency-cycles");
+      expect(cycleCheck?.status).toBe("PASS");
+    });
+
+    it("循環があれば FAIL と詳細を返す", async () => {
+      const tasks = [
+        makeTask("o/r#1", {
+          github_issue: 1,
+          blocked_by: [{ task: "o/r#2", type: "finish-to-start", lag: 0 }],
+        }),
+        makeTask("o/r#2", {
+          github_issue: 2,
+          blocked_by: [{ task: "o/r#1", type: "finish-to-start", lag: 0 }],
+        }),
+      ];
+      testDir = await setupProjectDir({
+        tasksFile: makeTasksFile(tasks),
+        syncState: makeSyncState({
+          id_map: {
+            "o/r#1": { issue_number: 1, issue_node_id: "I_1", project_item_id: "PI_1" },
+            "o/r#2": { issue_number: 2, issue_node_id: "I_2", project_item_id: "PI_2" },
+          },
+          snapshots: {
+            "o/r#1": { hash: "abc", synced_at: "2026-01-01T00:00:00Z" },
+            "o/r#2": { hash: "def", synced_at: "2026-01-01T00:00:00Z" },
+          },
+        }),
+      });
+
+      const output = await runDoctorJson(testDir);
+      const cycleCheck = output.checks.find((c) => c.name === "dependency-cycles");
+      expect(cycleCheck?.status).toBe("FAIL");
+      expect(cycleCheck?.details?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("--fix オプション", () => {
+    it("--fix なしでは sync-state.json を書き換えない", async () => {
+      testDir = await setupProjectDir({
+        tasksFile: makeTasksFile([]),
+        syncState: makeSyncState({
+          snapshots: {
+            "orphan-2": { hash: "xyz", synced_at: "2026-01-01T00:00:00Z" },
+          },
+        }),
+      });
+
+      const output = await runDoctorJson(testDir);
+      const integrityCheck = output.checks.find((c) => c.name === "sync-state-integrity");
+      expect(integrityCheck?.fixed).toBeUndefined();
+
+      // sync-state.json が書き戻されていないことを確認
+      const written = JSON.parse(
+        await readFile(join(testDir, GANTT_DIR, SYNC_STATE_FILE), "utf-8"),
+      );
+      expect(written.snapshots["orphan-2"]).toBeDefined();
+    });
+
+    it("orphan snapshot を自動修復して書き戻す", async () => {
+      testDir = await setupProjectDir({
+        tasksFile: makeTasksFile([]),
+        syncState: makeSyncState({
+          snapshots: {
+            "orphan-1": { hash: "abc", synced_at: "2026-01-01T00:00:00Z" },
+          },
+        }),
+      });
+
+      const output = await runDoctorJson(testDir, ["--fix"]);
+      const integrityCheck = output.checks.find((c) => c.name === "sync-state-integrity");
+      expect(integrityCheck?.fixed).toBe(true);
+
+      // sync-state.json が書き戻されていることを確認
+      const written = JSON.parse(
+        await readFile(join(testDir, GANTT_DIR, SYNC_STATE_FILE), "utf-8"),
+      );
+      expect(written.snapshots["orphan-1"]).toBeUndefined();
+    });
+  });
+
+  describe("終了コード", () => {
+    it("問題がなければ summary.fail が 0", async () => {
+      testDir = await setupProjectDir({});
+      const output = await runDoctorJson(testDir);
+      expect(output.summary.fail).toBe(0);
+    });
+
+    it("FAIL チェックがあれば summary.fail > 0", async () => {
+      testDir = await setupProjectDir({ config: false });
+      const output = await runDoctorJson(testDir);
+      expect(output.summary.fail).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,19 +1,13 @@
 import { Command } from "commander";
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  ConfigSchema,
-  TasksFileSchema,
-  SyncStateSchema,
-  GANTT_DIR,
-  CONFIG_FILE,
-  TASKS_FILE,
-  SYNC_STATE_FILE,
-} from "@gh-gantt/shared";
 import type { Task, SyncState, TasksFile } from "@gh-gantt/shared";
+import { detectCycles } from "@gh-gantt/shared";
+import { ConfigStore } from "../store/config.js";
+import { TasksStore } from "../store/tasks.js";
+import { SyncStateStore } from "../store/state.js";
 import { hashTask } from "../sync/hash.js";
+import { validateSyncState, type SyncStateFinding } from "../sync/validate-sync-state.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -26,6 +20,8 @@ interface CheckResult {
   status: CheckStatus;
   message: string;
   details?: string[];
+  /** --fix で自動修復された場合 true */
+  fixed?: boolean;
 }
 
 /** doctor コマンドの全体結果 */
@@ -38,44 +34,153 @@ interface DoctorResult {
 
 /** gantt.config.json の schema 妥当性をチェック */
 async function checkConfig(projectRoot: string): Promise<CheckResult> {
-  const path = join(projectRoot, GANTT_DIR, CONFIG_FILE);
   try {
-    const raw = await readFile(path, "utf-8");
-    const parsed = JSON.parse(raw);
-    ConfigSchema.parse(parsed);
+    await new ConfigStore(projectRoot).read();
     return { name: "config-schema", status: "PASS", message: "gantt.config.json は有効です" };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return {
         name: "config-schema",
         status: "FAIL",
-        message: `${CONFIG_FILE} が見つかりません。'gh-gantt init' を実行してください`,
+        message: "gantt.config.json が見つかりません。'gh-gantt init' を実行してください",
       };
     }
     return {
       name: "config-schema",
       status: "FAIL",
-      message: `${CONFIG_FILE} のスキーマが不正です`,
+      message: "gantt.config.json のスキーマが不正です",
       details: [String(err instanceof Error ? err.message : err)],
     };
   }
 }
 
-/** sync-state.json と tasks.json のハッシュ整合性をチェック */
-async function checkHashIntegrity(
-  tasksFile: TasksFile,
+/** tasks.json の schema 妥当性をチェック */
+async function checkTasksFile(
+  projectRoot: string,
+): Promise<{ result: CheckResult; data: TasksFile | null }> {
+  try {
+    const data = await new TasksStore(projectRoot).read();
+    return {
+      result: { name: "tasks-file", status: "PASS", message: "tasks.json は有効です" },
+      data,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        result: {
+          name: "tasks-file",
+          status: "FAIL",
+          message: "tasks.json が見つかりません。'gh-gantt pull' を実行してください",
+        },
+        data: null,
+      };
+    }
+    return {
+      result: {
+        name: "tasks-file",
+        status: "FAIL",
+        message: "tasks.json の読み込みに失敗しました",
+        details: [String(err instanceof Error ? err.message : err)],
+      },
+      data: null,
+    };
+  }
+}
+
+/** sync-state.json の schema 妥当性をチェック */
+async function checkSyncStateFile(
+  projectRoot: string,
+): Promise<{ result: CheckResult; data: SyncState | null }> {
+  try {
+    const data = await new SyncStateStore(projectRoot).read();
+    return {
+      result: { name: "sync-state-file", status: "PASS", message: "sync-state.json は有効です" },
+      data,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        result: {
+          name: "sync-state-file",
+          status: "FAIL",
+          message: "sync-state.json が見つかりません。'gh-gantt pull' を実行してください",
+        },
+        data: null,
+      };
+    }
+    return {
+      result: {
+        name: "sync-state-file",
+        status: "FAIL",
+        message: "sync-state.json の読み込みに失敗しました",
+        details: [String(err instanceof Error ? err.message : err)],
+      },
+      data: null,
+    };
+  }
+}
+
+/** sync-state 整合性チェック（validateSyncState を利用） */
+function checkSyncStateIntegrity(
   syncState: SyncState,
-): Promise<CheckResult> {
+  tasksFile: TasksFile,
+  fix: boolean,
+): { result: CheckResult; fixedSyncState: SyncState | null; findings: SyncStateFinding[] } {
+  const { syncState: validated, findings } = validateSyncState(syncState, tasksFile);
+
+  if (findings.length === 0) {
+    return {
+      result: {
+        name: "sync-state-integrity",
+        status: "PASS",
+        message: "sync-state 整合性は正常です",
+      },
+      fixedSyncState: null,
+      findings,
+    };
+  }
+
+  const autoFixable = findings.filter((f) => f.autoFixed);
+  const warnings = findings.filter((f) => !f.autoFixed);
+  const details = findings.map((f) => `[${f.category}] ${f.message}`);
+
+  // --fix で自動修復可能なものがある場合
+  if (fix && autoFixable.length > 0) {
+    return {
+      result: {
+        name: "sync-state-integrity",
+        status: warnings.length > 0 ? "WARN" : "PASS",
+        message:
+          `${autoFixable.length} 件を自動修復しました` +
+          (warnings.length > 0 ? `（${warnings.length} 件は手動対応が必要です）` : ""),
+        details,
+        fixed: true,
+      },
+      fixedSyncState: validated,
+      findings,
+    };
+  }
+
+  return {
+    result: {
+      name: "sync-state-integrity",
+      status: "WARN",
+      message: `${findings.length} 件の sync-state 不整合があります`,
+      details,
+    },
+    fixedSyncState: null,
+    findings,
+  };
+}
+
+/** hash 再計算照合: hashTask() で再計算し snapshot.hash と比較 */
+function checkHashIntegrity(tasksFile: TasksFile, syncState: SyncState): CheckResult {
   const mismatches: string[] = [];
 
   for (const task of tasksFile.tasks) {
     const snapshot = syncState.snapshots[task.id];
     if (!snapshot) continue;
 
-    const currentHash = hashTask(task);
-    // snapshot.hash はローカル側の最後に同期したハッシュ。
-    // ローカル変更がなければ currentHash === snapshot.hash になるはず。
-    // ここでは snapshot 自体の hash フィールドが空や不正でないかをチェック。
     if (!snapshot.hash || typeof snapshot.hash !== "string") {
       mismatches.push(`${task.id}: snapshot.hash が不正 (値: ${JSON.stringify(snapshot.hash)})`);
     }
@@ -92,75 +197,9 @@ async function checkHashIntegrity(
   };
 }
 
-/** id_map と tasks.json の対応関係をチェック */
-function checkIdMap(tasksFile: TasksFile, syncState: SyncState): CheckResult {
-  const taskIds = new Set(tasksFile.tasks.map((t) => t.id));
-  const idMapKeys = new Set(Object.keys(syncState.id_map));
-  const issues: string[] = [];
-
-  // id_map にあるが tasks に無い
-  for (const id of idMapKeys) {
-    if (!taskIds.has(id)) {
-      issues.push(`id_map に ${id} がありますが tasks.json に存在しません`);
-    }
-  }
-
-  // tasks にあるが id_map に無い (draft- と milestone- は除外)
-  for (const task of tasksFile.tasks) {
-    if (task.id.startsWith("draft-")) continue;
-    if (task.id.startsWith("milestone-")) continue;
-    if (!idMapKeys.has(task.id)) {
-      issues.push(`${task.id} が id_map に存在しません`);
-    }
-  }
-
-  if (issues.length === 0) {
-    return { name: "id-map", status: "PASS", message: "id_map と tasks.json は整合しています" };
-  }
-  return {
-    name: "id-map",
-    status: "WARN",
-    message: `${issues.length} 件の id_map 不整合があります`,
-    details: issues,
-  };
-}
-
-/** タスク間の依存関係の循環検出 */
+/** タスク間の依存関係の循環検出（shared の detectCycles を使用） */
 function checkCycles(tasks: Task[]): CheckResult {
-  // detectCycles のロジックをインラインで実装 (ui パッケージへの依存を避ける)
-  const graph = new Map<string, string[]>();
-  for (const task of tasks) {
-    if (!graph.has(task.id)) graph.set(task.id, []);
-    for (const dep of task.blocked_by) {
-      if (!graph.has(dep.task)) graph.set(dep.task, []);
-      graph.get(dep.task)!.push(task.id);
-    }
-  }
-
-  const cycles: string[][] = [];
-  const visited = new Set<string>();
-  const inStack = new Set<string>();
-  const path: string[] = [];
-
-  function dfs(node: string) {
-    visited.add(node);
-    inStack.add(node);
-    path.push(node);
-    for (const neighbor of graph.get(node) ?? []) {
-      if (inStack.has(neighbor)) {
-        const cycleStart = path.indexOf(neighbor);
-        cycles.push(path.slice(cycleStart));
-      } else if (!visited.has(neighbor)) {
-        dfs(neighbor);
-      }
-    }
-    path.pop();
-    inStack.delete(node);
-  }
-
-  for (const node of graph.keys()) {
-    if (!visited.has(node)) dfs(node);
-  }
+  const cycles = detectCycles(tasks);
 
   if (cycles.length === 0) {
     return { name: "dependency-cycles", status: "PASS", message: "循環依存はありません" };
@@ -192,65 +231,51 @@ async function checkGitHubAuth(): Promise<CheckResult> {
 
 // ── メインロジック ──
 
-async function runDoctor(projectRoot: string): Promise<DoctorResult> {
+interface DoctorOptions {
+  fix: boolean;
+  offline: boolean;
+}
+
+async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<DoctorResult> {
   const checks: CheckResult[] = [];
 
   // 1. config チェック
   checks.push(await checkConfig(projectRoot));
 
-  // sync データの読み込みを試みる
-  let tasksFile: TasksFile | null = null;
-  let syncState: SyncState | null = null;
+  // 2. tasks.json チェック
+  const { result: tasksResult, data: tasksFile } = await checkTasksFile(projectRoot);
+  checks.push(tasksResult);
 
-  try {
-    const tasksRaw = await readFile(join(projectRoot, GANTT_DIR, TASKS_FILE), "utf-8");
-    tasksFile = TasksFileSchema.parse(JSON.parse(tasksRaw));
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      checks.push({
-        name: "tasks-file",
-        status: "FAIL",
-        message: `${TASKS_FILE} が見つかりません。'gh-gantt pull' を実行してください`,
-      });
-    } else {
-      checks.push({
-        name: "tasks-file",
-        status: "FAIL",
-        message: `${TASKS_FILE} の読み込みに失敗しました`,
-        details: [String(err instanceof Error ? err.message : err)],
-      });
-    }
-  }
-
-  try {
-    const stateRaw = await readFile(join(projectRoot, GANTT_DIR, SYNC_STATE_FILE), "utf-8");
-    syncState = SyncStateSchema.parse(JSON.parse(stateRaw));
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      checks.push({
-        name: "sync-state-file",
-        status: "FAIL",
-        message: `${SYNC_STATE_FILE} が見つかりません。'gh-gantt pull' を実行してください`,
-      });
-    } else {
-      checks.push({
-        name: "sync-state-file",
-        status: "FAIL",
-        message: `${SYNC_STATE_FILE} の読み込みに失敗しました`,
-        details: [String(err instanceof Error ? err.message : err)],
-      });
-    }
-  }
+  // 3. sync-state.json チェック
+  const { result: stateResult, data: syncState } = await checkSyncStateFile(projectRoot);
+  checks.push(stateResult);
 
   // tasks と syncState が両方読めた場合のみ整合性チェックを実行
   if (tasksFile && syncState) {
-    checks.push(await checkHashIntegrity(tasksFile, syncState));
-    checks.push(checkIdMap(tasksFile, syncState));
+    // 4. sync-state 整合性
+    const { result: integrityResult, fixedSyncState } = checkSyncStateIntegrity(
+      syncState,
+      tasksFile,
+      opts.fix,
+    );
+    checks.push(integrityResult);
+
+    // --fix で修復した場合、書き戻し
+    if (fixedSyncState && opts.fix) {
+      await new SyncStateStore(projectRoot).write(fixedSyncState);
+    }
+
+    // 5. hash 整合性
+    checks.push(checkHashIntegrity(tasksFile, syncState));
+
+    // 6. 循環依存検出
     checks.push(checkCycles(tasksFile.tasks));
   }
 
-  // 5. GitHub 認証チェック
-  checks.push(await checkGitHubAuth());
+  // 7. 認証チェック (--offline で省略)
+  if (!opts.offline) {
+    checks.push(await checkGitHubAuth());
+  }
 
   const summary = {
     pass: checks.filter((c) => c.status === "PASS").length,
@@ -264,22 +289,20 @@ async function runDoctor(projectRoot: string): Promise<DoctorResult> {
 // ── コマンド定義 ──
 
 export const doctorCommand = new Command("doctor")
-  .description("ローカル状態の整合性チェックと診断")
+  .description("ローカル状態の整合性チェックと簡易修復")
+  .option("--fix", "自動修復可能な問題を修復する")
+  .option("--offline", "認証チェックをスキップする")
   .option("--json", "JSON 形式で出力")
-  .option("--fix", "自動修復可能な項目を修正")
   .action(async (opts) => {
     const projectRoot = process.cwd();
-
-    if (opts.fix) {
-      // --fix は将来の拡張用。現時点では自動修復対象がないことを明示する。
-      console.log("--fix: 現在自動修復可能な項目はありません。診断のみ実行します。");
-      console.log();
-    }
-
-    const result = await runDoctor(projectRoot);
+    const result = await runDoctor(projectRoot, {
+      fix: !!opts.fix,
+      offline: !!opts.offline,
+    });
 
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
+      process.exitCode = result.summary.fail > 0 ? 1 : 0;
       return;
     }
 
@@ -289,7 +312,10 @@ export const doctorCommand = new Command("doctor")
       s === "PASS" ? "[PASS]" : s === "WARN" ? "[WARN]" : "[FAIL]";
 
     for (const check of result.checks) {
-      console.log(`${statusIcon(check.status)} ${statusLabel(check.status)} ${check.message}`);
+      const fixedTag = check.fixed ? " (修復済み)" : "";
+      console.log(
+        `${statusIcon(check.status)} ${statusLabel(check.status)} ${check.message}${fixedTag}`,
+      );
       if (check.details) {
         for (const detail of check.details) {
           console.log(`    ${detail}`);

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,308 @@
+import { Command } from "commander";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  ConfigSchema,
+  TasksFileSchema,
+  SyncStateSchema,
+  GANTT_DIR,
+  CONFIG_FILE,
+  TASKS_FILE,
+  SYNC_STATE_FILE,
+} from "@gh-gantt/shared";
+import type { Task, SyncState, TasksFile } from "@gh-gantt/shared";
+import { hashTask } from "../sync/hash.js";
+
+const execFileAsync = promisify(execFile);
+
+/** チェック結果のステータス */
+type CheckStatus = "PASS" | "WARN" | "FAIL";
+
+/** 個別のチェック結果 */
+interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+  details?: string[];
+}
+
+/** doctor コマンドの全体結果 */
+interface DoctorResult {
+  checks: CheckResult[];
+  summary: { pass: number; warn: number; fail: number };
+}
+
+// ── チェック関数群 ──
+
+/** gantt.config.json の schema 妥当性をチェック */
+async function checkConfig(projectRoot: string): Promise<CheckResult> {
+  const path = join(projectRoot, GANTT_DIR, CONFIG_FILE);
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    ConfigSchema.parse(parsed);
+    return { name: "config-schema", status: "PASS", message: "gantt.config.json は有効です" };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        name: "config-schema",
+        status: "FAIL",
+        message: `${CONFIG_FILE} が見つかりません。'gh-gantt init' を実行してください`,
+      };
+    }
+    return {
+      name: "config-schema",
+      status: "FAIL",
+      message: `${CONFIG_FILE} のスキーマが不正です`,
+      details: [String(err instanceof Error ? err.message : err)],
+    };
+  }
+}
+
+/** sync-state.json と tasks.json のハッシュ整合性をチェック */
+async function checkHashIntegrity(
+  tasksFile: TasksFile,
+  syncState: SyncState,
+): Promise<CheckResult> {
+  const mismatches: string[] = [];
+
+  for (const task of tasksFile.tasks) {
+    const snapshot = syncState.snapshots[task.id];
+    if (!snapshot) continue;
+
+    const currentHash = hashTask(task);
+    // snapshot.hash はローカル側の最後に同期したハッシュ。
+    // ローカル変更がなければ currentHash === snapshot.hash になるはず。
+    // ここでは snapshot 自体の hash フィールドが空や不正でないかをチェック。
+    if (!snapshot.hash || typeof snapshot.hash !== "string") {
+      mismatches.push(`${task.id}: snapshot.hash が不正 (値: ${JSON.stringify(snapshot.hash)})`);
+    }
+  }
+
+  if (mismatches.length === 0) {
+    return { name: "hash-integrity", status: "PASS", message: "ハッシュ整合性は正常です" };
+  }
+  return {
+    name: "hash-integrity",
+    status: "WARN",
+    message: `${mismatches.length} 件のハッシュ不整合があります`,
+    details: mismatches,
+  };
+}
+
+/** id_map と tasks.json の対応関係をチェック */
+function checkIdMap(tasksFile: TasksFile, syncState: SyncState): CheckResult {
+  const taskIds = new Set(tasksFile.tasks.map((t) => t.id));
+  const idMapKeys = new Set(Object.keys(syncState.id_map));
+  const issues: string[] = [];
+
+  // id_map にあるが tasks に無い
+  for (const id of idMapKeys) {
+    if (!taskIds.has(id)) {
+      issues.push(`id_map に ${id} がありますが tasks.json に存在しません`);
+    }
+  }
+
+  // tasks にあるが id_map に無い (draft- と milestone- は除外)
+  for (const task of tasksFile.tasks) {
+    if (task.id.startsWith("draft-")) continue;
+    if (task.id.startsWith("milestone-")) continue;
+    if (!idMapKeys.has(task.id)) {
+      issues.push(`${task.id} が id_map に存在しません`);
+    }
+  }
+
+  if (issues.length === 0) {
+    return { name: "id-map", status: "PASS", message: "id_map と tasks.json は整合しています" };
+  }
+  return {
+    name: "id-map",
+    status: "WARN",
+    message: `${issues.length} 件の id_map 不整合があります`,
+    details: issues,
+  };
+}
+
+/** タスク間の依存関係の循環検出 */
+function checkCycles(tasks: Task[]): CheckResult {
+  // detectCycles のロジックをインラインで実装 (ui パッケージへの依存を避ける)
+  const graph = new Map<string, string[]>();
+  for (const task of tasks) {
+    if (!graph.has(task.id)) graph.set(task.id, []);
+    for (const dep of task.blocked_by) {
+      if (!graph.has(dep.task)) graph.set(dep.task, []);
+      graph.get(dep.task)!.push(task.id);
+    }
+  }
+
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+  const path: string[] = [];
+
+  function dfs(node: string) {
+    visited.add(node);
+    inStack.add(node);
+    path.push(node);
+    for (const neighbor of graph.get(node) ?? []) {
+      if (inStack.has(neighbor)) {
+        const cycleStart = path.indexOf(neighbor);
+        cycles.push(path.slice(cycleStart));
+      } else if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      }
+    }
+    path.pop();
+    inStack.delete(node);
+  }
+
+  for (const node of graph.keys()) {
+    if (!visited.has(node)) dfs(node);
+  }
+
+  if (cycles.length === 0) {
+    return { name: "dependency-cycles", status: "PASS", message: "循環依存はありません" };
+  }
+  return {
+    name: "dependency-cycles",
+    status: "FAIL",
+    message: `${cycles.length} 件の循環依存を検出しました`,
+    details: cycles.map((c) => c.join(" → ") + " → " + c[0]),
+  };
+}
+
+/** GitHub 認証の有効性をチェック */
+async function checkGitHubAuth(): Promise<CheckResult> {
+  try {
+    await execFileAsync("gh", ["auth", "status"], { timeout: 10000 });
+    return { name: "github-auth", status: "PASS", message: "GitHub 認証は有効です" };
+  } catch (err) {
+    const message =
+      err instanceof Error && "stderr" in err ? (err as { stderr: string }).stderr : String(err);
+    return {
+      name: "github-auth",
+      status: "FAIL",
+      message: "GitHub 認証が無効です。'gh auth login' を実行してください",
+      details: [message.trim()],
+    };
+  }
+}
+
+// ── メインロジック ──
+
+async function runDoctor(projectRoot: string): Promise<DoctorResult> {
+  const checks: CheckResult[] = [];
+
+  // 1. config チェック
+  checks.push(await checkConfig(projectRoot));
+
+  // sync データの読み込みを試みる
+  let tasksFile: TasksFile | null = null;
+  let syncState: SyncState | null = null;
+
+  try {
+    const tasksRaw = await readFile(join(projectRoot, GANTT_DIR, TASKS_FILE), "utf-8");
+    tasksFile = TasksFileSchema.parse(JSON.parse(tasksRaw));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      checks.push({
+        name: "tasks-file",
+        status: "FAIL",
+        message: `${TASKS_FILE} が見つかりません。'gh-gantt pull' を実行してください`,
+      });
+    } else {
+      checks.push({
+        name: "tasks-file",
+        status: "FAIL",
+        message: `${TASKS_FILE} の読み込みに失敗しました`,
+        details: [String(err instanceof Error ? err.message : err)],
+      });
+    }
+  }
+
+  try {
+    const stateRaw = await readFile(join(projectRoot, GANTT_DIR, SYNC_STATE_FILE), "utf-8");
+    syncState = SyncStateSchema.parse(JSON.parse(stateRaw));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      checks.push({
+        name: "sync-state-file",
+        status: "FAIL",
+        message: `${SYNC_STATE_FILE} が見つかりません。'gh-gantt pull' を実行してください`,
+      });
+    } else {
+      checks.push({
+        name: "sync-state-file",
+        status: "FAIL",
+        message: `${SYNC_STATE_FILE} の読み込みに失敗しました`,
+        details: [String(err instanceof Error ? err.message : err)],
+      });
+    }
+  }
+
+  // tasks と syncState が両方読めた場合のみ整合性チェックを実行
+  if (tasksFile && syncState) {
+    checks.push(await checkHashIntegrity(tasksFile, syncState));
+    checks.push(checkIdMap(tasksFile, syncState));
+    checks.push(checkCycles(tasksFile.tasks));
+  }
+
+  // 5. GitHub 認証チェック
+  checks.push(await checkGitHubAuth());
+
+  const summary = {
+    pass: checks.filter((c) => c.status === "PASS").length,
+    warn: checks.filter((c) => c.status === "WARN").length,
+    fail: checks.filter((c) => c.status === "FAIL").length,
+  };
+
+  return { checks, summary };
+}
+
+// ── コマンド定義 ──
+
+export const doctorCommand = new Command("doctor")
+  .description("ローカル状態の整合性チェックと診断")
+  .option("--json", "JSON 形式で出力")
+  .option("--fix", "自動修復可能な項目を修正")
+  .action(async (opts) => {
+    const projectRoot = process.cwd();
+
+    if (opts.fix) {
+      // --fix は将来の拡張用。現時点では自動修復対象がないことを明示する。
+      console.log("--fix: 現在自動修復可能な項目はありません。診断のみ実行します。");
+      console.log();
+    }
+
+    const result = await runDoctor(projectRoot);
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    // テキスト出力
+    const statusIcon = (s: CheckStatus) => (s === "PASS" ? "✓" : s === "WARN" ? "⚠" : "✗");
+    const statusLabel = (s: CheckStatus) =>
+      s === "PASS" ? "[PASS]" : s === "WARN" ? "[WARN]" : "[FAIL]";
+
+    for (const check of result.checks) {
+      console.log(`${statusIcon(check.status)} ${statusLabel(check.status)} ${check.message}`);
+      if (check.details) {
+        for (const detail of check.details) {
+          console.log(`    ${detail}`);
+        }
+      }
+    }
+
+    console.log();
+    console.log(
+      `結果: ${result.summary.pass} passed, ${result.summary.warn} warnings, ${result.summary.fail} failures`,
+    );
+
+    if (result.summary.fail > 0) {
+      process.exitCode = 1;
+    }
+  });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -183,6 +183,15 @@ function checkHashIntegrity(tasksFile: TasksFile, syncState: SyncState): CheckRe
 
     if (!snapshot.hash || typeof snapshot.hash !== "string") {
       mismatches.push(`${task.id}: snapshot.hash が不正 (値: ${JSON.stringify(snapshot.hash)})`);
+      continue;
+    }
+
+    // hashTask() で再計算し、snapshot.hash と比較
+    const recalculated = hashTask(task);
+    if (recalculated !== snapshot.hash) {
+      mismatches.push(
+        `${task.id}: ハッシュ不一致 (snapshot: ${snapshot.hash.slice(0, 8)}... / 再計算: ${recalculated.slice(0, 8)}...)`,
+      );
     }
   }
 
@@ -218,6 +227,26 @@ async function checkGitHubAuth(): Promise<CheckResult> {
     await execFileAsync("gh", ["auth", "status"], { timeout: 10000 });
     return { name: "github-auth", status: "PASS", message: "GitHub 認証は有効です" };
   } catch (err) {
+    // gh CLI が未インストールの場合
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        name: "github-auth",
+        status: "WARN",
+        message: "gh CLI が見つかりません。インストールしてください",
+      };
+    }
+    // タイムアウト
+    if (
+      (err as NodeJS.ErrnoException).code === "ETIMEDOUT" ||
+      (err as { killed?: boolean }).killed
+    ) {
+      return {
+        name: "github-auth",
+        status: "WARN",
+        message: "gh auth status がタイムアウトしました。ネットワーク接続を確認してください",
+      };
+    }
+    // 認証エラー
     const message =
       err instanceof Error && "stderr" in err ? (err as { stderr: string }).stderr : String(err);
     return {
@@ -265,8 +294,8 @@ async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<Doct
       await new SyncStateStore(projectRoot).write(fixedSyncState);
     }
 
-    // 5. hash 整合性
-    checks.push(checkHashIntegrity(tasksFile, syncState));
+    // 5. hash 整合性 (修復後の syncState があればそちらを使用)
+    checks.push(checkHashIntegrity(tasksFile, fixedSyncState ?? syncState));
 
     // 6. 循環依存検出
     checks.push(checkCycles(tasksFile.tasks));

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -11,6 +11,7 @@ import { createTaskUpdateCommand } from "./commands/task/update.js";
 import { createTaskLinkCommand } from "./commands/task/link.js";
 import { conflictsCommand } from "./commands/conflicts.js";
 import { resolveCommand } from "./commands/resolve.js";
+import { doctorCommand } from "./commands/doctor.js";
 
 export function buildProgram(): Command {
   const program = new Command();
@@ -25,6 +26,7 @@ export function buildProgram(): Command {
   program.addCommand(createCommand);
   program.addCommand(conflictsCommand);
   program.addCommand(resolveCommand);
+  program.addCommand(doctorCommand);
 
   // Flattened task commands (formerly under `task` subcommand)
   program.addCommand(createTaskListCommand());

--- a/packages/shared/src/dependency-graph.ts
+++ b/packages/shared/src/dependency-graph.ts
@@ -1,0 +1,67 @@
+import type { Task, Dependency } from "./types.js";
+
+export interface DependencyEdge {
+  from: string;
+  to: string;
+  type: Dependency["type"];
+  lag: number;
+}
+
+export function buildDependencyEdges(tasks: Task[]): DependencyEdge[] {
+  const edges: DependencyEdge[] = [];
+  for (const task of tasks) {
+    for (const dep of task.blocked_by) {
+      edges.push({
+        from: dep.task,
+        to: task.id,
+        type: dep.type,
+        lag: dep.lag,
+      });
+    }
+  }
+  return edges;
+}
+
+/**
+ * タスクの依存関係グラフから循環を検出する。
+ * 検出された各循環を構成するタスク ID の配列として返す。
+ */
+export function detectCycles(tasks: Task[]): string[][] {
+  const graph = new Map<string, string[]>();
+  for (const task of tasks) {
+    if (!graph.has(task.id)) graph.set(task.id, []);
+    for (const dep of task.blocked_by) {
+      if (!graph.has(dep.task)) graph.set(dep.task, []);
+      graph.get(dep.task)!.push(task.id);
+    }
+  }
+
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+  const path: string[] = [];
+
+  function dfs(node: string) {
+    visited.add(node);
+    inStack.add(node);
+    path.push(node);
+
+    for (const neighbor of graph.get(node) ?? []) {
+      if (inStack.has(neighbor)) {
+        const cycleStart = path.indexOf(neighbor);
+        cycles.push(path.slice(cycleStart));
+      } else if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      }
+    }
+
+    path.pop();
+    inStack.delete(node);
+  }
+
+  for (const node of graph.keys()) {
+    if (!visited.has(node)) dfs(node);
+  }
+
+  return cycles;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from "./schema.js";
 export * from "./constants.js";
 export * from "./comments.js";
 export * from "./status-dates.js";
+export * from "./dependency-graph.js";

--- a/packages/ui/src/lib/dependency-graph.ts
+++ b/packages/ui/src/lib/dependency-graph.ts
@@ -1,66 +1,8 @@
-import type { Task, Dependency } from "../types/index.js";
-
-export interface DependencyEdge {
-  from: string;
-  to: string;
-  type: Dependency["type"];
-  lag: number;
-}
-
-export function buildDependencyEdges(tasks: Task[]): DependencyEdge[] {
-  const edges: DependencyEdge[] = [];
-  for (const task of tasks) {
-    for (const dep of task.blocked_by) {
-      edges.push({
-        from: dep.task,
-        to: task.id,
-        type: dep.type,
-        lag: dep.lag,
-      });
-    }
-  }
-  return edges;
-}
-
-export function detectCycles(tasks: Task[]): string[][] {
-  const graph = new Map<string, string[]>();
-  for (const task of tasks) {
-    if (!graph.has(task.id)) graph.set(task.id, []);
-    for (const dep of task.blocked_by) {
-      if (!graph.has(dep.task)) graph.set(dep.task, []);
-      graph.get(dep.task)!.push(task.id);
-    }
-  }
-
-  const cycles: string[][] = [];
-  const visited = new Set<string>();
-  const inStack = new Set<string>();
-  const path: string[] = [];
-
-  function dfs(node: string) {
-    visited.add(node);
-    inStack.add(node);
-    path.push(node);
-
-    for (const neighbor of graph.get(node) ?? []) {
-      if (inStack.has(neighbor)) {
-        const cycleStart = path.indexOf(neighbor);
-        cycles.push(path.slice(cycleStart));
-      } else if (!visited.has(neighbor)) {
-        dfs(neighbor);
-      }
-    }
-
-    path.pop();
-    inStack.delete(node);
-  }
-
-  for (const node of graph.keys()) {
-    if (!visited.has(node)) dfs(node);
-  }
-
-  return cycles;
-}
+// shared パッケージから re-export（detectCycles, buildDependencyEdges）
+// UI 固有の getEdgeCoordinates のみこのファイルで定義
+export { detectCycles, buildDependencyEdges } from "@gh-gantt/shared";
+export type { DependencyEdge } from "@gh-gantt/shared";
+import type { DependencyEdge } from "@gh-gantt/shared";
 
 export function getEdgeCoordinates(
   edge: DependencyEdge,


### PR DESCRIPTION
## Summary

- `gh-gantt doctor` コマンドを新設し、ローカル状態の整合性チェックと簡易修復を提供
- `detectCycles` を `@gh-gantt/shared` に移動し CLI と UI の両方から利用可能にする

## チェック項目

| チェック | 内容 |
|---|---|
| config-schema | `gantt.config.json` の Zod スキーマ妥当性 |
| hash-integrity | `sync-state.json` の snapshot hash と tasks.json の再計算 hash の整合性 |
| id-map | `id_map` と `tasks.json` の対応関係 (draft/milestone は除外) |
| dependency-cycles | タスク間の `blocked_by` 循環検出 |
| github-auth | `gh auth status` による認証有効性確認 |

## オプション

- `--fix`: 自動修復可能な問題を修復 (orphan snapshot 等)
- `--offline`: 認証チェックをスキップ
- `--json`: JSON 出力

## 変更点

- `packages/shared/src/dependency-graph.ts`: `detectCycles`, `buildDependencyEdges` を shared に移動
- `packages/ui/src/lib/dependency-graph.ts`: shared から re-export
- `packages/cli/src/commands/doctor.ts`: doctor コマンド本体 (新規)
- `packages/cli/src/program.ts`: コマンド登録
- `packages/cli/src/__tests__/doctor.test.ts`: テスト (16 ケース)

## Test plan

- [x] `pnpm test` 全パス (shared: 32, cli: 363, ui: 131)
- [x] `pnpm build` 成功
- [x] `pnpm lint` 0 errors

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **`doctor` コマンドを追加しました**
  * プロジェクトのローカル整合性チェック機能が利用できるようになります。設定ファイル、タスクファイル、同期状態の整合性を検証し、依存関係の循環検出やハッシュ整合性の確認が可能です。`--fix` オプションで自動修復、`--offline` で認証チェックをスキップ、`--json` で JSON 出力に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->