### PR TITLE
fix(cli): Organization Issue Type の同期を修正

### DIFF
--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -354,6 +354,98 @@ describe("executePush", () => {
       expect(updateIssueTypeVars.issueTypeId).toBe("IT_FEATURE");
     });
 
+    it("Organization Issue Type が見つからない type 変更は snapshot を進めず次回 push で再試行できる", async () => {
+      const before = makeTask("o/r#1", {
+        github_issue: 1,
+        type: "task",
+        title: "Before",
+      });
+      const after = makeTask("o/r#1", {
+        github_issue: 1,
+        type: "feature",
+        title: "Before",
+      });
+      const oldSyncFields = extractSyncFields(before);
+      const tasksFile: TasksFile = {
+        tasks: [after],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: {},
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(before),
+            synced_at: "",
+            syncFields: oldSyncFields,
+          },
+        },
+      };
+      const config = makeConfig({
+        task_types: {
+          task: { label: "Task", display: "bar", color: "#000", github_label: null },
+          feature: {
+            label: "Feature",
+            display: "bar",
+            color: "#00f",
+            github_label: null,
+            github_issue_type: "Feature",
+          },
+        },
+      });
+
+      let updateIssueTypeVars: any;
+      const fallbackGql = makeMockGql();
+      const mockGql = vi.fn().mockImplementation(async (query: string, vars?: any) => {
+        if (query.includes("issueTypes")) {
+          return {
+            organization: {
+              issueTypes: {
+                nodes: [
+                  {
+                    id: "IT_BUG",
+                    name: "Bug",
+                    description: null,
+                    isEnabled: true,
+                  },
+                ],
+              },
+            },
+          };
+        }
+        if (query.includes("updateIssueIssueType")) {
+          updateIssueTypeVars = vars;
+          return { updateIssueIssueType: { issue: { id: "ISSUE_1" } } };
+        }
+        return fallbackGql(query, vars);
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const { syncState: newSyncState } = await executePush(
+          mockGql as any,
+          config,
+          tasksFile,
+          syncState,
+        );
+
+        const snap = newSyncState.snapshots["o/r#1"];
+        expect(updateIssueTypeVars).toBeUndefined();
+        expect(snap).toBeDefined();
+        expect(snap!.syncFields?.type).toBe(oldSyncFields.type);
+        expect(snap!.hash).not.toBe(hashTask(after));
+
+        const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+        expect(retryDiffs.some((d) => d.id === "o/r#1")).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it("snapshot updated_at is refreshed after push (Fix 1-1)", async () => {
       const task = makeTask("o/r#1", { github_issue: 1, title: "Modified" });
       const tasksFile: TasksFile = {

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -205,6 +205,155 @@ describe("executePush", () => {
       expect(closeIssueCalls.length).toBe(1);
     });
 
+    it("Organization Issue Type が設定された draft task は createIssue に issueTypeId を渡す", async () => {
+      const draft = makeTask("o/r#draft-1", {
+        type: "feature",
+        title: "Feature task",
+      });
+      const tasksFile: TasksFile = {
+        tasks: [draft],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {},
+        field_ids: {},
+        snapshots: {},
+      };
+      const config = makeConfig({
+        task_types: {
+          task: { label: "Task", display: "bar", color: "#000", github_label: null },
+          feature: {
+            label: "Feature",
+            display: "bar",
+            color: "#00f",
+            github_label: null,
+            github_issue_type: "Feature",
+          },
+        },
+      });
+
+      let createIssueVars: any;
+      const mockGql = vi.fn().mockImplementation(async (query: string, vars?: any) => {
+        if (query.includes("issueTypes")) {
+          return {
+            organization: {
+              issueTypes: {
+                nodes: [
+                  {
+                    id: "IT_FEATURE",
+                    name: "Feature",
+                    description: null,
+                    isEnabled: true,
+                  },
+                ],
+              },
+            },
+          };
+        }
+        if (query.includes("createIssue")) {
+          createIssueVars = vars;
+          return { createIssue: { issue: { id: "ISSUE_99", number: 99 } } };
+        }
+        if (query.includes("addProjectV2ItemById")) {
+          return { addProjectV2ItemById: { item: { id: "ITEM_99" } } };
+        }
+        if (query.includes("labels") || query.includes("milestones")) {
+          return {
+            repository: { labels: { nodes: [] }, milestones: { nodes: [] } },
+          };
+        }
+        if (query.includes("repository(")) {
+          return { repository: { id: "REPO_1" } };
+        }
+        if (query.includes("issue(number:")) {
+          return makeBatchIssueResponse(extractBatchIssueNumbers(query));
+        }
+        return {};
+      });
+
+      const { result } = await executePush(mockGql as any, config, tasksFile, syncState);
+
+      expect(result.created).toBe(1);
+      expect(createIssueVars.issueTypeId).toBe("IT_FEATURE");
+    });
+
+    it("既存 task の type 変更は Organization Issue Type を updateIssueIssueType で更新する", async () => {
+      const before = makeTask("o/r#1", {
+        github_issue: 1,
+        type: "task",
+        title: "Before",
+      });
+      const after = makeTask("o/r#1", {
+        github_issue: 1,
+        type: "feature",
+        title: "Before",
+      });
+      const tasksFile: TasksFile = {
+        tasks: [after],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: {},
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(before),
+            synced_at: "",
+            syncFields: extractSyncFields(before),
+          },
+        },
+      };
+      const config = makeConfig({
+        task_types: {
+          task: { label: "Task", display: "bar", color: "#000", github_label: null },
+          feature: {
+            label: "Feature",
+            display: "bar",
+            color: "#00f",
+            github_label: null,
+            github_issue_type: "Feature",
+          },
+        },
+      });
+
+      let updateIssueTypeVars: any;
+      const fallbackGql = makeMockGql();
+      const mockGql = vi.fn().mockImplementation(async (query: string, vars?: any) => {
+        if (query.includes("issueTypes")) {
+          return {
+            organization: {
+              issueTypes: {
+                nodes: [
+                  {
+                    id: "IT_FEATURE",
+                    name: "Feature",
+                    description: null,
+                    isEnabled: true,
+                  },
+                ],
+              },
+            },
+          };
+        }
+        if (query.includes("updateIssueIssueType")) {
+          updateIssueTypeVars = vars;
+          return { updateIssueIssueType: { issue: { id: "ISSUE_1" } } };
+        }
+        return fallbackGql(query, vars);
+      });
+
+      const { result } = await executePush(mockGql as any, config, tasksFile, syncState);
+
+      expect(result.updated).toBe(1);
+      expect(updateIssueTypeVars.issueTypeId).toBe("IT_FEATURE");
+    });
+
     it("snapshot updated_at is refreshed after push (Fix 1-1)", async () => {
       const task = makeTask("o/r#1", { github_issue: 1, title: "Modified" });
       const tasksFile: TasksFile = {

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -173,4 +173,101 @@ describe("createApiRouter", () => {
       globalThis.Map = OriginalMap;
     }
   });
+
+  it("PATCH /api/tasks/:id で type 変更を保存し github_label を差し替える", async () => {
+    const configStore = new ConfigStore(dir);
+    const tasksStore = new TasksStore(dir);
+
+    await configStore.write({
+      version: "1",
+      project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+      sync: {
+        auto_create_issues: false,
+        field_mapping: { start_date: "S", end_date: "E", status: "Status" },
+      },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#333333", github_label: "task" },
+        feature: {
+          label: "Feature",
+          display: "bar",
+          color: "#222222",
+          github_label: "feature",
+        },
+      },
+      type_hierarchy: {},
+      statuses: { field_name: "Status", values: {} },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+      },
+    });
+    await tasksStore.write({
+      tasks: [
+        {
+          id: "o/r#1",
+          type: "task",
+          github_issue: 1,
+          github_repo: "o/r",
+          parent: null,
+          sub_tasks: [],
+          title: "Task",
+          body: null,
+          state: "open" as const,
+          state_reason: null,
+          assignees: [],
+          labels: ["task", "keep"],
+          milestone: null,
+          linked_prs: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          closed_at: null,
+          custom_fields: {},
+          start_date: null,
+          end_date: null,
+          date: null,
+          blocked_by: [],
+        },
+      ],
+      cache: { comments: {}, reactions: {} },
+    });
+
+    const router = createApiRouter(dir);
+    const routeLayer = router.stack.find(
+      (layer: any) => layer.route?.path === "/api/tasks/:id" && layer.route?.methods?.patch,
+    );
+    const handler = routeLayer?.route?.stack?.[0]?.handle as
+      | ((req: unknown, res: unknown) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("PATCH /api/tasks/:id handler not found");
+
+    let statusCode = 200;
+    let jsonPayload: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    await handler(
+      {
+        params: { id: encodeURIComponent("o/r#1") },
+        body: { type: "feature" },
+      },
+      res,
+    );
+
+    const written = await tasksStore.read();
+
+    expect(statusCode).toBe(200);
+    expect(jsonPayload.type).toBe("feature");
+    expect(jsonPayload.labels).toEqual(["keep", "feature"]);
+    expect(written.tasks[0].type).toBe("feature");
+    expect(written.tasks[0].labels).toEqual(["keep", "feature"]);
+  });
 });

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -270,4 +270,100 @@ describe("createApiRouter", () => {
     expect(written.tasks[0].type).toBe("feature");
     expect(written.tasks[0].labels).toEqual(["keep", "feature"]);
   });
+
+  it("PATCH /api/tasks/:id は labels が文字列配列でない場合 400 を返す", async () => {
+    const configStore = new ConfigStore(dir);
+    const tasksStore = new TasksStore(dir);
+
+    await configStore.write({
+      version: "1",
+      project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+      sync: {
+        auto_create_issues: false,
+        field_mapping: { start_date: "S", end_date: "E", status: "Status" },
+      },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#333333", github_label: "task" },
+        feature: {
+          label: "Feature",
+          display: "bar",
+          color: "#222222",
+          github_label: "feature",
+        },
+      },
+      type_hierarchy: {},
+      statuses: { field_name: "Status", values: {} },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+      },
+    });
+    await tasksStore.write({
+      tasks: [
+        {
+          id: "o/r#1",
+          type: "task",
+          github_issue: 1,
+          github_repo: "o/r",
+          parent: null,
+          sub_tasks: [],
+          title: "Task",
+          body: null,
+          state: "open" as const,
+          state_reason: null,
+          assignees: [],
+          labels: ["task", "keep"],
+          milestone: null,
+          linked_prs: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          closed_at: null,
+          custom_fields: {},
+          start_date: null,
+          end_date: null,
+          date: null,
+          blocked_by: [],
+        },
+      ],
+      cache: { comments: {}, reactions: {} },
+    });
+
+    const router = createApiRouter(dir);
+    const routeLayer = router.stack.find(
+      (layer: any) => layer.route?.path === "/api/tasks/:id" && layer.route?.methods?.patch,
+    );
+    const handler = routeLayer?.route?.stack?.[0]?.handle as
+      | ((req: unknown, res: unknown) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("PATCH /api/tasks/:id handler not found");
+
+    let statusCode = 200;
+    let jsonPayload: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    await handler(
+      {
+        params: { id: encodeURIComponent("o/r#1") },
+        body: { type: "feature", labels: null },
+      },
+      res,
+    );
+
+    const written = await tasksStore.read();
+
+    expect(statusCode).toBe(400);
+    expect(jsonPayload.error).toBe("labels must be an array of strings");
+    expect(written.tasks[0].type).toBe("task");
+    expect(written.tasks[0].labels).toEqual(["task", "keep"]);
+  });
 });

--- a/packages/cli/src/github/mutations.ts
+++ b/packages/cli/src/github/mutations.ts
@@ -1,8 +1,8 @@
 import type { graphql } from "@octokit/graphql";
 
 const CREATE_ISSUE_MUTATION = `
-  mutation($repositoryId: ID!, $title: String!, $body: String, $labelIds: [ID!], $milestoneId: ID, $assigneeIds: [ID!]) {
-    createIssue(input: { repositoryId: $repositoryId, title: $title, body: $body, labelIds: $labelIds, milestoneId: $milestoneId, assigneeIds: $assigneeIds }) {
+  mutation($repositoryId: ID!, $title: String!, $body: String, $labelIds: [ID!], $milestoneId: ID, $assigneeIds: [ID!], $issueTypeId: ID) {
+    createIssue(input: { repositoryId: $repositoryId, title: $title, body: $body, labelIds: $labelIds, milestoneId: $milestoneId, assigneeIds: $assigneeIds, issueTypeId: $issueTypeId }) {
       issue {
         id
         number
@@ -24,6 +24,14 @@ const ADD_PROJECT_V2_ITEM_MUTATION = `
 const UPDATE_ISSUE_MUTATION = `
   mutation($issueId: ID!, $title: String, $body: String) {
     updateIssue(input: { id: $issueId, title: $title, body: $body }) {
+      issue { id }
+    }
+  }
+`;
+
+const UPDATE_ISSUE_ISSUE_TYPE_MUTATION = `
+  mutation($issueId: ID!, $issueTypeId: ID) {
+    updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $issueTypeId }) {
       issue { id }
     }
   }
@@ -66,6 +74,17 @@ export async function updateIssue(
   });
 }
 
+export async function updateIssueIssueType(
+  gql: typeof graphql,
+  issueNodeId: string,
+  issueTypeId: string | null,
+): Promise<void> {
+  await gql(UPDATE_ISSUE_ISSUE_TYPE_MUTATION, {
+    issueId: issueNodeId,
+    issueTypeId,
+  });
+}
+
 export async function setIssueState(
   gql: typeof graphql,
   issueNodeId: string,
@@ -84,6 +103,7 @@ export interface CreateIssueOptions {
   labelIds?: string[];
   milestoneId?: string;
   assigneeIds?: string[];
+  issueTypeId?: string;
 }
 
 export async function createIssue(
@@ -98,6 +118,7 @@ export async function createIssue(
     labelIds: options.labelIds?.length ? options.labelIds : undefined,
     milestoneId: options.milestoneId ?? undefined,
     assigneeIds: options.assigneeIds?.length ? options.assigneeIds : undefined,
+    issueTypeId: options.issueTypeId ?? undefined,
   });
   return {
     issueId: result.createIssue.issue.id,

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -144,6 +144,7 @@ export function createApiRouter(projectRoot: string): Router {
     try {
       const taskId = decodeURIComponent(req.params.id);
       const updates = req.body;
+      const config = await configStore.read();
       const tasksFile = await tasksStore.read();
       const idx = tasksFile.tasks.findIndex((t) => t.id === taskId);
 
@@ -155,6 +156,7 @@ export function createApiRouter(projectRoot: string): Router {
       const UPDATABLE_FIELDS = [
         "title",
         "body",
+        "type",
         "state",
         "state_reason",
         "assignees",
@@ -170,6 +172,13 @@ export function createApiRouter(projectRoot: string): Router {
       ] as const;
 
       const oldTask = tasksFile.tasks[idx];
+      if ("type" in updates) {
+        if (typeof updates.type !== "string" || !config.task_types[updates.type]) {
+          res.status(400).json({ error: `Unknown task type: "${updates.type}"` });
+          return;
+        }
+      }
+
       const safeUpdates: Partial<Task> = {};
       for (const key of UPDATABLE_FIELDS) {
         if (key in updates) {
@@ -178,8 +187,20 @@ export function createApiRouter(projectRoot: string): Router {
       }
       const updatedTask = { ...oldTask, ...safeUpdates };
 
+      if (safeUpdates.type && safeUpdates.type !== oldTask.type) {
+        const oldTypeDef = config.task_types[oldTask.type];
+        const newTypeDef = config.task_types[safeUpdates.type];
+        if (oldTypeDef?.github_label) {
+          updatedTask.labels = updatedTask.labels.filter(
+            (label) => label !== oldTypeDef.github_label,
+          );
+        }
+        if (newTypeDef?.github_label && !updatedTask.labels.includes(newTypeDef.github_label)) {
+          updatedTask.labels = [...updatedTask.labels, newTypeDef.github_label];
+        }
+      }
+
       // Auto-update dates on status transition
-      const config = await configStore.read();
       const statusField = config.statuses.field_name;
       const oldStatus = oldTask.custom_fields[statusField] as string | undefined;
       const newStatus = updatedTask.custom_fields[statusField] as string | undefined;

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -4,18 +4,13 @@ import { TasksStore } from "../store/tasks.js";
 import { SyncStateStore } from "../store/state.js";
 import { CommentsStore } from "../store/comments.js";
 import { setParent, removeParent } from "../commands/task/link.js";
-import { hashTask, extractSyncFields } from "../sync/hash.js";
+import { hashTask } from "../sync/hash.js";
 import { computeLocalDiff, formatDiffPreview } from "../sync/diff.js";
 import { executePush } from "../sync/push-executor.js";
 import { executePull } from "../sync/pull-executor.js";
 import { createGraphQLClient } from "../github/client.js";
-import {
-  isDraftTask,
-  isMilestoneSyntheticTask,
-  buildDraftTaskId,
-  getNextDraftNumber,
-} from "../github/issues.js";
-import type { Task, StatusValue, SyncState } from "@gh-gantt/shared";
+import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
+import type { Task, StatusValue } from "@gh-gantt/shared";
 import { computeStatusDateUpdates } from "@gh-gantt/shared";
 
 export function createApiRouter(projectRoot: string): Router {
@@ -32,7 +27,7 @@ export function createApiRouter(projectRoot: string): Router {
     try {
       const config = await configStore.read();
       res.json(config);
-    } catch (err) {
+    } catch {
       res.status(500).json({ error: "Failed to read config" });
     }
   });
@@ -64,7 +59,7 @@ export function createApiRouter(projectRoot: string): Router {
         config.statuses.field_name,
       );
       res.json({ tasks: tasksWithProgress, cache: mergedCache });
-    } catch (err) {
+    } catch {
       res.status(500).json({ error: "Failed to read tasks" });
     }
   });
@@ -178,6 +173,15 @@ export function createApiRouter(projectRoot: string): Router {
           return;
         }
       }
+      if ("labels" in updates) {
+        if (
+          !Array.isArray(updates.labels) ||
+          updates.labels.some((label: unknown) => typeof label !== "string")
+        ) {
+          res.status(400).json({ error: "labels must be an array of strings" });
+          return;
+        }
+      }
 
       const safeUpdates: Partial<Task> = {};
       for (const key of UPDATABLE_FIELDS) {
@@ -231,7 +235,7 @@ export function createApiRouter(projectRoot: string): Router {
       await tasksStore.write(tasksFile);
 
       res.json(updatedTask);
-    } catch (err) {
+    } catch {
       res.status(500).json({ error: "Failed to update task" });
     }
   });
@@ -427,7 +431,7 @@ export function createApiRouter(projectRoot: string): Router {
         local_changes: localChanges.length,
         total_tasks: tasksFile.tasks.length,
       });
-    } catch (err) {
+    } catch {
       res.status(500).json({ error: "Failed to get sync status" });
     }
   });

--- a/packages/cli/src/server/openapi.ts
+++ b/packages/cli/src/server/openapi.ts
@@ -29,6 +29,7 @@ registry.register("TaskCreateRequest", TaskCreateRequestSchema);
 const TaskUpdateRequestSchema = z.object({
   title: z.string().optional(),
   body: z.string().nullable().optional(),
+  type: z.string().optional(),
   state: z.enum(["open", "closed"]).optional(),
   state_reason: z.string().nullable().optional(),
   assignees: z.array(z.string()).optional(),

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -1,5 +1,5 @@
 import type { graphql } from "@octokit/graphql";
-import type { Config, Task, SyncState, TasksFile, TaskType } from "@gh-gantt/shared";
+import type { Config, SyncFields, Task, SyncState, TasksFile, TaskType } from "@gh-gantt/shared";
 import { computeLocalDiff } from "./diff.js";
 import { hashTask, hashSyncFields, extractSyncFields } from "./hash.js";
 import {
@@ -169,7 +169,11 @@ export async function executePush(
     parentFailed: boolean;
     blockedByFailed: boolean;
   }
+  interface IssueTypeFailure {
+    previousSyncFields: SyncFields | undefined;
+  }
   const failedRelations = new Map<string, RelationFailure>();
+  const failedIssueTypes = new Map<string, IssueTypeFailure>();
   // Pre-relation baseline: remote state before relation mutations were attempted
   const preRelationBaseline = new Map<
     string,
@@ -522,6 +526,10 @@ export async function executePush(
           const issueTypeId = await resolveGithubIssueTypeId(task.type);
           if (issueTypeId !== undefined) {
             issueMutations.push(updateIssueIssueType(gql, idEntry.issue_node_id, issueTypeId));
+          } else if (issueTypeId === undefined) {
+            failedIssueTypes.set(task.id, {
+              previousSyncFields: snapshot?.syncFields,
+            });
           }
         }
 
@@ -720,23 +728,42 @@ export async function executePush(
       const existing = newSnapshots[id];
       let syncFields = extractSyncFields(task);
 
+      const issueTypeFailure = failedIssueTypes.get(id);
+      if (issueTypeFailure) {
+        if (issueTypeFailure.previousSyncFields) {
+          syncFields = { ...syncFields, type: issueTypeFailure.previousSyncFields.type };
+        } else {
+          if (existing) {
+            newSnapshots[id] = {
+              ...existing,
+              synced_at: new Date().toISOString(),
+              updated_at: freshUpdatedAt.get(id) ?? existing.updated_at,
+            };
+          } else {
+            delete newSnapshots[id];
+          }
+          continue;
+        }
+      }
+
       // If relationship mutations partially failed, roll back only the failed fields
       // to the pre-mutation baseline so computeLocalDiff detects the diff on next push
-      const failure = failedRelations.get(id);
-      if (failure) {
+      const relationFailure = failedRelations.get(id);
+      if (relationFailure) {
         const baseline = preRelationBaseline.get(id);
         if (baseline) {
-          if (failure.parentFailed) {
+          if (relationFailure.parentFailed) {
             syncFields = { ...syncFields, parent: baseline.parent };
           }
-          if (failure.blockedByFailed) {
+          if (relationFailure.blockedByFailed) {
             syncFields = { ...syncFields, blocked_by: baseline.blocked_by };
           }
         }
       }
 
       // Hash must match syncFields so diff detection works correctly
-      const snapshotHash = failure ? hashSyncFields(syncFields) : hashTask(task);
+      const hasRetryableFailure = Boolean(issueTypeFailure || relationFailure);
+      const snapshotHash = hasRetryableFailure ? hashSyncFields(syncFields) : hashTask(task);
 
       newSnapshots[id] = {
         hash: snapshotHash,

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -9,7 +9,12 @@ import {
   buildTaskId,
   buildMilestoneSyntheticId,
 } from "../github/issues.js";
-import { fetchRepositoryId, fetchRepositoryMetadata, fetchUserIds } from "../github/projects.js";
+import {
+  fetchRepositoryId,
+  fetchRepositoryMetadata,
+  fetchUserIds,
+  fetchOrgIssueTypes,
+} from "../github/projects.js";
 import { buildIssueUpdatedAtQuery } from "../github/queries.js";
 import { getToken } from "../github/auth.js";
 import {
@@ -18,6 +23,7 @@ import {
   addSubIssue,
   removeSubIssue,
   updateIssue,
+  updateIssueIssueType,
   setIssueState,
   updateProjectItemField,
   createGithubMilestone,
@@ -133,6 +139,27 @@ export async function executePush(
 
   const fm = config.sync.field_mapping;
   const { owner, repo } = config.project.github;
+  let issueTypeIdByName: Map<string, string> | undefined;
+  const usesGithubIssueTypes = Object.values(config.task_types).some((t) => t.github_issue_type);
+
+  const resolveGithubIssueTypeId = async (typeName: string): Promise<string | null | undefined> => {
+    const issueTypeName = config.task_types[typeName]?.github_issue_type ?? null;
+    if (!issueTypeName) return null;
+
+    if (!issueTypeIdByName) {
+      const orgIssueTypes = await fetchOrgIssueTypes(gql, owner);
+      issueTypeIdByName = new Map(orgIssueTypes.map((t) => [t.name, t.id]));
+    }
+
+    const issueTypeId = issueTypeIdByName.get(issueTypeName);
+    if (!issueTypeId) {
+      console.warn(
+        `  ⚠ Organization Issue Type "${issueTypeName}" が見つからないため type 同期をスキップ (${typeName})`,
+      );
+      return undefined;
+    }
+    return issueTypeId;
+  };
 
   // Track which tasks were actually pushed (by their current ID after push)
   const pushedTaskIds = new Set<string>();
@@ -240,6 +267,7 @@ export async function executePush(
       const assigneeIds = task.assignees
         .map((login) => userIdMap.get(login))
         .filter((id): id is string => id != null);
+      const issueTypeId = await resolveGithubIssueTypeId(task.type);
 
       // Create GitHub issue
       const { issueId, issueNumber } = await createIssue(gql, repositoryId, {
@@ -248,6 +276,7 @@ export async function executePush(
         labelIds,
         milestoneId,
         assigneeIds,
+        issueTypeId: issueTypeId ?? undefined,
       });
 
       // Add to project
@@ -480,13 +509,23 @@ export async function executePush(
 
     if (diff.type === "modified" || diff.type === "added") {
       if (idEntry.issue_node_id) {
-        await Promise.all([
+        const issueMutations: Promise<unknown>[] = [
           updateIssue(gql, idEntry.issue_node_id, {
             title: task.title,
             body: task.body ?? undefined,
           }),
           setIssueState(gql, idEntry.issue_node_id, task.state),
-        ]);
+        ];
+
+        const snapshot = syncState.snapshots[task.id];
+        if (usesGithubIssueTypes && snapshot?.syncFields?.type !== task.type) {
+          const issueTypeId = await resolveGithubIssueTypeId(task.type);
+          if (issueTypeId !== undefined) {
+            issueMutations.push(updateIssueIssueType(gql, idEntry.issue_node_id, issueTypeId));
+          }
+        }
+
+        await Promise.all(issueMutations);
       }
 
       if (idEntry.project_item_id) {


### PR DESCRIPTION
## 概要

- `github_issue_type` 設定を Organization Issue Type ID に解決し、Issue 作成時に native Issue Type を設定するようにしました。
- 既存 Issue の `type` 変更時にも native Issue Type を更新するようにしました。
- Gantt/API の `PATCH /api/tasks/:id` で `type` を更新対象として扱い、label fallback も旧 type から新 type へ差し替えるようにしました。

## 原因

pull 側では Organization Issue Type を読めていましたが、push 側は `github_issue_type` を Issue 作成・更新 mutation に渡していませんでした。また Gantt/API 側の PATCH は `type` を許可フィールドから落としていたため、UI 変更がローカル状態にも残りませんでした。

## 検証

- `pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/push-executor.test.ts src/__tests__/server-api.test.ts`
- `pnpm --filter @gh-gantt/cli test`
- `pnpm --filter @gh-gantt/cli build`
- `pnpm lint`
- pre-push hook: `pnpm test:json`, `pnpm build`, `pnpm req:trace`, `pnpm req:validate`, `pnpm docs:gen`

## 実環境確認

`gh-gantt-e2e/test-repo` と一時 Project `gh-gantt issue type verification 2026-04-29` で確認しました。

- current CLI で `init --owner gh-gantt-e2e --repo test-repo --project 1` を実行し、Organization Issue Type `Task`, `Bug`, `Feature` の検出を確認
- `create --type feature` から `push --yes` し、作成された Issue `gh-gantt-e2e/test-repo#1` の GraphQL `issueType.name` が `Feature` になることを確認
- API server 経由で `PATCH /api/tasks/gh-gantt-e2e%2Ftest-repo%231` に `{"type":"bug"}` を送り、`push --yes` 後に GraphQL `issueType.name` が `Bug` に変わることを確認
- 検証後、Issue `#1` は close、一時 Project は削除済み

## 補足

- `pnpm smoke:org` は既存の smoke runner が古い `init --project-url` を使っており、現在の CLI とずれているため今回の実環境確認では使っていません。
- `pnpm --filter @gh-gantt/cli typecheck` は既存の test type / fixture / OpenAPI 周辺の型エラーで失敗する状態です。今回の修正範囲は上記の targeted/full test と build で検証しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * GitHub issue type の同期機能を追加。タスク作成時と更新時に issue type を設定・変更できるようになりました。
  * タスク type 更新 API (`PATCH /api/tasks/:id`) を拡張。type フィールドの検証と対応するラベルの自動同期に対応しました。

* **Tests**
  * Issue type マッピングと API 検証に関する包括的なテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->