### PR TITLE
[codex] serve の UI 配信元を CLI 側に修正

### DIFF
--- a/packages/cli/src/__tests__/serve-command.test.ts
+++ b/packages/cli/src/__tests__/serve-command.test.ts
@@ -80,4 +80,31 @@ describe("serve コマンド", () => {
     expect(mocks.app.use).toHaveBeenCalledWith(mocks.staticMiddleware);
     expect(mocks.createApiRouter).toHaveBeenCalledWith(projectRoot);
   });
+
+  it("/api 配下の未定義パスは SPA fallback ではなく API 側へ委譲する", async () => {
+    const { serveCommand } = await import("../commands/serve.js");
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    const cliUiDistPath = join(testDir, "..", "..", "..", "ui", "dist");
+
+    mocks.existsSync.mockImplementation((path: unknown) => path === cliUiDistPath);
+
+    await serveCommand.parseAsync(["serve", "--port", "0"], { from: "user" });
+
+    const fallbackHandler = mocks.app.get.mock.calls.find(([path]) => path === "*")?.[1] as
+      | ((
+          req: { path: string },
+          res: { sendFile: ReturnType<typeof vi.fn> },
+          next: () => void,
+        ) => void)
+      | undefined;
+    if (!fallbackHandler) throw new Error("SPA fallback handler not found");
+
+    const sendFile = vi.fn();
+    const next = vi.fn();
+
+    fallbackHandler({ path: "/api/missing" }, { sendFile }, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(sendFile).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/__tests__/serve-command.test.ts
+++ b/packages/cli/src/__tests__/serve-command.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mocks = vi.hoisted(() => {
+  const staticMiddleware = Symbol("staticMiddleware");
+  const apiRouter = Symbol("apiRouter");
+  const app = {
+    use: vi.fn(),
+    get: vi.fn(),
+    listen: vi.fn((_port: number, callback?: () => void) => {
+      callback?.();
+      return { close: vi.fn() };
+    }),
+  };
+  const express = vi.fn(() => app) as unknown as ReturnType<typeof vi.fn> & {
+    static: ReturnType<typeof vi.fn>;
+  };
+  express.static = vi.fn(() => staticMiddleware);
+
+  return {
+    apiRouter,
+    app,
+    createApiRouter: vi.fn(() => apiRouter),
+    existsSync: vi.fn(),
+    express,
+    staticMiddleware,
+  };
+});
+
+vi.mock("express", () => ({
+  default: mocks.express,
+}));
+
+vi.mock("node:fs", async (importOriginal: () => Promise<typeof import("node:fs")>) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    existsSync: mocks.existsSync,
+  };
+});
+
+vi.mock("../server/api.js", () => ({
+  createApiRouter: mocks.createApiRouter,
+}));
+
+describe("serve コマンド", () => {
+  let projectRoot: string;
+  let originalCwd: string;
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    projectRoot = await realpath(await mkdtemp(join(tmpdir(), "gh-gantt-serve-project-")));
+    originalCwd = process.cwd();
+    process.chdir(projectRoot);
+    consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    consoleLog.mockRestore();
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("実行中のプロジェクトではなく CLI 側の UI ビルド成果物を配信する", async () => {
+    const { serveCommand } = await import("../commands/serve.js");
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    const cliUiDistPath = join(testDir, "..", "..", "..", "ui", "dist");
+    const projectUiDistPath = join(projectRoot, "packages", "ui", "dist");
+
+    mocks.existsSync.mockImplementation((path: unknown) => path === cliUiDistPath);
+
+    await serveCommand.parseAsync(["serve", "--port", "0"], { from: "user" });
+
+    expect(mocks.existsSync).not.toHaveBeenCalledWith(projectUiDistPath);
+    expect(mocks.express.static).toHaveBeenCalledWith(cliUiDistPath);
+    expect(mocks.app.use).toHaveBeenCalledWith(mocks.staticMiddleware);
+    expect(mocks.createApiRouter).toHaveBeenCalledWith(projectRoot);
+  });
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -48,7 +48,11 @@ export const serveCommand = new Command("serve")
       if (uiDistPath) {
         app.use(express.static(uiDistPath));
         // SPA ルーティングは静的配信後に index.html へ戻す。
-        app.get("*", (_req, res) => {
+        app.get("*", (req, res, next) => {
+          if (req.path === "/api" || req.path.startsWith("/api/")) {
+            next();
+            return;
+          }
           res.sendFile(join(uiDistPath, "index.html"));
         });
         console.log(`Serving UI from ${uiDistPath}`);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,9 +1,21 @@
 import { Command } from "commander";
 import express from "express";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createApiRouter } from "../server/api.js";
 import { DEFAULT_PORT } from "@gh-gantt/shared";
+
+export function resolveUiDistPath(moduleUrl = import.meta.url): string | null {
+  const moduleDir = dirname(fileURLToPath(moduleUrl));
+  const candidates = [
+    join(moduleDir, "ui", "dist"),
+    join(moduleDir, "..", "ui", "dist"),
+    join(moduleDir, "..", "..", "ui", "dist"),
+    join(moduleDir, "..", "..", "..", "ui", "dist"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
 
 export const serveCommand = new Command("serve")
   .description("Start the Gantt chart UI server")
@@ -15,7 +27,7 @@ export const serveCommand = new Command("serve")
 
     const app = express();
 
-    // CORS for dev mode (Vite dev server on different port)
+    // 開発時は Vite dev server が別ポートで動くため CORS を許可する。
     app.use((_req, res, next) => {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, PATCH, POST, OPTIONS");
@@ -27,22 +39,23 @@ export const serveCommand = new Command("serve")
       next();
     });
 
-    // Mount API routes
+    // API は gh-gantt を実行したプロジェクトの同期データを読む。
     const apiRouter = createApiRouter(projectRoot);
     app.use(apiRouter);
 
     if (!opts.apiOnly) {
-      // Serve built UI if available
-      const uiDistPath = join(projectRoot, "packages", "ui", "dist");
-      if (existsSync(uiDistPath)) {
+      const uiDistPath = resolveUiDistPath();
+      if (uiDistPath) {
         app.use(express.static(uiDistPath));
-        // SPA fallback
+        // SPA ルーティングは静的配信後に index.html へ戻す。
         app.get("*", (_req, res) => {
           res.sendFile(join(uiDistPath, "index.html"));
         });
         console.log(`Serving UI from ${uiDistPath}`);
       } else {
-        console.log(`No built UI found. Run 'pnpm --filter @gh-gantt/ui build' first.`);
+        console.log(
+          `No built UI found in the gh-gantt installation. Run 'pnpm --filter @gh-gantt/ui build' first.`,
+        );
         console.log(`For development, use 'pnpm dev' to start Vite dev server alongside.`);
       }
     }


### PR DESCRIPTION
## 概要

`gh-gantt serve` を別リポジトリから実行したときに、UI のビルド成果物を実行先リポジトリ配下から探してしまい、`No built UI found` 警告が出る問題を修正しました。

## 変更内容

- API が読む project root は `process.cwd()` のまま維持
- UI の静的配信元は gh-gantt CLI の設置場所から `packages/ui/dist` を解決
- 別プロジェクトの `cwd` でも CLI 側 UI を配信する回帰テストを追加

## 原因

`serve` コマンドが API 用の project root と UI 配信用の dist path の両方に `process.cwd()` を使っていたため、利用側リポジトリで `packages/ui/dist` を探していました。

## 確認

- `pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/serve-command.test.ts`
- `pnpm --filter @gh-gantt/cli test`
- `pnpm --filter @gh-gantt/cli build`
- `pnpm exec vp check packages/cli/src/commands/serve.ts packages/cli/src/__tests__/serve-command.test.ts`
- `pnpm req:validate` は warning 26 件のみで合格
- `git push` の pre-push hook: test/build/req-trace/req-validate/docs-gen すべて通過
- `/Users/stanah/work/github.com/stanah/iris` から `gh-gantt serve --port 39733` を起動し、`Serving UI from /Users/stanah/work/github.com/stanah/gh-gantt/packages/ui/dist` と HTTP 200 を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * CLI serve コマンド用の新しいテストスイートを追加しました。

* **Bug Fixes**
  * UIビルドディレクトリの検出ロジックを改善し、より柔軟な配置に対応しました。
  * API エンドポイント向けのルーティングハンドリングを修正し、API リクエストがSPA フォールバックに影響されないようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->