### PR TITLE
fix(e2e): JSON fixture 読み込みを Node 24 対応

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,21 @@
 import type { Page } from "@playwright/test";
-import configJson from "./fixtures/config.json";
-import tasksJson from "./fixtures/tasks.json";
+import { readFileSync } from "node:fs";
+
+type FixtureTask = {
+  id: string;
+  [key: string]: unknown;
+};
+
+type TasksFixture = {
+  tasks: FixtureTask[];
+};
+
+function readJsonFixture<T>(path: string): T {
+  return JSON.parse(readFileSync(new URL(path, import.meta.url), "utf8")) as T;
+}
+
+const configJson = readJsonFixture<Record<string, unknown>>("./fixtures/config.json");
+const tasksJson = readJsonFixture<TasksFixture>("./fixtures/tasks.json");
 
 export async function mockApi(page: Page) {
   await page.route("**/api/config", (route) => route.fulfill({ json: configJson }));


### PR DESCRIPTION
## 概要

CI の e2e job が Node 24 で JSON fixture の import attribute 要求により test discovery 前に失敗していた問題を修正しました。

## 変更内容

- e2e helper の JSON fixture 読み込みを static JSON import から readFileSync(new URL(..., import.meta.url)) + JSON.parse に変更
- Playwright/Node の ESM JSON loader 差異に依存しない形にしました

## 確認

- gh run view --job 73623936612 --log で失敗原因を確認
- pnpm exec vp check e2e/helpers.ts
- pnpm test:e2e
- env CI=1 pnpm exec vp run test:e2e
- push 前フック: test/build/req-trace/req-validate/docs-gen すべて通過

## 補足

- pnpm exec vp check 全体は未追跡の .claude/worktrees/ まで拾う既存 warning が大量に出るため、今回の変更ファイルに絞って確認しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部コード構造の改善を行いました。APIの動作に変更はありません。

---

**注記:** このリリースでは、エンドユーザー向けの新機能やバグ修正はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->