### PR TITLE
ci: release-please action を v5.0.0 に更新

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f8e03db635a # v4 を固定コミットで利用
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0 を固定コミットで利用
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## 概要
Release Please workflow が存在しない `release-please-action` の固定 SHA を参照して失敗していたため、現行の `v5.0.0` 固定 commit に更新しました。

## 原因
`googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f8e03db635a` は upstream に存在しない ref でした。

## 変更内容
- `googleapis/release-please-action` を `v5.0.0` の commit `45996ed1f6d02564a971a2fa1b5860e934307cf7` に固定
- コメントも `v5.0.0` に更新

## 確認
- `gh run view --job 73627357558 --log` で失敗原因を確認
- `gh release view --repo googleapis/release-please-action --json tagName,name,publishedAt,url,targetCommitish` で `v5.0.0` を確認
- `git ls-remote https://github.com/googleapis/release-please-action.git 45996ed1f6d02564a971a2fa1b5860e934307cf7 refs/tags/v5.0.0 refs/tags/v5`
- workflow YAML parse
- `git diff --check`
- pre-commit hook: branch-check / lint / betterleaks / commitlint
- pre-push hook: test / build / req-trace / req-validate / docs-gen

補足: `release-please` workflow は `main` への push で実行されるため、この PR 上では通常 CI の確認までになります。