### PR TITLE
feat(ui): 依存ハイライトの切替を追加

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -135,6 +135,8 @@ export function App() {
   const {
     hideClosed,
     toggleHideClosed,
+    dependencyHighlightEnabled,
+    toggleDependencyHighlight,
     selectedAssignee,
     selectedAssignees,
     setSelectedAssignee,
@@ -250,8 +252,8 @@ export function App() {
 
   const { getRelated } = useRelatedTasks(tasks, config?.task_types ?? EMPTY_TASK_TYPES);
   const { ids: highlightedTaskIds, relationMap: highlightRelationMap } = useMemo(
-    () => getRelated(hoveredTaskId),
-    [getRelated, hoveredTaskId],
+    () => getRelated(dependencyHighlightEnabled ? hoveredTaskId : null),
+    [dependencyHighlightEnabled, getRelated, hoveredTaskId],
   );
 
   const handleReparent = useCallback(
@@ -551,6 +553,8 @@ export function App() {
             syncing={syncing}
             displayOptions={displayOptions}
             onToggleDisplayOption={toggleDisplayOption}
+            dependencyHighlightEnabled={dependencyHighlightEnabled}
+            onToggleDependencyHighlight={toggleDependencyHighlight}
             hideClosed={hideClosed}
             onToggleHideClosed={toggleHideClosed}
             selectedAssignee={selectedAssignee}
@@ -608,6 +612,7 @@ export function App() {
                     displayOptions={displayOptions}
                     hoveredTaskId={hoveredTaskId}
                     onHoverTask={setHoveredTaskId}
+                    dependencyHighlightEnabled={dependencyHighlightEnabled}
                     highlightedTaskIds={highlightedTaskIds}
                     highlightRelationMap={highlightRelationMap}
                     searchQuery={searchQuery}
@@ -635,6 +640,7 @@ export function App() {
                     displayOptions={displayOptions}
                     hoveredTaskId={hoveredTaskId}
                     onHoverTask={setHoveredTaskId}
+                    dependencyHighlightEnabled={dependencyHighlightEnabled}
                     highlightRelationMap={highlightRelationMap}
                   />
                 }

--- a/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
+++ b/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
@@ -6,6 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { GanttChart } from "../components/GanttChart.js";
 import { TaskTreeBody } from "../components/TaskTree.js";
 import { useTaskFilter } from "../hooks/useTaskFilter.js";
+import type { RelationType } from "../hooks/useRelatedTasks.js";
 import type { Config, Task } from "../types/index.js";
 import type { TreeNode } from "../hooks/useTaskTree.js";
 
@@ -103,6 +104,8 @@ const config: Config = {
 
 const tasks = [baseTask, relatedTask, unrelatedTask];
 const flatList: TreeNode[] = tasks.map((task) => ({ task, children: [], depth: 0 }));
+const highlightRelationMap = new Map<string, RelationType>([[relatedTask.id, "blocked"]]);
+const highlightedTaskIds = new Set([baseTask.id, relatedTask.id]);
 const originalConsoleError = console.error.bind(console);
 
 function FilterProbe() {
@@ -168,6 +171,24 @@ describe("依存ハイライトトグル", () => {
     expect(new URL(window.location.href).searchParams.has("dependencyHighlight")).toBe(false);
   });
 
+  it("GanttChart は ON のときホバーした非関連タスクを dim する", () => {
+    const html = renderToStaticMarkup(
+      <GanttChart
+        tasks={tasks}
+        flatList={flatList}
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        header={() => {}}
+        hoveredTaskId={baseTask.id}
+        highlightRelationMap={highlightRelationMap}
+        dependencyHighlightEnabled={true}
+      />,
+    );
+
+    expect(html).toContain('opacity="0.3"');
+  });
+
   it("GanttChart は OFF のときホバーしても非関連タスクを dim しない", () => {
     const html = renderToStaticMarkup(
       <GanttChart
@@ -178,12 +199,30 @@ describe("依存ハイライトトグル", () => {
         onSelectTask={() => {}}
         header={() => {}}
         hoveredTaskId={baseTask.id}
-        highlightRelationMap={new Map()}
+        highlightRelationMap={highlightRelationMap}
         dependencyHighlightEnabled={false}
       />,
     );
 
     expect(html).not.toContain('opacity="0.3"');
+  });
+
+  it("TaskTreeBody は ON のときホバーした非関連タスクを dim する", () => {
+    const html = renderToStaticMarkup(
+      <TaskTreeBody
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        flatList={flatList}
+        collapsed={new Set()}
+        onToggleCollapse={() => {}}
+        hoveredTaskId={baseTask.id}
+        highlightedTaskIds={highlightedTaskIds}
+        dependencyHighlightEnabled={true}
+      />,
+    );
+
+    expect(html).toContain("opacity:0.4");
   });
 
   it("TaskTreeBody は OFF のときホバーしても非関連タスクを dim しない", () => {
@@ -196,7 +235,7 @@ describe("依存ハイライトトグル", () => {
         collapsed={new Set()}
         onToggleCollapse={() => {}}
         hoveredTaskId={baseTask.id}
-        highlightedTaskIds={new Set()}
+        highlightedTaskIds={highlightedTaskIds}
         dependencyHighlightEnabled={false}
       />,
     );

--- a/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
+++ b/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import React from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -103,6 +103,7 @@ const config: Config = {
 
 const tasks = [baseTask, relatedTask, unrelatedTask];
 const flatList: TreeNode[] = tasks.map((task) => ({ task, children: [], depth: 0 }));
+const originalConsoleError = console.error.bind(console);
 
 function FilterProbe() {
   const { dependencyHighlightEnabled, toggleDependencyHighlight } = useTaskFilter([]);
@@ -114,6 +115,22 @@ function FilterProbe() {
 }
 
 describe("依存ハイライトトグル", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "error").mockImplementation((message: unknown, ...args: unknown[]) => {
+      if (
+        typeof message === "string" &&
+        message.includes("useLayoutEffect does nothing on the server")
+      ) {
+        return;
+      }
+      originalConsoleError(message, ...args);
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
   afterEach(() => {
     cleanup();
     window.history.replaceState({}, "", "/");

--- a/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
+++ b/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import React from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GanttChart } from "../components/GanttChart.js";
+import { TaskTreeBody } from "../components/TaskTree.js";
+import { useTaskFilter } from "../hooks/useTaskFilter.js";
+import type { Config, Task } from "../types/index.js";
+import type { TreeNode } from "../hooks/useTaskTree.js";
+
+const baseTask: Task = {
+  id: "stanah/gh-gantt#1",
+  type: "task",
+  github_issue: 1,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "Base task",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: "2026-03-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: { Status: "Todo" },
+  start_date: "2026-04-01",
+  end_date: "2026-04-05",
+  date: null,
+  blocked_by: [],
+};
+
+const relatedTask: Task = {
+  ...baseTask,
+  id: "stanah/gh-gantt#2",
+  github_issue: 2,
+  title: "Related task",
+  blocked_by: [{ task: "stanah/gh-gantt#1", type: "finish-to-start", lag: 0 }],
+};
+
+const unrelatedTask: Task = {
+  ...baseTask,
+  id: "stanah/gh-gantt#3",
+  github_issue: 3,
+  title: "Unrelated task",
+  start_date: "2026-04-06",
+  end_date: "2026-04-10",
+};
+
+const config: Config = {
+  version: "1",
+  project: {
+    name: "Test Project",
+    github: {
+      owner: "stanah",
+      repo: "gh-gantt",
+      project_number: 1,
+    },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: {
+      start_date: "Start Date",
+      end_date: "End Date",
+      status: "Status",
+    },
+  },
+  task_types: {
+    task: {
+      label: "Task",
+      display: "bar",
+      color: "#27AE60",
+      github_label: null,
+    },
+  },
+  type_hierarchy: {
+    task: [],
+  },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: {
+        color: "#3498DB",
+        done: false,
+      },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+const tasks = [baseTask, relatedTask, unrelatedTask];
+const flatList: TreeNode[] = tasks.map((task) => ({ task, children: [], depth: 0 }));
+
+function FilterProbe() {
+  const { dependencyHighlightEnabled, toggleDependencyHighlight } = useTaskFilter([]);
+  return (
+    <button type="button" data-testid="toggle" onClick={toggleDependencyHighlight}>
+      {dependencyHighlightEnabled ? "on" : "off"}
+    </button>
+  );
+}
+
+describe("依存ハイライトトグル", () => {
+  afterEach(() => {
+    cleanup();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("URL パラメータがない場合は依存ハイライトを有効にする", () => {
+    window.history.replaceState({}, "", "/");
+    const { getByTestId } = render(<FilterProbe />);
+
+    expect(getByTestId("toggle").textContent).toBe("on");
+  });
+
+  it("URL パラメータで依存ハイライトの OFF 状態を復元する", () => {
+    window.history.replaceState({}, "", "/?dependencyHighlight=off");
+    const { getByTestId } = render(<FilterProbe />);
+
+    expect(getByTestId("toggle").textContent).toBe("off");
+  });
+
+  it("依存ハイライトの OFF 状態を URL に永続化する", () => {
+    window.history.replaceState({}, "", "/");
+    const { getByTestId } = render(<FilterProbe />);
+
+    act(() => getByTestId("toggle").click());
+
+    expect(new URL(window.location.href).searchParams.get("dependencyHighlight")).toBe("off");
+  });
+
+  it("依存ハイライトを再度 ON にすると URL パラメータを削除する", () => {
+    window.history.replaceState({}, "", "/?dependencyHighlight=off");
+    const { getByTestId } = render(<FilterProbe />);
+
+    act(() => getByTestId("toggle").click());
+
+    expect(new URL(window.location.href).searchParams.has("dependencyHighlight")).toBe(false);
+  });
+
+  it("GanttChart は OFF のときホバーしても非関連タスクを dim しない", () => {
+    const html = renderToStaticMarkup(
+      <GanttChart
+        tasks={tasks}
+        flatList={flatList}
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        header={() => {}}
+        hoveredTaskId={baseTask.id}
+        highlightRelationMap={new Map()}
+        dependencyHighlightEnabled={false}
+      />,
+    );
+
+    expect(html).not.toContain('opacity="0.3"');
+  });
+
+  it("TaskTreeBody は OFF のときホバーしても非関連タスクを dim しない", () => {
+    const html = renderToStaticMarkup(
+      <TaskTreeBody
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        flatList={flatList}
+        collapsed={new Set()}
+        onToggleCollapse={() => {}}
+        hoveredTaskId={baseTask.id}
+        highlightedTaskIds={new Set()}
+        dependencyHighlightEnabled={false}
+      />,
+    );
+
+    expect(html).not.toContain("opacity:0.4");
+  });
+});

--- a/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
+++ b/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
@@ -3,6 +3,22 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import React from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
+
+const dependencyGraphMocks = vi.hoisted(() => ({
+  buildDependencyEdges: vi.fn(() => [
+    {
+      from: "stanah/gh-gantt#1",
+      to: "stanah/gh-gantt#2",
+      type: "finish-to-start",
+      lag: 0,
+    },
+  ]),
+  detectCycles: vi.fn(() => []),
+  getEdgeCoordinates: vi.fn(() => ({ path: "M 0 0 L 10 10" })),
+}));
+
+vi.mock("../lib/dependency-graph.js", () => dependencyGraphMocks);
+
 import { GanttChart } from "../components/GanttChart.js";
 import { TaskTreeBody } from "../components/TaskTree.js";
 import { useTaskFilter } from "../hooks/useTaskFilter.js";
@@ -205,6 +221,29 @@ describe("依存ハイライトトグル", () => {
     );
 
     expect(html).not.toContain('opacity="0.3"');
+  });
+
+  it("GanttChart は OFF のとき依存線を描画せず依存グラフも計算しない", () => {
+    dependencyGraphMocks.buildDependencyEdges.mockClear();
+    dependencyGraphMocks.detectCycles.mockClear();
+    dependencyGraphMocks.getEdgeCoordinates.mockClear();
+
+    renderToStaticMarkup(
+      <GanttChart
+        tasks={tasks}
+        flatList={flatList}
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        header={() => {}}
+        hoveredTaskId={baseTask.id}
+        dependencyHighlightEnabled={false}
+      />,
+    );
+
+    expect(dependencyGraphMocks.buildDependencyEdges).not.toHaveBeenCalled();
+    expect(dependencyGraphMocks.detectCycles).not.toHaveBeenCalled();
+    expect(dependencyGraphMocks.getEdgeCoordinates).not.toHaveBeenCalled();
   });
 
   it("TaskTreeBody は ON のときホバーした非関連タスクを dim する", () => {

--- a/packages/ui/src/components/GanttChart.tsx
+++ b/packages/ui/src/components/GanttChart.tsx
@@ -255,14 +255,16 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
         pixelsPerDay={pixelsPerDay}
         sprints={config.sprints}
       />
-      <GanttBlockLines
-        tasks={tasks}
-        flatList={flatList}
-        xScale={xScale}
-        totalWidth={totalWidth}
-        totalHeight={totalHeight}
-        hoveredTaskId={dependencyHighlightEnabled ? (hoveredTaskId ?? null) : null}
-      />
+      {dependencyHighlightEnabled && (
+        <GanttBlockLines
+          tasks={tasks}
+          flatList={flatList}
+          xScale={xScale}
+          totalWidth={totalWidth}
+          totalHeight={totalHeight}
+          hoveredTaskId={hoveredTaskId ?? null}
+        />
+      )}
       <svg
         ref={mainSvgRef}
         role="group"

--- a/packages/ui/src/components/GanttChart.tsx
+++ b/packages/ui/src/components/GanttChart.tsx
@@ -45,6 +45,7 @@ interface GanttChartProps {
   displayOptions?: Set<DisplayOption>;
   hoveredTaskId?: string | null;
   onHoverTask?: (taskId: string | null) => void;
+  dependencyHighlightEnabled?: boolean;
   highlightRelationMap?: Map<string, RelationType>;
 }
 
@@ -62,6 +63,7 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
     displayOptions,
     hoveredTaskId,
     onHoverTask,
+    dependencyHighlightEnabled = true,
     highlightRelationMap,
   },
   ref,
@@ -259,7 +261,7 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
         xScale={xScale}
         totalWidth={totalWidth}
         totalHeight={totalHeight}
-        hoveredTaskId={hoveredTaskId ?? null}
+        hoveredTaskId={dependencyHighlightEnabled ? (hoveredTaskId ?? null) : null}
       />
       <svg
         ref={mainSvgRef}
@@ -324,8 +326,11 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
           const showAssignees = displayOptions?.has("assignees");
 
           const isHoveredTask = hoveredTaskId === task.id;
-          const highlightType = highlightRelationMap?.get(task.id) ?? null;
-          const isDimmed = hoveredTaskId != null && !isHoveredTask && !highlightType;
+          const highlightType = dependencyHighlightEnabled
+            ? (highlightRelationMap?.get(task.id) ?? null)
+            : null;
+          const isDimmed =
+            dependencyHighlightEnabled && hoveredTaskId != null && !isHoveredTask && !highlightType;
 
           if (display === "summary") {
             return (

--- a/packages/ui/src/components/TaskTree.tsx
+++ b/packages/ui/src/components/TaskTree.tsx
@@ -43,6 +43,7 @@ interface TaskTreeBodyProps {
   displayOptions?: Set<DisplayOption>;
   hoveredTaskId?: string | null;
   onHoverTask?: (taskId: string | null) => void;
+  dependencyHighlightEnabled?: boolean;
   highlightedTaskIds?: Set<string>;
   highlightRelationMap?: Map<string, RelationType>;
   searchQuery?: string;
@@ -62,6 +63,7 @@ export function TaskTreeBody({
   displayOptions,
   hoveredTaskId,
   onHoverTask,
+  dependencyHighlightEnabled = true,
   highlightedTaskIds,
   highlightRelationMap,
   searchQuery,
@@ -89,8 +91,11 @@ export function TaskTreeBody({
       showAssignees={displayOptions?.has("assignees")}
       showPriority={displayOptions?.has("priority")}
       priorityFieldName={config.sync?.field_mapping?.priority}
-      highlightType={highlightRelationMap?.get(node.task.id) ?? null}
+      highlightType={
+        dependencyHighlightEnabled ? (highlightRelationMap?.get(node.task.id) ?? null) : null
+      }
       isDimmed={
+        dependencyHighlightEnabled &&
         hoveredTaskId != null &&
         hoveredTaskId !== node.task.id &&
         !highlightedTaskIds?.has(node.task.id)

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/toolbar/Toolbar.tsx
 import React from "react";
+import { GitBranch } from "lucide-react";
 import type { DisplayOption } from "../../hooks/useDisplayOptions.js";
 import type { SprintConfig, ViewScale } from "@gh-gantt/shared";
 import type { TaskType } from "../../types/index.js";
@@ -10,6 +11,7 @@ import { UndoRedoGroup } from "./UndoRedoGroup.js";
 import { SyncGroup } from "./SyncGroup.js";
 import { MoreMenu } from "./MoreMenu.js";
 import { ThemeToggle } from "./ThemeToggle.js";
+import { IconButton } from "./IconButton.js";
 
 interface ToolbarProps {
   projectName: string;
@@ -23,6 +25,8 @@ interface ToolbarProps {
   lastSyncedAt?: string;
   displayOptions: Set<DisplayOption>;
   onToggleDisplayOption: (opt: DisplayOption) => void;
+  dependencyHighlightEnabled: boolean;
+  onToggleDependencyHighlight: () => void;
   hideClosed: boolean;
   onToggleHideClosed: () => void;
   taskTypes: Record<string, TaskType>;
@@ -110,6 +114,12 @@ export function Toolbar(props: ToolbarProps) {
         undoRedoBusy={props.undoRedoBusy}
       />
       <div style={{ flex: 1 }} />
+      <IconButton
+        icon={<GitBranch size={14} />}
+        title="Dependency Highlight"
+        onClick={props.onToggleDependencyHighlight}
+        active={props.dependencyHighlightEnabled}
+      />
       <MoreMenu
         displayOptions={props.displayOptions}
         onToggleDisplayOption={props.onToggleDisplayOption}

--- a/packages/ui/src/hooks/useTaskFilter.ts
+++ b/packages/ui/src/hooks/useTaskFilter.ts
@@ -7,9 +7,11 @@ export const NO_LABEL = "__no_label__";
 const ASSIGNEES_QUERY_KEY = "assignees";
 const PRIORITIES_QUERY_KEY = "priorities";
 const LABELS_QUERY_KEY = "labels";
+const DEPENDENCY_HIGHLIGHT_QUERY_KEY = "dependencyHighlight";
 
 export interface TaskFilterState {
   hideClosed: boolean;
+  dependencyHighlightEnabled: boolean;
   selectedAssignee: string | null;
   searchQuery: string;
   selectedPriorities: string[];
@@ -45,6 +47,12 @@ function parseLabelsFromQuery(search: string): string[] {
   return params.getAll(LABELS_QUERY_KEY).filter((v) => v.length > 0);
 }
 
+function parseDependencyHighlightFromQuery(search: string): boolean {
+  const params = new URLSearchParams(search);
+  const raw = params.get(DEPENDENCY_HIGHLIGHT_QUERY_KEY);
+  return raw !== "off";
+}
+
 export function useTaskFilter(tasks: Task[]) {
   const [hideClosed, setHideClosed] = useState(true);
   const [selectedAssignees, setSelectedAssignees] = useState<string[]>(() => {
@@ -59,10 +67,18 @@ export function useTaskFilter(tasks: Task[]) {
     if (typeof window === "undefined") return [];
     return parseLabelsFromQuery(window.location.search);
   });
+  const [dependencyHighlightEnabled, setDependencyHighlightEnabled] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return parseDependencyHighlightFromQuery(window.location.search);
+  });
   const [searchQuery, setSearchQuery] = useState("");
 
   const toggleHideClosed = useCallback(() => {
     setHideClosed((prev) => !prev);
+  }, []);
+
+  const toggleDependencyHighlight = useCallback(() => {
+    setDependencyHighlightEnabled((prev) => !prev);
   }, []);
 
   const allAssignees = useMemo(() => {
@@ -117,12 +133,19 @@ export function useTaskFilter(tasks: Task[]) {
     for (const label of selectedLabels) {
       url.searchParams.append(LABELS_QUERY_KEY, label);
     }
+    if (dependencyHighlightEnabled) {
+      url.searchParams.delete(DEPENDENCY_HIGHLIGHT_QUERY_KEY);
+    } else {
+      url.searchParams.set(DEPENDENCY_HIGHLIGHT_QUERY_KEY, "off");
+    }
     window.history.replaceState({}, "", url.toString());
-  }, [selectedAssignees, selectedPriorities, selectedLabels]);
+  }, [selectedAssignees, selectedPriorities, selectedLabels, dependencyHighlightEnabled]);
 
   return {
     hideClosed,
     toggleHideClosed,
+    dependencyHighlightEnabled,
+    toggleDependencyHighlight,
     selectedAssignee,
     setSelectedAssignee,
     selectedAssignees,


### PR DESCRIPTION
## 概要
Gantt 上のマウスオーバー依存ハイライトをオン/オフできる Toolbar トグルを追加しました。

## 変更内容
- Toolbar に `Dependency Highlight` の IconButton トグルを追加
- `useTaskFilter` に依存ハイライト状態を追加し、`dependencyHighlight=off` で URL 永続化
- OFF 時は TaskTree / GanttChart の関連ハイライト・非関連タスク dimming・依存線表示を抑止
- 既定は ON のままにして現行動作を維持

## 確認
- `pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/dependency-highlight-toggle.test.tsx`
- `pnpm --filter @gh-gantt/ui exec vp check src/hooks/useTaskFilter.ts src/components/TaskTree.tsx src/components/GanttChart.tsx src/components/toolbar/Toolbar.tsx src/App.tsx src/__tests__/dependency-highlight-toggle.test.tsx`
- `pnpm --filter @gh-gantt/ui test`
- `pnpm --filter @gh-gantt/ui build`
- `pnpm test`
- `pnpm build`
- pre-commit: branch-check / lint / betterleaks / commitlint
- pre-push: test / build / req-trace / req-validate / docs-gen

## 補足
- gh-gantt 上では #80 は #18 に block されていますが、ユーザー指示により #80 の UI 実装を先行しました。
- CodeRabbit CLI review は未コミット差分を外部サービスへ送る明示許可がなく、環境側で拒否されたため未実行です。代わりにローカル自己レビューを実施し、ブロッキング指摘はありません。

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ツールバーに依存関係ハイライトのオン/オフ切替ボタンを追加。切替はURLに保存され、復元されます。
  * 切替に応じてガントチャートとタスクリストのホバー時の依存ハイライト／淡色表示を制御します。

* **Tests**
  * 依存関係ハイライト切替の挙動とURL同期を検証するテストスイートを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->