### PR TITLE
fix(cli): status の remote_changed 誤検出を修正 (#197)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -432,6 +432,7 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-169-status-false-remote-changes.test.ts
+              - packages/cli/src/__tests__/regressions/issue-197-status-remote-changed-stale-updated-at.test.ts
       - id: NFR-STABILITY-002
         summary: silent failure の禁止
         acceptance_criteria:

--- a/packages/cli/src/__tests__/regressions/issue-197-status-remote-changed-stale-updated-at.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-197-status-remote-changed-stale-updated-at.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { SyncState, Task } from "@gh-gantt/shared";
+import { countRemoteChanges } from "../../commands/status.js";
+import { hashTask } from "../../sync/hash.js";
+
+function makeTask(updatedAt: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id: "stanah/gh-gantt#139",
+    type: "task",
+    github_issue: 139,
+    github_repo: "stanah/gh-gantt",
+    parent: null,
+    sub_tasks: [],
+    title: "context コマンド新設",
+    body: null,
+    state: "closed",
+    state_reason: "COMPLETED",
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-04-05T12:46:03Z",
+    updated_at: updatedAt,
+    closed_at: "2026-05-03T15:09:50Z",
+    custom_fields: {
+      "End Date": "2026-04-30",
+      "Start Date": "2026-04-25",
+      Status: "Done",
+      Title: "context コマンド新設",
+    },
+    start_date: "2026-04-25",
+    end_date: "2026-04-30",
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeSyncState(snapshotTask: Task, overrides: Partial<SyncState> = {}): SyncState {
+  const hash = hashTask(snapshotTask);
+  return {
+    last_synced_at: "2026-05-03T15:10:26.877Z",
+    project_node_id: "PVT_1",
+    id_map: {},
+    field_ids: {},
+    snapshots: {
+      [snapshotTask.id]: {
+        hash,
+        remoteHash: hash,
+        synced_at: "2026-05-03T15:10:26.877Z",
+        updated_at: snapshotTask.updated_at,
+        syncFields: {
+          title: snapshotTask.title,
+          body: snapshotTask.body,
+          state: snapshotTask.state,
+          type: snapshotTask.type,
+          assignees: snapshotTask.assignees,
+          labels: snapshotTask.labels,
+          milestone: snapshotTask.milestone,
+          custom_fields: snapshotTask.custom_fields,
+          parent: snapshotTask.parent,
+          sub_tasks: snapshotTask.sub_tasks,
+          start_date: snapshotTask.start_date,
+          end_date: snapshotTask.end_date,
+          date: snapshotTask.date,
+          blocked_by: snapshotTask.blocked_by,
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("[NFR-STABILITY-001-AC5] [Issue #197] status remote_changed の stale updated_at 誤検出", () => {
+  it("remote updated_at が last_synced_at より古く hash も一致する場合は remote_changed に数えない", () => {
+    const snapshotTask = makeTask("2026-05-03T15:09:00Z");
+    const remoteTask = makeTask("2026-05-03T15:09:50Z");
+    const syncState = makeSyncState(snapshotTask);
+
+    expect(countRemoteChanges([remoteTask], syncState)).toBe(0);
+  });
+
+  it("remote updated_at が last_synced_at より新しい場合は hash 一致でも remote_changed に数える", () => {
+    const snapshotTask = makeTask("2026-05-03T15:09:00Z");
+    const remoteTask = makeTask("2026-05-03T15:11:00Z");
+    const syncState = makeSyncState(snapshotTask);
+
+    expect(countRemoteChanges([remoteTask], syncState)).toBe(1);
+  });
+
+  it("snapshot.updated_at がない旧 sync-state では hash 差分を remote_changed に数える", () => {
+    const snapshotTask = makeTask("2026-05-03T15:09:00Z");
+    const remoteTask = makeTask("2026-05-03T15:09:50Z", { title: "context コマンド新設を更新" });
+    const syncState = makeSyncState(snapshotTask);
+    delete syncState.snapshots[snapshotTask.id]!.updated_at;
+
+    expect(countRemoteChanges([remoteTask], syncState)).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -10,11 +10,49 @@ import { threeWayMerge, type FieldConflict } from "../sync/three-way-merge.js";
 import { formatValue } from "../util/format.js";
 import { mapRemoteItemToTask } from "../sync/mapper.js";
 import { hashTask, extractSyncFields } from "../sync/hash.js";
-import type { Task } from "@gh-gantt/shared";
+import type { SyncState, Task } from "@gh-gantt/shared";
 
 function extractIssueNumber(id: string): number | undefined {
   const match = id.match(/#(\d+)$/);
   return match ? parseInt(match[1], 10) : undefined;
+}
+
+export function countRemoteChanges(remoteTasks: Task[], syncState: SyncState): number {
+  let remoteChanged = 0;
+  for (const remote of remoteTasks) {
+    const snapshot = syncState.snapshots[remote.id];
+    if (!snapshot) {
+      remoteChanged++;
+      continue;
+    }
+
+    if (remote.updated_at && snapshot.updated_at) {
+      if (
+        isRemoteUpdatedAfterLastSync(
+          remote.updated_at,
+          snapshot.updated_at,
+          syncState.last_synced_at,
+        )
+      ) {
+        remoteChanged++;
+      }
+    } else if (hashTask(remote) !== (snapshot.remoteHash ?? snapshot.hash)) {
+      remoteChanged++;
+    }
+  }
+  return remoteChanged;
+}
+
+function isRemoteUpdatedAfterLastSync(
+  remoteUpdatedAt: string,
+  snapshotUpdatedAt: string | undefined,
+  lastSyncedAt: string,
+): boolean {
+  if (!snapshotUpdatedAt || remoteUpdatedAt === snapshotUpdatedAt) return false;
+  const remoteTime = Date.parse(remoteUpdatedAt);
+  const lastSyncedTime = Date.parse(lastSyncedAt);
+  if (!Number.isFinite(remoteTime) || !Number.isFinite(lastSyncedTime)) return true;
+  return remoteTime > lastSyncedTime;
 }
 
 export const statusCommand = new Command("status")
@@ -45,19 +83,7 @@ export const statusCommand = new Command("status")
     }
 
     // Compute remote changes (aligned with pull's quick check)
-    let remoteChanged = 0;
-    for (const remote of remoteTasks) {
-      const snapshot = syncState.snapshots[remote.id];
-      if (!snapshot) {
-        remoteChanged++;
-      } else if (remote.updated_at && snapshot.updated_at) {
-        if (remote.updated_at !== snapshot.updated_at) {
-          remoteChanged++;
-        }
-      } else if (hashTask(remote) !== (snapshot.remoteHash ?? snapshot.hash)) {
-        remoteChanged++;
-      }
-    }
+    const remoteChanged = countRemoteChanges(remoteTasks, syncState);
 
     // Detect conflicts via 3-way merge
     interface StatusConflict {


### PR DESCRIPTION
## 概要
- pull 後に stale な snapshot.updated_at が残っていても、last_synced_at 以前の差分を remote_changed に数えないよう修正
- updated_at がない旧 sync-state では hash fallback を維持
- Issue #197 の regression test と requirements traceability を追加

## 検証
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/regressions/issue-169-status-false-remote-changes.test.ts src/__tests__/regressions/issue-197-status-remote-changed-stale-updated-at.test.ts
- pnpm run test:json
- pnpm build
- pnpm run req:trace
- pnpm run req:validate
- pnpm docs:gen
- gh-gantt status --json
- pre-push hook: test/build/req-trace/req-validate/docs-gen

Closes #197