### PR TITLE
feat(cli): sprint CLI CRUD を追加 (#199)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -219,7 +219,7 @@ areas:
         summary: コマンド体系
         acceptance_criteria:
           - id: FR-CLI-006-AC1
-            description: init/pull/push/status/create/list/show/update/link/context/serve/conflicts/resolve コマンドが定義されている
+            description: init/pull/push/status/create/list/show/update/link/context/sprint/serve/conflicts/resolve コマンドが定義されている
             status: covered
             tests:
               - packages/cli/src/__tests__/command-structure.test.ts
@@ -244,6 +244,19 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/context.test.ts
+      - id: FR-CLI-009
+        summary: スプリント設定 CRUD
+        acceptance_criteria:
+          - id: FR-CLI-009-AC1
+            description: sprint CLI で config の sprints を list/create/update/delete できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/sprint-command.test.ts
+          - id: FR-CLI-009-AC2
+            description: sprint CLI は重複 name と不正な日付範囲を拒否する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/sprint-command.test.ts
   - id: API
     name: REST API
     description: UI と CLI の間のデータアクセス層

--- a/packages/cli/src/__tests__/command-structure.test.ts
+++ b/packages/cli/src/__tests__/command-structure.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildProgram } from "../program.js";
 
-describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/context/serve/conflicts/resolve コマンドが定義されている", () => {
+describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/context/sprint/serve/conflicts/resolve コマンドが定義されている", () => {
   const program = buildProgram();
   const commandNames = program.commands.map((c) => c.name());
 
@@ -25,6 +25,10 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/co
 
   it("has 'context' as a top-level command", () => {
     expect(commandNames).toContain("context");
+  });
+
+  it("has 'sprint' as a top-level command", () => {
+    expect(commandNames).toContain("sprint");
   });
 
   // --- 既存のトップレベルコマンドは維持 ---

--- a/packages/cli/src/__tests__/sprint-command.test.ts
+++ b/packages/cli/src/__tests__/sprint-command.test.ts
@@ -1,0 +1,216 @@
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "@gh-gantt/shared";
+import { CONFIG_FILE, GANTT_DIR } from "@gh-gantt/shared";
+import { createSprintCommand } from "../commands/sprint.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    version: "1",
+    project: {
+      name: "test",
+      github: { owner: "owner", repo: "repo", project_number: 1 },
+    },
+    sync: {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000000", github_label: null },
+    },
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: {
+        critical_path: "#ff0000",
+        on_track: "#00ff00",
+        at_risk: "#ffff00",
+        overdue: "#ff0000",
+      },
+    },
+    ...overrides,
+  };
+}
+
+async function writeConfig(root: string, config: Config): Promise<void> {
+  const configDir = join(root, GANTT_DIR);
+  await mkdir(configDir, { recursive: true });
+  await writeFile(join(configDir, CONFIG_FILE), JSON.stringify(config, null, 2) + "\n");
+}
+
+async function readConfig(root: string): Promise<Config> {
+  const raw = await readFile(join(root, GANTT_DIR, CONFIG_FILE), "utf-8");
+  return JSON.parse(raw) as Config;
+}
+
+async function runSprintCommand(args: string[]): Promise<void> {
+  const command = createSprintCommand();
+  command.exitOverride();
+  await command.parseAsync(args, { from: "user" });
+}
+
+describe("[FR-CLI-009-AC1] sprint CLI で config の sprints を CRUD できる", () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+  let originalExitCode: number | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "gh-gantt-sprint-"));
+    originalCwd = process.cwd();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    process.chdir(tmpRoot);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await writeConfig(tmpRoot, makeConfig());
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("list/create/update/delete が JSON とテキスト出力で同じ sprint 設定を扱う", async () => {
+    await runSprintCommand([
+      "create",
+      "Sprint 1",
+      "--start-date",
+      "2026-05-04",
+      "--end-date",
+      "2026-05-15",
+      "--color",
+      "#123abc",
+      "--json",
+    ]);
+
+    const created = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string) as {
+      sprint: { name: string; start_date: string; end_date: string; color: string };
+    };
+    expect(created.sprint).toEqual({
+      name: "Sprint 1",
+      start_date: "2026-05-04",
+      end_date: "2026-05-15",
+      color: "#123abc",
+    });
+    await expect(readConfig(tmpRoot)).resolves.toMatchObject({
+      sprints: [created.sprint],
+    });
+
+    await runSprintCommand(["list", "--json"]);
+    const listed = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string) as {
+      sprints: (typeof created.sprint)[];
+    };
+    expect(listed.sprints).toEqual([created.sprint]);
+
+    await runSprintCommand([
+      "update",
+      "Sprint 1",
+      "--name",
+      "Sprint 1A",
+      "--start-date",
+      "2026-05-05",
+      "--end-date",
+      "2026-05-16",
+      "--color",
+      "#abcdef",
+      "--json",
+    ]);
+    const updated = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string) as {
+      sprint: { name: string; start_date: string; end_date: string; color: string };
+    };
+    expect(updated.sprint).toEqual({
+      name: "Sprint 1A",
+      start_date: "2026-05-05",
+      end_date: "2026-05-16",
+      color: "#abcdef",
+    });
+
+    await runSprintCommand(["delete", "Sprint 1A"]);
+    expect(logSpy.mock.calls.at(-1)?.[0]).toBe("Deleted sprint: Sprint 1A");
+    await expect(readConfig(tmpRoot)).resolves.toMatchObject({ sprints: [] });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("[FR-CLI-009-AC2] sprint CLI は重複 name と不正な日付範囲を拒否する", () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+  let originalExitCode: number | undefined;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "gh-gantt-sprint-invalid-"));
+    originalCwd = process.cwd();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    process.chdir(tmpRoot);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await writeConfig(
+      tmpRoot,
+      makeConfig({
+        sprints: [
+          {
+            name: "Sprint 1",
+            start_date: "2026-05-04",
+            end_date: "2026-05-15",
+            color: "#123abc",
+          },
+        ],
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("既存 name の create と end_date < start_date の update を失敗扱いにする", async () => {
+    await runSprintCommand([
+      "create",
+      "Sprint 1",
+      "--start-date",
+      "2026-06-01",
+      "--end-date",
+      "2026-06-14",
+      "--color",
+      "#654321",
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.at(-1)?.[0]).toContain("already exists");
+
+    process.exitCode = undefined;
+    await runSprintCommand([
+      "update",
+      "Sprint 1",
+      "--start-date",
+      "2026-05-20",
+      "--end-date",
+      "2026-05-10",
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.at(-1)?.[0]).toContain("start_date");
+    await expect(readConfig(tmpRoot)).resolves.toMatchObject({
+      sprints: [
+        {
+          name: "Sprint 1",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+          color: "#123abc",
+        },
+      ],
+    });
+  });
+});

--- a/packages/cli/src/commands/sprint.ts
+++ b/packages/cli/src/commands/sprint.ts
@@ -1,0 +1,286 @@
+import { Command } from "commander";
+import Table from "cli-table3";
+import { ConfigStore } from "../store/config.js";
+import type { Config, SprintConfig } from "@gh-gantt/shared";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export interface SprintCreateOptions {
+  startDate?: string;
+  endDate?: string;
+  color?: string;
+}
+
+export interface SprintUpdateOptions {
+  name?: string;
+  startDate?: string;
+  endDate?: string;
+  color?: string;
+}
+
+export interface SprintMutationResult {
+  config: Config;
+  sprint?: SprintConfig;
+  deleted?: SprintConfig;
+  error?: string;
+}
+
+function normalizeName(name: string): string {
+  return name.trim();
+}
+
+function isValidDateOnly(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+function validateSprintFields(sprint: SprintConfig): string | undefined {
+  if (sprint.name.length === 0) {
+    return "Sprint name must not be empty.";
+  }
+  if (!isValidDateOnly(sprint.start_date)) {
+    return `Invalid start date format: "${sprint.start_date}". Use YYYY-MM-DD.`;
+  }
+  if (!isValidDateOnly(sprint.end_date)) {
+    return `Invalid end date format: "${sprint.end_date}". Use YYYY-MM-DD.`;
+  }
+  if (sprint.start_date > sprint.end_date) {
+    return `Invalid date range: start_date (${sprint.start_date}) is after end_date (${sprint.end_date}).`;
+  }
+  if (!HEX_COLOR_RE.test(sprint.color)) {
+    return `Invalid color: "${sprint.color}". Use #RRGGBB.`;
+  }
+  return undefined;
+}
+
+function withSprints(config: Config, sprints: SprintConfig[]): Config {
+  return {
+    ...config,
+    sprints,
+  };
+}
+
+function sprintIndex(sprints: SprintConfig[], name: string): number {
+  const normalized = normalizeName(name);
+  return sprints.findIndex((sprint) => sprint.name === normalized);
+}
+
+export function listSprints(config: Config): SprintConfig[] {
+  return [...(config.sprints ?? [])];
+}
+
+export function createSprint(
+  config: Config,
+  name: string,
+  options: SprintCreateOptions,
+): SprintMutationResult {
+  const sprints = listSprints(config);
+  const sprint: SprintConfig = {
+    name: normalizeName(name),
+    start_date: options.startDate ?? "",
+    end_date: options.endDate ?? "",
+    color: options.color ?? "#3b82f6",
+  };
+
+  const validationError = validateSprintFields(sprint);
+  if (validationError) return { config, error: validationError };
+  if (sprintIndex(sprints, sprint.name) !== -1) {
+    return { config, error: `Sprint already exists: "${sprint.name}".` };
+  }
+
+  const nextConfig = withSprints(config, [...sprints, sprint]);
+  return { config: nextConfig, sprint };
+}
+
+export function updateSprint(
+  config: Config,
+  name: string,
+  options: SprintUpdateOptions,
+): SprintMutationResult {
+  const sprints = listSprints(config);
+  const index = sprintIndex(sprints, name);
+  if (index === -1) return { config, error: `Sprint not found: "${name}".` };
+
+  const current = sprints[index];
+  const sprint: SprintConfig = {
+    name: options.name !== undefined ? normalizeName(options.name) : current.name,
+    start_date: options.startDate ?? current.start_date,
+    end_date: options.endDate ?? current.end_date,
+    color: options.color ?? current.color,
+  };
+
+  const validationError = validateSprintFields(sprint);
+  if (validationError) return { config, error: validationError };
+
+  const duplicateIndex = sprintIndex(sprints, sprint.name);
+  if (duplicateIndex !== -1 && duplicateIndex !== index) {
+    return { config, error: `Sprint already exists: "${sprint.name}".` };
+  }
+
+  const nextSprints = [...sprints];
+  nextSprints[index] = sprint;
+  return { config: withSprints(config, nextSprints), sprint };
+}
+
+export function deleteSprint(config: Config, name: string): SprintMutationResult {
+  const sprints = listSprints(config);
+  const index = sprintIndex(sprints, name);
+  if (index === -1) return { config, error: `Sprint not found: "${name}".` };
+
+  const deleted = sprints[index];
+  const nextSprints = sprints.filter((_, i) => i !== index);
+  return { config: withSprints(config, nextSprints), deleted };
+}
+
+function formatSprintTable(sprints: SprintConfig[]): string {
+  const table = new Table({
+    head: ["Name", "Start", "End", "Color"],
+    style: { head: ["cyan"] },
+  });
+
+  for (const sprint of sprints) {
+    table.push([sprint.name, sprint.start_date, sprint.end_date, sprint.color]);
+  }
+
+  return table.toString();
+}
+
+async function readConfig(): Promise<{ store: ConfigStore; config: Config }> {
+  const store = new ConfigStore(process.cwd());
+  const config = await store.read();
+  return { store, config };
+}
+
+function fail(message: string): void {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+export function createSprintCommand(): Command {
+  const command = new Command("sprint").description("Manage sprint config");
+
+  command
+    .command("list")
+    .description("List configured sprints")
+    .option("--json", "Output sprints as JSON")
+    .action(async (opts) => {
+      try {
+        const { config } = await readConfig();
+        const sprints = listSprints(config);
+        if (opts.json) {
+          console.log(JSON.stringify({ sprints }, null, 2));
+          return;
+        }
+        if (sprints.length === 0) {
+          console.log("No sprints configured.");
+          return;
+        }
+        console.log(formatSprintTable(sprints));
+      } catch (err) {
+        fail(`Failed to list sprints: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  command
+    .command("create")
+    .description("Create a sprint in config")
+    .argument("<name>", "Sprint name")
+    .requiredOption("--start-date <date>", "Start date (YYYY-MM-DD)")
+    .requiredOption("--end-date <date>", "End date (YYYY-MM-DD)")
+    .requiredOption("--color <hex>", "Sprint color (#RRGGBB)")
+    .option("--json", "Output created sprint as JSON")
+    .action(async (name: string, opts) => {
+      try {
+        const { store, config } = await readConfig();
+        const result = createSprint(config, name, opts);
+        if (result.error || !result.sprint) {
+          fail(result.error ?? "Failed to create sprint.");
+          return;
+        }
+        await store.write(result.config);
+        if (opts.json) {
+          console.log(
+            JSON.stringify({ sprint: result.sprint, sprints: result.config.sprints }, null, 2),
+          );
+        } else {
+          console.log(`Created sprint: ${result.sprint.name}`);
+        }
+      } catch (err) {
+        fail(`Failed to create sprint: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  command
+    .command("update")
+    .description("Update a sprint in config")
+    .argument("<name>", "Current sprint name")
+    .option("--name <name>", "New sprint name")
+    .option("--start-date <date>", "Start date (YYYY-MM-DD)")
+    .option("--end-date <date>", "End date (YYYY-MM-DD)")
+    .option("--color <hex>", "Sprint color (#RRGGBB)")
+    .option("--json", "Output updated sprint as JSON")
+    .action(async (name: string, opts) => {
+      try {
+        const { store, config } = await readConfig();
+        const hasUpdate =
+          opts.name !== undefined ||
+          opts.startDate !== undefined ||
+          opts.endDate !== undefined ||
+          opts.color !== undefined;
+        if (!hasUpdate) {
+          fail("Specify at least one update option.");
+          return;
+        }
+        const result = updateSprint(config, name, opts);
+        if (result.error || !result.sprint) {
+          fail(result.error ?? "Failed to update sprint.");
+          return;
+        }
+        await store.write(result.config);
+        if (opts.json) {
+          console.log(
+            JSON.stringify({ sprint: result.sprint, sprints: result.config.sprints }, null, 2),
+          );
+        } else {
+          console.log(`Updated sprint: ${result.sprint.name}`);
+        }
+      } catch (err) {
+        fail(`Failed to update sprint: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  command
+    .command("delete")
+    .description("Delete a sprint from config")
+    .argument("<name>", "Sprint name")
+    .option("--json", "Output deleted sprint as JSON")
+    .action(async (name: string, opts) => {
+      try {
+        const { store, config } = await readConfig();
+        const result = deleteSprint(config, name);
+        if (result.error || !result.deleted) {
+          fail(result.error ?? "Failed to delete sprint.");
+          return;
+        }
+        await store.write(result.config);
+        if (opts.json) {
+          console.log(
+            JSON.stringify({ deleted: result.deleted, sprints: result.config.sprints }, null, 2),
+          );
+        } else {
+          console.log(`Deleted sprint: ${result.deleted.name}`);
+        }
+      } catch (err) {
+        fail(`Failed to delete sprint: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  return command;
+}
+
+export const sprintCommand = createSprintCommand();

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -13,6 +13,7 @@ import { conflictsCommand } from "./commands/conflicts.js";
 import { resolveCommand } from "./commands/resolve.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { contextCommand } from "./commands/context.js";
+import { sprintCommand } from "./commands/sprint.js";
 
 export function buildProgram(): Command {
   const program = new Command();
@@ -29,6 +30,7 @@ export function buildProgram(): Command {
   program.addCommand(resolveCommand);
   program.addCommand(doctorCommand);
   program.addCommand(contextCommand);
+  program.addCommand(sprintCommand);
 
   // Flattened task commands (formerly under `task` subcommand)
   program.addCommand(createTaskListCommand());


### PR DESCRIPTION
## 概要
- gh-gantt sprint サブコマンドを追加
- list/create/update/delete で config の sprints を CRUD 可能にした
- 重複 name、不正日付、逆転した日付範囲、hex color を検証する
- FR-CLI-009 と CLI テストを追加

## 検証
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/sprint-command.test.ts src/__tests__/command-structure.test.ts
- pnpm --filter @gh-gantt/cli exec vp check --fix src/commands/sprint.ts src/__tests__/sprint-command.test.ts src/__tests__/command-structure.test.ts src/program.ts
- pnpm exec tsx packages/cli/src/index.ts sprint list --json
- pnpm run test:json
- pnpm build
- pnpm run req:trace
- pnpm run req:validate
- pnpm docs:gen
- pre-push hook: test/build/req-trace/req-validate/docs-gen

## 発見した別課題
- vp check が未追跡の .claude/worktrees/ を走査し、無関係 warning を大量に出す問題を #200 として登録済み

Closes #199