### PR TITLE
test(ui): sprint band 表示の回帰テストを追加 (#203)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -286,6 +286,14 @@ areas:
             description: 自己参照・循環・階層違反を API レベルで拒否する
             status: uncovered
             tests: []
+      - id: FR-API-004
+        summary: Sprint 設定取得
+        acceptance_criteria:
+          - id: FR-API-004-AC1
+            description: GET /api/config が gantt.config.json の sprints 設定を返す
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/server-api.test.ts
   - id: VIS
     name: Visualization
     description: ガントチャートによるプロジェクト可視化
@@ -368,6 +376,24 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/useUndoRedo.test.ts
+      - id: FR-VIS-010
+        summary: スプリント期間バンド表示
+        acceptance_criteria:
+          - id: FR-VIS-010-AC1
+            description: config.sprints の期間をガントヘッダーとグリッド背景に表示する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/sprint-display.test.tsx
+          - id: FR-VIS-010-AC2
+            description: 現在日を含む sprint を他の sprint より強調表示する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/sprint-display.test.tsx
+          - id: FR-VIS-010-AC3
+            description: sprint が未設定の場合は既存ヘッダー高さとグリッド表示を維持する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/sprint-display.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -18,6 +18,70 @@ describe("createApiRouter", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it("[FR-API-004-AC1] GET /api/config は sprint 設定を返す", async () => {
+    const configStore = new ConfigStore(dir);
+    await configStore.write({
+      version: "1",
+      project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+      sync: {
+        auto_create_issues: false,
+        field_mapping: { start_date: "S", end_date: "E", status: "Status" },
+      },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#333333", github_label: null },
+      },
+      type_hierarchy: { task: [] },
+      statuses: { field_name: "Status", values: {} },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+      },
+      sprints: [
+        {
+          name: "Sprint 1",
+          start_date: "2026-04-01",
+          end_date: "2026-04-14",
+          color: "#123456",
+        },
+      ],
+    });
+
+    const router = createApiRouter(dir);
+    const routeLayer = router.stack.find((layer: any) => layer.route?.path === "/api/config");
+    const handler = routeLayer?.route?.stack?.[0]?.handle as
+      | ((req: unknown, res: unknown) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("GET /api/config handler not found");
+
+    let statusCode = 200;
+    let jsonPayload: unknown;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    await handler({}, res);
+
+    expect(statusCode).toBe(200);
+    expect(jsonPayload).toMatchObject({
+      sprints: [
+        {
+          name: "Sprint 1",
+          start_date: "2026-04-01",
+          end_date: "2026-04-14",
+          color: "#123456",
+        },
+      ],
+    });
+  });
+
   it("builds the progress task map only once per GET /api/tasks request", async () => {
     const configStore = new ConfigStore(dir);
     const tasksStore = new TasksStore(dir);

--- a/packages/ui/src/__tests__/sprint-display.test.tsx
+++ b/packages/ui/src/__tests__/sprint-display.test.tsx
@@ -1,7 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { scaleTime } from "d3-scale";
 import { GanttChart } from "../components/GanttChart.js";
+import { GanttGrid } from "../components/GanttGrid.js";
+import { GanttTimeline } from "../components/GanttTimeline.js";
 import { TaskTreeHeader } from "../components/TaskTree.js";
 import type { Config, Task } from "../types/index.js";
 import type { TreeNode } from "../hooks/useTaskTree.js";
@@ -98,9 +101,13 @@ const flatList: TreeNode[] = [
 ];
 
 const originalConsoleError = console.error.bind(console);
+const dateRange: [Date, Date] = [new Date(2026, 3, 1), new Date(2026, 3, 30)];
+const xScale = scaleTime().domain(dateRange).range([0, 300]);
 
 describe("Sprint display integration", () => {
   beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 7));
     vi.spyOn(console, "error").mockImplementation((message: unknown, ...args: unknown[]) => {
       if (
         typeof message === "string" &&
@@ -113,10 +120,31 @@ describe("Sprint display integration", () => {
   });
 
   afterAll(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("passes sprint config into the gantt grid rendering", () => {
+  it("[FR-VIS-010-AC1][FR-VIS-010-AC2] sprint config をヘッダーとグリッド背景に表示し、現在 sprint を強調する", () => {
+    const headerHtml = renderToStaticMarkup(
+      <GanttTimeline
+        xScale={xScale}
+        dateRange={dateRange}
+        viewScale="month"
+        totalWidth={300}
+        sprints={config.sprints}
+      />,
+    );
+    const gridHtml = renderToStaticMarkup(
+      <GanttGrid
+        xScale={xScale}
+        dateRange={dateRange}
+        totalWidth={300}
+        totalHeight={84}
+        workingDays={config.gantt.working_days}
+        pixelsPerDay={10}
+        sprints={config.sprints}
+      />,
+    );
     const html = renderToStaticMarkup(
       <GanttChart
         tasks={[task]}
@@ -128,13 +156,49 @@ describe("Sprint display integration", () => {
       />,
     );
 
+    expect(headerHtml).toContain("Sprint 1");
+    expect(headerHtml).toContain("#123456");
+    expect(headerHtml).toContain('fill-opacity="0.34"');
+    expect(gridHtml).toContain("#123456");
+    expect(gridHtml).toContain('fill-opacity="0.09"');
     expect(html).toContain("#123456");
   });
 
-  it("reserves extra task tree header height when sprint bands are enabled", () => {
+  it("[FR-VIS-010-AC1] sprint band 有効時はタスクツリーヘッダーに同じ高さを確保する", () => {
     const html = renderToStaticMarkup(<TaskTreeHeader config={config} />);
 
     expect(html).toContain("height:52px");
     expect(html).toContain("padding-top:20px");
+  });
+
+  it("[FR-VIS-010-AC3] sprint 未設定時は sprint band と追加ヘッダー余白を出さない", () => {
+    const configWithoutSprints: Config = { ...config, sprints: undefined };
+    const headerHtml = renderToStaticMarkup(
+      <GanttTimeline
+        xScale={xScale}
+        dateRange={dateRange}
+        viewScale="month"
+        totalWidth={300}
+        sprints={configWithoutSprints.sprints}
+      />,
+    );
+    const gridHtml = renderToStaticMarkup(
+      <GanttGrid
+        xScale={xScale}
+        dateRange={dateRange}
+        totalWidth={300}
+        totalHeight={84}
+        workingDays={config.gantt.working_days}
+        pixelsPerDay={10}
+        sprints={configWithoutSprints.sprints}
+      />,
+    );
+    const treeHeaderHtml = renderToStaticMarkup(<TaskTreeHeader config={configWithoutSprints} />);
+
+    expect(headerHtml).not.toContain("Sprint 1");
+    expect(headerHtml).not.toContain("#123456");
+    expect(gridHtml).not.toContain("#123456");
+    expect(treeHeaderHtml).toContain("height:32px");
+    expect(treeHeaderHtml).not.toContain("padding-top:20px");
   });
 });


### PR DESCRIPTION
## 概要
- GET /api/config が sprints 設定を返すことを API test で固定
- GanttTimeline と GanttGrid の sprint band 表示、現在 sprint 強調、未設定時の既存表示維持を UI test で固定
- requirements.yaml に FR-API-004 と FR-VIS-010 を追加し、req:trace で covered に更新

## 検証
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/sprint-display.test.tsx
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/server-api.test.ts
- pnpm lint
- pnpm run test:json
- pnpm build
- pnpm run req:trace
- pnpm run req:validate
- pnpm docs:gen
- git diff --check
- pre-push hook

Closes #203