### PR TITLE
feat(cli): sprint task 移動コマンドを追加 (#205)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -257,6 +257,24 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/sprint-command.test.ts
+      - id: FR-CLI-010
+        summary: スプリントへのタスク移動
+        acceptance_criteria:
+          - id: FR-CLI-010-AC1
+            description: sprint assign で指定 task の start_date/end_date を sprint 期間へ更新できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/sprint-command.test.ts
+          - id: FR-CLI-010-AC2
+            description: sprint carry-over で source sprint 内の未完了 task を target sprint へ移動できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/sprint-command.test.ts
+          - id: FR-CLI-010-AC3
+            description: unknown sprint、unknown task、不正な引数では失敗し既存 task を変更しない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/sprint-command.test.ts
   - id: API
     name: REST API
     description: UI と CLI の間のデータアクセス層

--- a/packages/cli/src/__tests__/sprint-command.test.ts
+++ b/packages/cli/src/__tests__/sprint-command.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Config } from "@gh-gantt/shared";
-import { CONFIG_FILE, GANTT_DIR } from "@gh-gantt/shared";
+import type { Config, Task, TasksFile } from "@gh-gantt/shared";
+import { CONFIG_FILE, GANTT_DIR, TASKS_FILE } from "@gh-gantt/shared";
 import { createSprintCommand } from "../commands/sprint.js";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -45,6 +45,52 @@ async function writeConfig(root: string, config: Config): Promise<void> {
 async function readConfig(root: string): Promise<Config> {
   const raw = await readFile(join(root, GANTT_DIR, CONFIG_FILE), "utf-8");
   return JSON.parse(raw) as Config;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "owner/repo#1",
+    type: "task",
+    github_issue: 1,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: "Task 1",
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: { Status: "Todo" },
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+async function writeTasks(root: string, tasks: Task[]): Promise<void> {
+  const configDir = join(root, GANTT_DIR);
+  await mkdir(configDir, { recursive: true });
+  const tasksFile: TasksFile = {
+    tasks,
+    cache: {
+      comments: { "owner/repo#1": [{ author: "bot", body: "cached", created_at: "2026-05-01" }] },
+      reactions: {},
+    },
+  };
+  await writeFile(join(configDir, TASKS_FILE), JSON.stringify(tasksFile, null, 2) + "\n");
+}
+
+async function readTasks(root: string): Promise<TasksFile> {
+  const raw = await readFile(join(root, GANTT_DIR, TASKS_FILE), "utf-8");
+  return JSON.parse(raw) as TasksFile;
 }
 
 async function runSprintCommand(args: string[]): Promise<void> {
@@ -212,5 +258,205 @@ describe("[FR-CLI-009-AC2] sprint CLI は重複 name と不正な日付範囲を
         },
       ],
     });
+  });
+});
+
+describe("[FR-CLI-010-AC1][FR-CLI-010-AC2][FR-CLI-010-AC3] sprint CLI で task を sprint へ移動できる", () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+  let originalExitCode: number | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  const sprintConfig = makeConfig({
+    statuses: {
+      field_name: "Status",
+      values: {
+        Todo: { color: "#3498db", done: false },
+        Done: { color: "#2ecc71", done: true },
+      },
+    },
+    sprints: [
+      {
+        name: "Sprint 1",
+        start_date: "2026-05-04",
+        end_date: "2026-05-15",
+        color: "#123abc",
+      },
+      {
+        name: "Sprint 2",
+        start_date: "2026-05-18",
+        end_date: "2026-05-29",
+        color: "#654321",
+      },
+    ],
+  });
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "gh-gantt-sprint-move-"));
+    originalCwd = process.cwd();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    process.chdir(tmpRoot);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await writeConfig(tmpRoot, sprintConfig);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("[FR-CLI-010-AC1] assign は指定 task の期間を sprint 期間に更新し JSON を返す", async () => {
+    await writeTasks(tmpRoot, [
+      makeTask({ id: "owner/repo#1", github_issue: 1, title: "Backlog task" }),
+      makeTask({
+        id: "owner/repo#2",
+        github_issue: 2,
+        title: "Scheduled task",
+        start_date: "2026-06-01",
+        end_date: "2026-06-03",
+      }),
+    ]);
+
+    await runSprintCommand(["assign", "Sprint 1", "1", "owner/repo#2", "--json"]);
+
+    const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string) as {
+      sprint: { name: string };
+      updated: Task[];
+    };
+    expect(payload.sprint.name).toBe("Sprint 1");
+    expect(payload.updated.map((task) => task.id)).toEqual(["owner/repo#1", "owner/repo#2"]);
+    expect(payload.updated).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "owner/repo#1",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+        expect.objectContaining({
+          id: "owner/repo#2",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+      ]),
+    );
+
+    const tasksFile = await readTasks(tmpRoot);
+    expect(tasksFile.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "owner/repo#1",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+        expect.objectContaining({
+          id: "owner/repo#2",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+      ]),
+    );
+    expect(tasksFile.cache.comments["owner/repo#1"]?.[0]?.body).toBe("cached");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("[FR-CLI-010-AC2] carry-over は source sprint 内の未完了 task だけを target sprint へ移す", async () => {
+    await writeTasks(tmpRoot, [
+      makeTask({
+        id: "owner/repo#1",
+        github_issue: 1,
+        title: "Open in sprint",
+        start_date: "2026-05-04",
+        end_date: "2026-05-15",
+      }),
+      makeTask({
+        id: "owner/repo#2",
+        github_issue: 2,
+        title: "Closed in sprint",
+        state: "closed",
+        start_date: "2026-05-04",
+        end_date: "2026-05-15",
+      }),
+      makeTask({
+        id: "owner/repo#3",
+        github_issue: 3,
+        title: "Done in sprint",
+        custom_fields: { Status: "Done" },
+        start_date: "2026-05-04",
+        end_date: "2026-05-15",
+      }),
+      makeTask({
+        id: "owner/repo#4",
+        github_issue: 4,
+        title: "Outside sprint",
+        start_date: "2026-06-01",
+        end_date: "2026-06-03",
+      }),
+    ]);
+
+    await runSprintCommand(["carry-over", "Sprint 1", "Sprint 2", "--json"]);
+
+    const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string) as {
+      from: { name: string };
+      to: { name: string };
+      updated: Task[];
+    };
+    expect(payload.from.name).toBe("Sprint 1");
+    expect(payload.to.name).toBe("Sprint 2");
+    expect(payload.updated.map((task) => task.id)).toEqual(["owner/repo#1"]);
+
+    const tasksFile = await readTasks(tmpRoot);
+    expect(tasksFile.tasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "owner/repo#1",
+          start_date: "2026-05-18",
+          end_date: "2026-05-29",
+        }),
+        expect.objectContaining({
+          id: "owner/repo#2",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+        expect.objectContaining({
+          id: "owner/repo#3",
+          start_date: "2026-05-04",
+          end_date: "2026-05-15",
+        }),
+        expect.objectContaining({
+          id: "owner/repo#4",
+          start_date: "2026-06-01",
+          end_date: "2026-06-03",
+        }),
+      ]),
+    );
+  });
+
+  it("[FR-CLI-010-AC3] unknown task と unknown sprint は失敗し task を変更しない", async () => {
+    const originalTask = makeTask({
+      id: "owner/repo#1",
+      github_issue: 1,
+      title: "Stable task",
+      start_date: "2026-06-01",
+      end_date: "2026-06-03",
+    });
+    await writeTasks(tmpRoot, [originalTask]);
+
+    await runSprintCommand(["assign", "Sprint 1", "999"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.at(-1)?.[0]).toContain("Task not found");
+    await expect(readTasks(tmpRoot)).resolves.toMatchObject({ tasks: [originalTask] });
+
+    process.exitCode = undefined;
+    await runSprintCommand(["carry-over", "Missing", "Sprint 2"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.at(-1)?.[0]).toContain('Sprint not found: "Missing"');
+    await expect(readTasks(tmpRoot)).resolves.toMatchObject({ tasks: [originalTask] });
   });
 });

--- a/packages/cli/src/commands/sprint.ts
+++ b/packages/cli/src/commands/sprint.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import Table from "cli-table3";
 import { ConfigStore } from "../store/config.js";
-import type { Config, SprintConfig } from "@gh-gantt/shared";
+import { TasksStore } from "../store/tasks.js";
+import { resolveTaskId } from "../util/task-id.js";
+import type { Config, SprintConfig, Task, TasksFile } from "@gh-gantt/shared";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
@@ -23,6 +25,21 @@ export interface SprintMutationResult {
   config: Config;
   sprint?: SprintConfig;
   deleted?: SprintConfig;
+  error?: string;
+}
+
+export interface SprintAssignResult {
+  tasks: Task[];
+  sprint?: SprintConfig;
+  updated?: Task[];
+  error?: string;
+}
+
+export interface SprintCarryOverResult {
+  tasks: Task[];
+  from?: SprintConfig;
+  to?: SprintConfig;
+  updated?: Task[];
   error?: string;
 }
 
@@ -137,6 +154,84 @@ export function deleteSprint(config: Config, name: string): SprintMutationResult
   return { config: withSprints(config, nextSprints), deleted };
 }
 
+function findSprint(config: Config, name: string): SprintConfig | undefined {
+  const sprints = listSprints(config);
+  const index = sprintIndex(sprints, name);
+  return index === -1 ? undefined : sprints[index];
+}
+
+function moveTaskToSprint(task: Task, sprint: SprintConfig): Task {
+  return {
+    ...task,
+    start_date: sprint.start_date,
+    end_date: sprint.end_date,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function isTaskDone(task: Task, config: Config): boolean {
+  if (task.state === "closed") return true;
+  const status = task.custom_fields[config.statuses.field_name];
+  return typeof status === "string" && config.statuses.values[status]?.done === true;
+}
+
+function isTaskWithinSprint(task: Task, sprint: SprintConfig): boolean {
+  return (
+    task.start_date !== null &&
+    task.end_date !== null &&
+    task.start_date >= sprint.start_date &&
+    task.end_date <= sprint.end_date
+  );
+}
+
+export function assignTasksToSprint(
+  config: Config,
+  tasks: Task[],
+  sprintName: string,
+  taskIds: string[],
+): SprintAssignResult {
+  const sprint = findSprint(config, sprintName);
+  if (!sprint) return { tasks, error: `Sprint not found: "${sprintName}".` };
+  if (taskIds.length === 0) return { tasks, error: "Specify at least one task." };
+
+  const taskSet = new Set(taskIds);
+  const missing = taskIds.filter((id) => !tasks.some((task) => task.id === id));
+  if (missing.length > 0) return { tasks, error: `Task not found: ${missing.join(", ")}` };
+
+  const updated: Task[] = [];
+  const nextTasks = tasks.map((task) => {
+    if (!taskSet.has(task.id)) return task;
+    const moved = moveTaskToSprint(task, sprint);
+    updated.push(moved);
+    return moved;
+  });
+
+  return { tasks: nextTasks, sprint, updated };
+}
+
+export function carryOverSprintTasks(
+  config: Config,
+  tasks: Task[],
+  fromName: string,
+  toName: string,
+): SprintCarryOverResult {
+  const from = findSprint(config, fromName);
+  if (!from) return { tasks, error: `Sprint not found: "${fromName}".` };
+  const to = findSprint(config, toName);
+  if (!to) return { tasks, error: `Sprint not found: "${toName}".` };
+  if (from.name === to.name) return { tasks, error: "Source and target sprint must differ." };
+
+  const updated: Task[] = [];
+  const nextTasks = tasks.map((task) => {
+    if (isTaskDone(task, config) || !isTaskWithinSprint(task, from)) return task;
+    const moved = moveTaskToSprint(task, to);
+    updated.push(moved);
+    return moved;
+  });
+
+  return { tasks: nextTasks, from, to, updated };
+}
+
 function formatSprintTable(sprints: SprintConfig[]): string {
   const table = new Table({
     head: ["Name", "Start", "End", "Color"],
@@ -154,6 +249,22 @@ async function readConfig(): Promise<{ store: ConfigStore; config: Config }> {
   const store = new ConfigStore(process.cwd());
   const config = await store.read();
   return { store, config };
+}
+
+async function readProject(): Promise<{
+  config: Config;
+  tasksStore: TasksStore;
+  tasksFile: TasksFile;
+}> {
+  const projectRoot = process.cwd();
+  const config = await new ConfigStore(projectRoot).read();
+  const tasksStore = new TasksStore(projectRoot);
+  const tasksFile = await tasksStore.read();
+  return { config, tasksStore, tasksFile };
+}
+
+function shortTaskId(task: Task): string {
+  return task.id.includes("#") ? task.id.split("#")[1]! : task.id;
 }
 
 function fail(message: string): void {
@@ -277,6 +388,69 @@ export function createSprintCommand(): Command {
         }
       } catch (err) {
         fail(`Failed to delete sprint: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  command
+    .command("assign")
+    .description("Move tasks into a sprint date range")
+    .argument("<sprint>", "Sprint name")
+    .argument("<task...>", "Task IDs to assign")
+    .option("--json", "Output updated tasks as JSON")
+    .action(async (sprintName: string, taskIds: string[], opts) => {
+      try {
+        const { config, tasksStore, tasksFile } = await readProject();
+        const resolvedTaskIds = taskIds.map((id) => resolveTaskId(id, config));
+        const result = assignTasksToSprint(config, tasksFile.tasks, sprintName, resolvedTaskIds);
+        if (result.error || !result.sprint || !result.updated) {
+          fail(result.error ?? "Failed to assign tasks to sprint.");
+          return;
+        }
+        await tasksStore.write({ ...tasksFile, tasks: result.tasks });
+        if (opts.json) {
+          console.log(JSON.stringify({ sprint: result.sprint, updated: result.updated }, null, 2));
+        } else {
+          console.log(`Assigned ${result.updated.length} task(s) to sprint: ${result.sprint.name}`);
+          for (const task of result.updated) {
+            console.log(`  ${shortTaskId(task)}: ${task.title}`);
+          }
+        }
+      } catch (err) {
+        fail(`Failed to assign sprint: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  command
+    .command("carry-over")
+    .description("Move unfinished tasks from one sprint to another")
+    .argument("<from>", "Source sprint name")
+    .argument("<to>", "Target sprint name")
+    .option("--json", "Output carried-over tasks as JSON")
+    .action(async (fromName: string, toName: string, opts) => {
+      try {
+        const { config, tasksStore, tasksFile } = await readProject();
+        const result = carryOverSprintTasks(config, tasksFile.tasks, fromName, toName);
+        if (result.error || !result.from || !result.to || !result.updated) {
+          fail(result.error ?? "Failed to carry over sprint tasks.");
+          return;
+        }
+        await tasksStore.write({ ...tasksFile, tasks: result.tasks });
+        if (opts.json) {
+          console.log(
+            JSON.stringify({ from: result.from, to: result.to, updated: result.updated }, null, 2),
+          );
+        } else if (result.updated.length === 0) {
+          console.log(`No unfinished tasks found in sprint: ${result.from.name}`);
+        } else {
+          console.log(
+            `Carried over ${result.updated.length} task(s): ${result.from.name} → ${result.to.name}`,
+          );
+          for (const task of result.updated) {
+            console.log(`  ${shortTaskId(task)}: ${task.title}`);
+          }
+        }
+      } catch (err) {
+        fail(`Failed to carry over sprint: ${err instanceof Error ? err.message : String(err)}`);
       }
     });
 


### PR DESCRIPTION
## 概要
- gh-gantt sprint assign を追加し、指定 task の start_date/end_date を sprint 期間へ更新
- gh-gantt sprint carry-over を追加し、source sprint 内の未完了 task を target sprint へ移動
- unknown sprint / unknown task / 同一 sprint 指定を失敗扱いにし、失敗時は task を変更しない
- FR-CLI-010 を requirements.yaml に追加し、sprint-command test で traceable に検証

## 検証
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/sprint-command.test.ts
- pnpm lint
- pnpm run test:json
- pnpm build
- pnpm run req:trace
- pnpm run req:validate
- pnpm docs:gen
- git diff --check
- pre-push hook

Closes #205