### PR TITLE
feat(ui): sprint 移動 UI を追加 (#207)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -312,6 +312,14 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/server-api.test.ts
+      - id: FR-API-005
+        summary: スプリント期間へのタスク日付更新
+        acceptance_criteria:
+          - id: FR-API-005-AC1
+            description: PATCH /api/tasks/:id が sprint 期間として渡された start_date/end_date を保存できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/server-api.test.ts
   - id: VIS
     name: Visualization
     description: ガントチャートによるプロジェクト可視化
@@ -412,6 +420,24 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/sprint-display.test.tsx
+      - id: FR-VIS-011
+        summary: スプリントへのタスク移動 UI
+        acceptance_criteria:
+          - id: FR-VIS-011-AC1
+            description: タスク詳細パネルで選択タスクの現在 sprint を表示し、configured sprint を選択できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
+          - id: FR-VIS-011-AC2
+            description: sprint を選択すると task の start_date/end_date を sprint 期間へ更新する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
+          - id: FR-VIS-011-AC3
+            description: sprint 未設定時は既存の詳細パネル表示を維持する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -430,4 +430,103 @@ describe("createApiRouter", () => {
     expect(written.tasks[0].type).toBe("task");
     expect(written.tasks[0].labels).toEqual(["task", "keep"]);
   });
+
+  it("[FR-API-005-AC1] PATCH /api/tasks/:id は sprint 期間への日付更新を保存する", async () => {
+    const configStore = new ConfigStore(dir);
+    const tasksStore = new TasksStore(dir);
+
+    await configStore.write({
+      version: "1",
+      project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+      sync: {
+        auto_create_issues: false,
+        field_mapping: { start_date: "S", end_date: "E", status: "Status" },
+      },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#333333", github_label: "task" },
+      },
+      type_hierarchy: {},
+      statuses: { field_name: "Status", values: {} },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+      },
+      sprints: [
+        {
+          name: "Sprint 2",
+          start_date: "2026-04-15",
+          end_date: "2026-04-28",
+          color: "#123456",
+        },
+      ],
+    });
+    await tasksStore.write({
+      tasks: [
+        {
+          id: "o/r#1",
+          type: "task",
+          github_issue: 1,
+          github_repo: "o/r",
+          parent: null,
+          sub_tasks: [],
+          title: "Task",
+          body: null,
+          state: "open" as const,
+          state_reason: null,
+          assignees: [],
+          labels: ["task"],
+          milestone: null,
+          linked_prs: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          closed_at: null,
+          custom_fields: {},
+          start_date: null,
+          end_date: null,
+          date: null,
+          blocked_by: [],
+        },
+      ],
+      cache: { comments: {}, reactions: {} },
+    });
+
+    const router = createApiRouter(dir);
+    const routeLayer = router.stack.find(
+      (layer: any) => layer.route?.path === "/api/tasks/:id" && layer.route?.methods?.patch,
+    );
+    const handler = routeLayer?.route?.stack?.[0]?.handle as
+      | ((req: unknown, res: unknown) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("PATCH /api/tasks/:id handler not found");
+
+    let statusCode = 200;
+    let jsonPayload: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    await handler(
+      {
+        params: { id: encodeURIComponent("o/r#1") },
+        body: { start_date: "2026-04-15", end_date: "2026-04-28" },
+      },
+      res,
+    );
+
+    const written = await tasksStore.read();
+
+    expect(statusCode).toBe(200);
+    expect(jsonPayload.start_date).toBe("2026-04-15");
+    expect(jsonPayload.end_date).toBe("2026-04-28");
+    expect(written.tasks[0].start_date).toBe("2026-04-15");
+    expect(written.tasks[0].end_date).toBe("2026-04-28");
+  });
 });

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -1,6 +1,9 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
 import { TaskDetailPanel } from "../components/TaskDetailPanel.js";
 import type { Task, Config } from "../types/index.js";
 
@@ -67,7 +70,29 @@ const config: Config = {
   },
 };
 
+const sprintConfig: Config = {
+  ...config,
+  sprints: [
+    {
+      name: "Sprint 1",
+      start_date: "2026-01-01",
+      end_date: "2026-01-14",
+      color: "#2563eb",
+    },
+    {
+      name: "Sprint 2",
+      start_date: "2026-02-01",
+      end_date: "2026-02-14",
+      color: "#16a34a",
+    },
+  ],
+};
+
 describe("TaskDetailPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders title and issue number", () => {
     const task = makeTask();
     const html = renderToStaticMarkup(
@@ -119,5 +144,72 @@ describe("TaskDetailPanel", () => {
     );
 
     expect(html).toContain("Child Task Title");
+  });
+
+  it("[FR-VIS-011-AC1][FR-VIS-011-AC2] sprint 選択で task の期間を sprint 期間へ更新する", () => {
+    const task = makeTask({
+      start_date: null,
+      end_date: null,
+    });
+    const onUpdate = vi.fn();
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={sprintConfig}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
+    );
+
+    const select = getByLabelText("Sprint") as HTMLSelectElement;
+    expect(select.value).toBe("");
+
+    fireEvent.change(select, { target: { value: "Sprint 2" } });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      start_date: "2026-02-01",
+      end_date: "2026-02-14",
+    });
+  });
+
+  it("[FR-VIS-011-AC1] task の期間が sprint 内にある場合は現在 sprint として表示する", () => {
+    const task = makeTask({
+      start_date: "2026-01-02",
+      end_date: "2026-01-10",
+    });
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={sprintConfig}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
+    );
+
+    const select = getByLabelText("Sprint") as HTMLSelectElement;
+    expect(select.value).toBe("Sprint 1");
+  });
+
+  it("[FR-VIS-011-AC3] sprint 未設定では sprint 選択を表示しない", () => {
+    const task = makeTask();
+    const { queryByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={config}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
+    );
+
+    expect(queryByLabelText("Sprint")).toBeNull();
   });
 });

--- a/packages/ui/src/components/TaskDetailPanel.tsx
+++ b/packages/ui/src/components/TaskDetailPanel.tsx
@@ -6,6 +6,7 @@ import { DetailHeader } from "./detail/DetailHeader.js";
 import { DetailMetaSidebar } from "./detail/DetailMetaSidebar.js";
 import { DetailSubTasks } from "./detail/DetailSubTasks.js";
 import { DetailRelations } from "./detail/DetailRelations.js";
+import { DetailSprintControl } from "./detail/DetailSprintControl.js";
 import { formatUpdatedAt } from "../lib/date-utils.js";
 
 const MIN_PANEL_WIDTH = 320;
@@ -504,6 +505,8 @@ export function TaskDetailPanel({
               </span>
             ))}
           </div>
+
+          {!isMilestone && <DetailSprintControl task={task} config={config} onUpdate={onUpdate} />}
 
           {/* Description */}
           <div>

--- a/packages/ui/src/components/detail/DetailMetaSidebar.tsx
+++ b/packages/ui/src/components/detail/DetailMetaSidebar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Task, Config } from "../../types/index.js";
 import { formatUpdatedAt } from "../../lib/date-utils.js";
+import { DetailSprintControl } from "./DetailSprintControl.js";
 
 interface DetailMetaSidebarProps {
   task: Task;
@@ -119,6 +120,8 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
           </select>
         </div>
       )}
+
+      {!isMilestone && <DetailSprintControl task={task} config={config} onUpdate={onUpdate} />}
 
       {/* Dates (with separator) */}
       <div style={separatorStyle}>

--- a/packages/ui/src/components/detail/DetailSprintControl.tsx
+++ b/packages/ui/src/components/detail/DetailSprintControl.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import type { Config, SprintConfig, Task } from "../../types/index.js";
+
+interface DetailSprintControlProps {
+  task: Task;
+  config: Config;
+  onUpdate: (updates: Partial<Task>) => void;
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--color-text-muted)",
+  marginBottom: 4,
+  fontWeight: 600,
+  display: "block",
+};
+
+const selectStyle: React.CSSProperties = {
+  padding: "4px 8px",
+  fontSize: 12,
+  border: "1px solid var(--color-border)",
+  borderRadius: 4,
+  width: "100%",
+  background: "var(--color-bg)",
+  color: "var(--color-text)",
+};
+
+function isTaskInSprint(task: Task, sprint: SprintConfig): boolean {
+  return Boolean(
+    task.start_date &&
+    task.end_date &&
+    task.start_date >= sprint.start_date &&
+    task.end_date <= sprint.end_date,
+  );
+}
+
+export function findTaskSprint(task: Task, sprints: SprintConfig[]): SprintConfig | undefined {
+  return sprints.find((sprint) => isTaskInSprint(task, sprint));
+}
+
+export function DetailSprintControl({ task, config, onUpdate }: DetailSprintControlProps) {
+  const sprints = config.sprints ?? [];
+  if (sprints.length === 0) return null;
+
+  const selectedSprint = findTaskSprint(task, sprints);
+
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <label style={labelStyle}>Sprint</label>
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <select
+          aria-label="Sprint"
+          value={selectedSprint?.name ?? ""}
+          onChange={(e) => {
+            const sprint = sprints.find((candidate) => candidate.name === e.target.value);
+            if (!sprint) return;
+            onUpdate({
+              start_date: sprint.start_date,
+              end_date: sprint.end_date,
+            });
+          }}
+          style={selectStyle}
+        >
+          <option value="">Custom / Backlog</option>
+          {sprints.map((sprint) => (
+            <option key={sprint.name} value={sprint.name}>
+              {sprint.name}
+            </option>
+          ))}
+        </select>
+        {selectedSprint && (
+          <span
+            aria-hidden="true"
+            style={{
+              width: 10,
+              height: 10,
+              flexShrink: 0,
+              borderRadius: 2,
+              background: selectedSprint.color,
+              border: "1px solid var(--color-border)",
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
- タスク詳細パネルに sprint 選択 UI を追加
- 選択した sprint 期間を start_date/end_date として PATCH 保存
- UI/API の回帰テストと requirements を追加

## 検証
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/detail-panel.test.tsx
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/server-api.test.ts
- pnpm lint
- pnpm run test:json
- pnpm build
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen