### PR TITLE
feat(ui): Linked PR のタイトル表示を追加 (#101)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -82,6 +82,19 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/rebase.test.ts
+      - id: FR-SYNC-007
+        summary: Linked PR メタデータ同期
+        acceptance_criteria:
+          - id: FR-SYNC-007-AC1
+            description: GitHub Issue に紐づく PR の number/title/state/url を取得できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/fetch-project.test.ts
+          - id: FR-SYNC-007-AC2
+            description: 取得した linked PR メタデータを Task.linked_prs にマッピングできる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/mapper.test.ts
       - id: NFR-SYNC-001
         summary: push 中の障害耐性
         acceptance_criteria:
@@ -438,6 +451,19 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/detail-panel.test.tsx
+      - id: FR-VIS-012
+        summary: Linked PR のタイトル表示
+        acceptance_criteria:
+          - id: FR-VIS-012-AC1
+            description: TaskDetailPanel の Linked PRs セクションで PR タイトルを表示する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-relations.test.tsx
+          - id: FR-VIS-012-AC2
+            description: Linked PRs セクションで PR state をバッジとして表示する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-relations.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション
@@ -458,6 +484,14 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/store.test.ts
+      - id: FR-STORE-003
+        summary: Linked PR メタデータの保存形式
+        acceptance_criteria:
+          - id: FR-STORE-003-AC1
+            description: Task.linked_prs は legacy number と metadata object の両方を受理できる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/schema.test.ts
       - id: NFR-STORE-001
         summary: スキーマバリデーション
         acceptance_criteria:

--- a/packages/cli/src/__tests__/fetch-project.test.ts
+++ b/packages/cli/src/__tests__/fetch-project.test.ts
@@ -36,6 +36,7 @@ function makeIssueItem(overrides: Partial<Record<string, unknown>> = {}) {
       createdAt: "2026-01-01",
       updatedAt: "2026-01-01",
       closedAt: null,
+      closedByPullRequestsReferences: { nodes: [] },
       repository: { nameWithOwner: "owner/repo" },
       ...overrides,
     },
@@ -97,5 +98,35 @@ describe("fetchProject", () => {
     const result = await fetchProject(gql, "stanah", 5, "user");
     expect(result.items).toHaveLength(0);
     expect(result.projectTitle).toBe("Test Project");
+  });
+
+  it("[FR-SYNC-007-AC1] Issue に紐づく PR の番号・タイトル・状態を取得する", async () => {
+    const gql = vi.fn().mockResolvedValueOnce(
+      makeProjectResponse([
+        makeIssueItem({
+          closedByPullRequestsReferences: {
+            nodes: [
+              {
+                number: 100,
+                title: "Fix task detail relation display",
+                state: "MERGED",
+                url: "https://github.com/owner/repo/pull/100",
+              },
+            ],
+          },
+        }),
+      ]),
+    ) as any;
+
+    const result = await fetchProject(gql, "stanah", 5, "user");
+
+    expect(result.items[0].content?.linkedPullRequests).toEqual([
+      {
+        number: 100,
+        title: "Fix task detail relation display",
+        state: "merged",
+        url: "https://github.com/owner/repo/pull/100",
+      },
+    ]);
   });
 });

--- a/packages/cli/src/__tests__/mapper.test.ts
+++ b/packages/cli/src/__tests__/mapper.test.ts
@@ -31,6 +31,7 @@ function makeItem(overrides: Record<string, unknown> = {}) {
       assignees: ["alice"],
       labels: ["bug"],
       milestone: "v1.0",
+      linkedPullRequests: [],
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-01-02T00:00:00Z",
       closedAt: null,
@@ -85,6 +86,7 @@ describe("[FR-SYNC-004-AC1] GitHub Project Item をローカル Task 形式に�
         assignees: [],
         labels: [],
         milestone: null,
+        linkedPullRequests: [],
         createdAt: "2026-01-01T00:00:00Z",
         updatedAt: "2026-01-01T00:00:00Z",
         closedAt: null,
@@ -161,6 +163,33 @@ describe("[FR-SYNC-004-AC1] GitHub Project Item をローカル Task 形式に�
       Status: "In Progress",
       Priority: "High",
     });
+  });
+
+  it("[FR-SYNC-007-AC2] linked PR メタデータを Task にマッピングする", () => {
+    const item = makeItem({
+      content: {
+        ...makeItem().content,
+        linkedPullRequests: [
+          {
+            number: 100,
+            title: "Show linked PR title",
+            state: "merged",
+            url: "https://github.com/owner/repo/pull/100",
+          },
+        ],
+      },
+    });
+
+    const task = mapRemoteItemToTask(item, makeConfig());
+
+    expect(task!.linked_prs).toEqual([
+      {
+        number: 100,
+        title: "Show linked PR title",
+        state: "merged",
+        url: "https://github.com/owner/repo/pull/100",
+      },
+    ]);
   });
 
   it("defaults type to 'task' when no label or field value matches", () => {

--- a/packages/cli/src/github/projects.ts
+++ b/packages/cli/src/github/projects.ts
@@ -28,6 +28,12 @@ export interface RawProjectItem {
     closedAt: string | null;
     issueType: string | null;
     repository: string;
+    linkedPullRequests: Array<{
+      number: number;
+      title: string;
+      state: string;
+      url: string | null;
+    }>;
   } | null;
 }
 
@@ -104,6 +110,14 @@ export async function fetchProject(
           closedAt: content.closedAt,
           issueType: content.issueType?.name ?? null,
           repository: content.repository.nameWithOwner,
+          linkedPullRequests: (content.closedByPullRequestsReferences?.nodes ?? []).map(
+            (pr: any) => ({
+              number: pr.number,
+              title: pr.title,
+              state: String(pr.state).toLowerCase(),
+              url: pr.url ?? null,
+            }),
+          ),
         },
       });
     }

--- a/packages/cli/src/github/queries.ts
+++ b/packages/cli/src/github/queries.ts
@@ -64,6 +64,14 @@ const PROJECT_V2_FRAGMENT = `
                 createdAt
                 updatedAt
                 closedAt
+                closedByPullRequestsReferences(first: 20) {
+                  nodes {
+                    number
+                    title
+                    state
+                    url
+                  }
+                }
                 repository { nameWithOwner }
               }
             }

--- a/packages/cli/src/sync/mapper.ts
+++ b/packages/cli/src/sync/mapper.ts
@@ -35,7 +35,7 @@ export function mapRemoteItemToTask(item: RawProjectItem, config: Config): Task 
     assignees: c.assignees,
     labels: c.labels,
     milestone: c.milestone,
-    linked_prs: [],
+    linked_prs: c.linkedPullRequests,
     created_at: c.createdAt,
     updated_at: c.updatedAt,
     closed_at: c.closedAt,

--- a/packages/shared/src/__tests__/schema.test.ts
+++ b/packages/shared/src/__tests__/schema.test.ts
@@ -252,6 +252,28 @@ describe("TasksFileSchema", () => {
     expect(() => TasksFileSchema.parse(data)).not.toThrow();
   });
 
+  it("[FR-STORE-003-AC1] linked_prs はメタデータ付き PR と legacy number の両方を受理する", () => {
+    const data = {
+      tasks: [
+        {
+          ...validTask,
+          linked_prs: [
+            42,
+            {
+              number: 100,
+              title: "Show linked PR title",
+              state: "merged",
+              url: "https://github.com/owner/repo/pull/100",
+            },
+          ],
+        },
+      ],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    expect(() => TasksFileSchema.parse(data)).not.toThrow();
+  });
+
   it("should strip unknown keys from tasks (strict mode)", () => {
     const taskWithMarkers = {
       ...validTask,

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type {
   Config,
   Dependency,
+  LinkedPullRequest,
   SprintConfig,
   Statuses,
   SyncFields,
@@ -56,6 +57,15 @@ export const DependencySchema: z.ZodType<Dependency> = z.object({
   lag: z.number(),
 });
 
+export const LinkedPullRequestSchema: z.ZodType<LinkedPullRequest> = z.object({
+  number: z.number(),
+  title: z.string(),
+  state: z.string(),
+  url: z.string().nullable(),
+});
+
+const LinkedPullRequestRefSchema = z.union([z.number(), LinkedPullRequestSchema]);
+
 const TaskSchemaObject = z.object({
   id: z.string(),
   type: z.string(),
@@ -70,7 +80,7 @@ const TaskSchemaObject = z.object({
   assignees: z.array(z.string()),
   labels: z.array(z.string()),
   milestone: z.string().nullable(),
-  linked_prs: z.array(z.number()),
+  linked_prs: z.array(LinkedPullRequestRefSchema),
   created_at: z.string(),
   updated_at: z.string(),
   closed_at: z.string().nullable(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -36,6 +36,15 @@ export interface Dependency {
   lag: number;
 }
 
+export interface LinkedPullRequest {
+  number: number;
+  title: string;
+  state: string;
+  url: string | null;
+}
+
+export type LinkedPullRequestRef = number | LinkedPullRequest;
+
 export interface Task {
   id: string;
   type: string;
@@ -51,7 +60,7 @@ export interface Task {
   assignees: string[];
   labels: string[];
   milestone: string | null;
-  linked_prs: number[];
+  linked_prs: LinkedPullRequestRef[];
   created_at: string;
   updated_at: string;
   closed_at: string | null;

--- a/packages/ui/src/__tests__/detail-relations.test.tsx
+++ b/packages/ui/src/__tests__/detail-relations.test.tsx
@@ -62,7 +62,7 @@ describe("DetailRelations", () => {
     expect(html).toContain("#10");
   });
 
-  it("renders Linked PRs with correct links", () => {
+  it("renders legacy numeric Linked PRs with correct links", () => {
     const html = renderToStaticMarkup(
       <DetailRelations
         blockedBy={[]}
@@ -77,5 +77,37 @@ describe("DetailRelations", () => {
     expect(html).toContain("https://github.com/stanah/gh-gantt/pull/99");
     expect(html).toContain("#42");
     expect(html).toContain("#99");
+  });
+
+  it("[FR-VIS-012-AC1][FR-VIS-012-AC2] Linked PRs にタイトルと状態バッジを表示する", () => {
+    const html = renderToStaticMarkup(
+      <DetailRelations
+        blockedBy={[]}
+        linkedPrs={[
+          {
+            number: 100,
+            title: "Fix relation details",
+            state: "merged",
+            url: "https://github.com/stanah/gh-gantt/pull/100",
+          },
+          {
+            number: 101,
+            title: "Open follow-up",
+            state: "open",
+            url: null,
+          },
+        ]}
+        allTasks={[]}
+        onSelectTask={vi.fn()}
+        githubRepo="stanah/gh-gantt"
+      />,
+    );
+
+    expect(html).toContain("Fix relation details");
+    expect(html).toContain("Open follow-up");
+    expect(html).toContain("Merged");
+    expect(html).toContain("Open");
+    expect(html).toContain("https://github.com/stanah/gh-gantt/pull/100");
+    expect(html).toContain("https://github.com/stanah/gh-gantt/pull/101");
   });
 });

--- a/packages/ui/src/components/detail/DetailRelations.tsx
+++ b/packages/ui/src/components/detail/DetailRelations.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import type { Dependency, Task } from "../../types/index.js";
+import type { Dependency, LinkedPullRequestRef, Task } from "../../types/index.js";
 
 interface DetailRelationsProps {
   blockedBy: Dependency[];
-  linkedPrs: number[];
+  linkedPrs: LinkedPullRequestRef[];
   allTasks: Task[];
   onSelectTask: (taskId: string) => void;
   githubRepo: string;
@@ -16,6 +16,56 @@ const sectionHeaderStyle: React.CSSProperties = {
   display: "block",
   marginBottom: 4,
 };
+
+function normalizeLinkedPr(pr: LinkedPullRequestRef): {
+  number: number;
+  title: string | null;
+  state: string | null;
+  url: string | null;
+} {
+  if (typeof pr === "number") {
+    return { number: pr, title: null, state: null, url: null };
+  }
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state.toLowerCase(),
+    url: pr.url,
+  };
+}
+
+function formatPrState(state: string): string {
+  switch (state) {
+    case "merged":
+      return "Merged";
+    case "open":
+      return "Open";
+    case "closed":
+      return "Closed";
+    default:
+      return state;
+  }
+}
+
+function prStateStyle(state: string): React.CSSProperties {
+  const normalized = state.toLowerCase();
+  const color =
+    normalized === "merged"
+      ? "var(--color-complete)"
+      : normalized === "open"
+        ? "var(--color-success)"
+        : "var(--color-text-muted)";
+
+  return {
+    flexShrink: 0,
+    padding: "1px 6px",
+    borderRadius: 3,
+    fontSize: 10,
+    lineHeight: "14px",
+    color,
+    background: "var(--color-border-light)",
+  };
+}
 
 export function DetailRelations({
   blockedBy,
@@ -85,28 +135,48 @@ export function DetailRelations({
       {linkedPrs.length > 0 && (
         <div>
           <span style={sectionHeaderStyle}>Linked PRs</span>
-          {linkedPrs.map((pr) => (
-            <div
-              key={pr}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                fontSize: 12,
-                padding: "2px 0",
-              }}
-            >
-              <span style={{ color: "var(--color-complete)", flexShrink: 0 }}>&#8853;</span>
-              <a
-                href={`https://github.com/${githubRepo}/pull/${pr}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: "var(--color-info)", fontSize: 12 }}
+          {linkedPrs.map((pr) => {
+            const linkedPr = normalizeLinkedPr(pr);
+            const url = linkedPr.url ?? `https://github.com/${githubRepo}/pull/${linkedPr.number}`;
+            return (
+              <div
+                key={linkedPr.number}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontSize: 12,
+                  padding: "2px 0",
+                  minWidth: 0,
+                }}
               >
-                #{pr}
-              </a>
-            </div>
-          ))}
+                <span style={{ color: "var(--color-complete)", flexShrink: 0 }}>&#8853;</span>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: "var(--color-info)", fontSize: 12, flexShrink: 0 }}
+                >
+                  #{linkedPr.number}
+                </a>
+                {linkedPr.title && (
+                  <span
+                    style={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      color: "var(--color-text)",
+                    }}
+                  >
+                    {linkedPr.title}
+                  </span>
+                )}
+                {linkedPr.state && (
+                  <span style={prStateStyle(linkedPr.state)}>{formatPrState(linkedPr.state)}</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -22,6 +22,15 @@ export interface Dependency {
   lag: number;
 }
 
+export interface LinkedPullRequest {
+  number: number;
+  title: string;
+  state: string;
+  url: string | null;
+}
+
+export type LinkedPullRequestRef = number | LinkedPullRequest;
+
 export interface Task {
   id: string;
   type: string;
@@ -36,7 +45,7 @@ export interface Task {
   assignees: string[];
   labels: string[];
   milestone: string | null;
-  linked_prs: number[];
+  linked_prs: LinkedPullRequestRef[];
   created_at: string;
   updated_at: string;
   closed_at: string | null;


### PR DESCRIPTION
## 概要
- GitHub Issue に紐づく PR の number/title/state/url を pull 時に取得
- Task.linked_prs を legacy number と metadata object の両対応に拡張
- DetailRelations で PR タイトルと state バッジを表示

## 検証
- pnpm --filter @gh-gantt/shared exec vp test run src/__tests__/schema.test.ts
- pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/fetch-project.test.ts src/__tests__/mapper.test.ts
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/detail-relations.test.tsx
- pnpm lint
- pnpm build
- pnpm run test:json
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen