### PR TITLE
feat(ui): クリティカルパス表示を追加 (#18)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -487,6 +487,30 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/label-grouping.test.tsx
+      - id: FR-VIS-014
+        summary: クリティカルパス表示
+        acceptance_criteria:
+          - id: FR-VIS-014-AC1
+            description: finish-to-start 依存から CPM の critical task / critical edge / total float を算出する
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/dependency-graph.test.ts
+          - id: FR-VIS-014-AC2
+            description: critical task と blocked_by edge をガントチャート上で赤色強調する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/critical-path-display.test.tsx
+          - id: FR-VIS-014-AC3
+            description: tooltip に total float を表示する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/critical-path-display.test.tsx
+          - id: FR-VIS-014-AC4
+            description: 循環依存がある場合は critical path 計算を停止し警告を表示する
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/dependency-graph.test.ts
+              - packages/ui/src/__tests__/critical-path-display.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/shared/src/__tests__/dependency-graph.test.ts
+++ b/packages/shared/src/__tests__/dependency-graph.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { calculateCriticalPath, dependencyEdgeKey } from "../dependency-graph.js";
+import type { Task } from "../types.js";
+
+function makeTask(id: string, options: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: id,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "",
+    updated_at: "",
+    closed_at: null,
+    custom_fields: {},
+    start_date: "2026-01-01",
+    end_date: "2026-01-01",
+    date: null,
+    blocked_by: [],
+    ...options,
+  };
+}
+
+describe("[FR-VIS-014-AC1] CPM でクリティカルパスと total float を算出する", () => {
+  it("最長依存経路のタスクと edge を critical として返す", () => {
+    const tasks = [
+      makeTask("owner/repo#1", { start_date: "2026-01-01", end_date: "2026-01-02" }),
+      makeTask("owner/repo#2", {
+        start_date: "2026-01-03",
+        end_date: "2026-01-05",
+        blocked_by: [{ task: "owner/repo#1", type: "finish-to-start", lag: 0 }],
+      }),
+      makeTask("owner/repo#3", { start_date: "2026-01-01", end_date: "2026-01-01" }),
+    ];
+
+    const result = calculateCriticalPath(tasks);
+
+    expect(result.projectDurationDays).toBe(5);
+    expect(result.criticalTaskIds).toEqual(["owner/repo#1", "owner/repo#2"]);
+    expect(result.criticalEdgeKeys).toEqual([dependencyEdgeKey("owner/repo#1", "owner/repo#2")]);
+    expect(result.taskTimings["owner/repo#1"]?.totalFloat).toBe(0);
+    expect(result.taskTimings["owner/repo#2"]?.totalFloat).toBe(0);
+    expect(result.taskTimings["owner/repo#3"]?.totalFloat).toBe(4);
+  });
+
+  it("日付未設定タスクは計算対象から除外する", () => {
+    const result = calculateCriticalPath([
+      makeTask("owner/repo#1", { start_date: null, end_date: null }),
+      makeTask("owner/repo#2", { start_date: "2026-01-01", end_date: "2026-01-01" }),
+    ]);
+
+    expect(Object.keys(result.taskTimings)).toEqual(["owner/repo#2"]);
+    expect(result.criticalTaskIds).toEqual(["owner/repo#2"]);
+  });
+});
+
+describe("[FR-VIS-014-AC4] 循環依存がある場合はクリティカルパス計算を停止する", () => {
+  it("cycle を返して critical task を空にする", () => {
+    const result = calculateCriticalPath([
+      makeTask("owner/repo#1", {
+        blocked_by: [{ task: "owner/repo#2", type: "finish-to-start", lag: 0 }],
+      }),
+      makeTask("owner/repo#2", {
+        blocked_by: [{ task: "owner/repo#1", type: "finish-to-start", lag: 0 }],
+      }),
+    ]);
+
+    expect(result.cycles.length).toBeGreaterThan(0);
+    expect(result.criticalTaskIds).toEqual([]);
+    expect(result.criticalEdgeKeys).toEqual([]);
+  });
+});

--- a/packages/shared/src/dependency-graph.ts
+++ b/packages/shared/src/dependency-graph.ts
@@ -7,6 +7,25 @@ export interface DependencyEdge {
   lag: number;
 }
 
+export interface CriticalPathTaskTiming {
+  taskId: string;
+  durationDays: number;
+  earlyStart: number;
+  earlyFinish: number;
+  lateStart: number;
+  lateFinish: number;
+  totalFloat: number;
+  isCritical: boolean;
+}
+
+export interface CriticalPathResult {
+  taskTimings: Record<string, CriticalPathTaskTiming>;
+  criticalTaskIds: string[];
+  criticalEdgeKeys: string[];
+  projectDurationDays: number;
+  cycles: string[][];
+}
+
 export function buildDependencyEdges(tasks: Task[]): DependencyEdge[] {
   const edges: DependencyEdge[] = [];
   for (const task of tasks) {
@@ -20,6 +39,170 @@ export function buildDependencyEdges(tasks: Task[]): DependencyEdge[] {
     }
   }
   return edges;
+}
+
+export function dependencyEdgeKey(from: string, to: string): string {
+  return `${from}->${to}`;
+}
+
+function parseDateToUtcTime(value: string): number | null {
+  const [year, month, day] = value.split("-").map((part) => Number(part));
+  if (!year || !month || !day) return null;
+  return Date.UTC(year, month - 1, day);
+}
+
+function durationDays(task: Task): number | null {
+  if (!task.start_date || !task.end_date) return null;
+  const start = parseDateToUtcTime(task.start_date);
+  const end = parseDateToUtcTime(task.end_date);
+  if (start == null || end == null || end < start) return null;
+  return Math.max(1, Math.round((end - start) / (24 * 60 * 60 * 1000)) + 1);
+}
+
+function buildScheduledCycles(tasks: Task[], scheduledTaskIds: Set<string>): string[][] {
+  const scheduledTasks = tasks
+    .filter((task) => scheduledTaskIds.has(task.id))
+    .map((task) => ({
+      ...task,
+      blocked_by: task.blocked_by.filter(
+        (dep) => dep.type === "finish-to-start" && scheduledTaskIds.has(dep.task),
+      ),
+    }));
+  return detectCycles(scheduledTasks);
+}
+
+/**
+ * finish-to-start 依存を使って CPM の earliest/latest timing と total float を計算する。
+ * 日付未設定タスクはガント上の期間を持たないため計算対象から除外する。
+ */
+export function calculateCriticalPath(tasks: Task[]): CriticalPathResult {
+  const durations = new Map<string, number>();
+  for (const task of tasks) {
+    const duration = durationDays(task);
+    if (duration != null) durations.set(task.id, duration);
+  }
+
+  const scheduledTaskIds = new Set(durations.keys());
+  const cycles = buildScheduledCycles(tasks, scheduledTaskIds);
+  if (cycles.length > 0) {
+    return {
+      taskTimings: {},
+      criticalTaskIds: [],
+      criticalEdgeKeys: [],
+      projectDurationDays: 0,
+      cycles,
+    };
+  }
+
+  const successors = new Map<string, Array<{ to: string; lag: number }>>();
+  const predecessors = new Map<string, Array<{ from: string; lag: number }>>();
+  const indegree = new Map<string, number>();
+
+  for (const taskId of scheduledTaskIds) {
+    successors.set(taskId, []);
+    predecessors.set(taskId, []);
+    indegree.set(taskId, 0);
+  }
+
+  for (const task of tasks) {
+    if (!scheduledTaskIds.has(task.id)) continue;
+    for (const dep of task.blocked_by) {
+      if (dep.type !== "finish-to-start") continue;
+      if (!scheduledTaskIds.has(dep.task)) continue;
+      const lag = dep.lag ?? 0;
+      successors.get(dep.task)!.push({ to: task.id, lag });
+      predecessors.get(task.id)!.push({ from: dep.task, lag });
+      indegree.set(task.id, (indegree.get(task.id) ?? 0) + 1);
+    }
+  }
+
+  const queue = [...scheduledTaskIds].filter((taskId) => (indegree.get(taskId) ?? 0) === 0).sort();
+  const order: string[] = [];
+  while (queue.length > 0) {
+    const taskId = queue.shift()!;
+    order.push(taskId);
+    for (const edge of successors.get(taskId) ?? []) {
+      const nextDegree = (indegree.get(edge.to) ?? 0) - 1;
+      indegree.set(edge.to, nextDegree);
+      if (nextDegree === 0) {
+        queue.push(edge.to);
+        queue.sort();
+      }
+    }
+  }
+
+  if (order.length !== scheduledTaskIds.size) {
+    return {
+      taskTimings: {},
+      criticalTaskIds: [],
+      criticalEdgeKeys: [],
+      projectDurationDays: 0,
+      cycles: detectCycles(tasks),
+    };
+  }
+
+  const earlyStart = new Map<string, number>();
+  const earlyFinish = new Map<string, number>();
+  for (const taskId of order) {
+    const start = Math.max(
+      0,
+      ...(predecessors.get(taskId) ?? []).map(
+        (edge) => (earlyFinish.get(edge.from) ?? 0) + edge.lag,
+      ),
+    );
+    earlyStart.set(taskId, start);
+    earlyFinish.set(taskId, start + durations.get(taskId)!);
+  }
+
+  const projectDurationDays = Math.max(0, ...order.map((taskId) => earlyFinish.get(taskId) ?? 0));
+  const lateFinish = new Map<string, number>();
+  const lateStart = new Map<string, number>();
+
+  for (const taskId of [...order].reverse()) {
+    const outgoing = successors.get(taskId) ?? [];
+    const finish =
+      outgoing.length === 0
+        ? projectDurationDays
+        : Math.min(...outgoing.map((edge) => (lateStart.get(edge.to) ?? 0) - edge.lag));
+    lateFinish.set(taskId, finish);
+    lateStart.set(taskId, finish - durations.get(taskId)!);
+  }
+
+  const taskTimings: Record<string, CriticalPathTaskTiming> = {};
+  for (const taskId of order) {
+    const totalFloat = (lateStart.get(taskId) ?? 0) - (earlyStart.get(taskId) ?? 0);
+    taskTimings[taskId] = {
+      taskId,
+      durationDays: durations.get(taskId)!,
+      earlyStart: earlyStart.get(taskId) ?? 0,
+      earlyFinish: earlyFinish.get(taskId) ?? 0,
+      lateStart: lateStart.get(taskId) ?? 0,
+      lateFinish: lateFinish.get(taskId) ?? 0,
+      totalFloat,
+      isCritical: totalFloat === 0,
+    };
+  }
+
+  const criticalTaskIds = order.filter((taskId) => taskTimings[taskId]?.isCritical);
+  const criticalEdgeKeys: string[] = [];
+  for (const taskId of order) {
+    for (const edge of successors.get(taskId) ?? []) {
+      const from = taskTimings[taskId];
+      const to = taskTimings[edge.to];
+      if (!from?.isCritical || !to?.isCritical) continue;
+      if (to.earlyStart === from.earlyFinish + edge.lag) {
+        criticalEdgeKeys.push(dependencyEdgeKey(taskId, edge.to));
+      }
+    }
+  }
+
+  return {
+    taskTimings,
+    criticalTaskIds,
+    criticalEdgeKeys,
+    projectDurationDays,
+    cycles: [],
+  };
 }
 
 /**

--- a/packages/ui/src/__tests__/critical-path-display.test.tsx
+++ b/packages/ui/src/__tests__/critical-path-display.test.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GanttChart } from "../components/GanttChart.js";
+import { GanttTooltip } from "../components/GanttTooltip.js";
+import type { Config, Task } from "../types/index.js";
+import type { TreeNode } from "../hooks/useTaskTree.js";
+
+const originalConsoleError = console.error.bind(console);
+
+const config: Config = {
+  version: "1",
+  project: {
+    name: "Test Project",
+    github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+  },
+  type_hierarchy: { task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+function makeTask(id: string, options: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "stanah/gh-gantt",
+    parent: null,
+    sub_tasks: [],
+    title: id,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: { Status: "Todo" },
+    start_date: "2026-01-01",
+    end_date: "2026-01-01",
+    date: null,
+    blocked_by: [],
+    ...options,
+  };
+}
+
+function flatList(tasks: Task[]): TreeNode[] {
+  return tasks.map((task) => ({ task, children: [], depth: 0 }));
+}
+
+describe("クリティカルパス表示", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "error").mockImplementation((message: unknown, ...args: unknown[]) => {
+      if (
+        typeof message === "string" &&
+        message.includes("useLayoutEffect does nothing on the server")
+      ) {
+        return;
+      }
+      originalConsoleError(message, ...args);
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("[FR-VIS-014-AC2] critical task と blocked_by edge を赤色強調対象として描画する", () => {
+    const tasks = [
+      makeTask("stanah/gh-gantt#1", { start_date: "2026-01-01", end_date: "2026-01-02" }),
+      makeTask("stanah/gh-gantt#2", {
+        start_date: "2026-01-03",
+        end_date: "2026-01-05",
+        blocked_by: [{ task: "stanah/gh-gantt#1", type: "finish-to-start", lag: 0 }],
+      }),
+      makeTask("stanah/gh-gantt#3", { start_date: "2026-01-01", end_date: "2026-01-01" }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <GanttChart
+        tasks={tasks}
+        flatList={flatList(tasks)}
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        header={() => {}}
+        dependencyHighlightEnabled={true}
+      />,
+    );
+
+    expect(html.match(/data-critical-path="true"/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+    expect(html).toContain("#E74C3C");
+  });
+
+  it("[FR-VIS-014-AC3] tooltip に total float を表示する", () => {
+    const task = makeTask("stanah/gh-gantt#1");
+
+    const html = renderToStaticMarkup(
+      <GanttTooltip
+        task={task}
+        taskType={config.task_types.task}
+        x={100}
+        y={100}
+        criticalPathTiming={{
+          taskId: task.id,
+          durationDays: 1,
+          earlyStart: 0,
+          earlyFinish: 1,
+          lateStart: 0,
+          lateFinish: 1,
+          totalFloat: 0,
+          isCritical: true,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Critical path");
+    expect(html).toContain("Float: 0d");
+  });
+
+  it("[FR-VIS-014-AC4] 循環依存がある場合はチャート上に警告を表示する", () => {
+    const tasks = [
+      makeTask("stanah/gh-gantt#1", {
+        blocked_by: [{ task: "stanah/gh-gantt#2", type: "finish-to-start", lag: 0 }],
+      }),
+      makeTask("stanah/gh-gantt#2", {
+        blocked_by: [{ task: "stanah/gh-gantt#1", type: "finish-to-start", lag: 0 }],
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <GanttChart
+        tasks={tasks}
+        flatList={flatList(tasks)}
+        config={config}
+        selectedTaskId={null}
+        onSelectTask={() => {}}
+        header={() => {}}
+        dependencyHighlightEnabled={true}
+      />,
+    );
+
+    expect(html).toContain("循環依存があるためクリティカルパスを計算できません");
+  });
+});

--- a/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
+++ b/packages/ui/src/__tests__/dependency-highlight-toggle.test.tsx
@@ -13,8 +13,16 @@ const dependencyGraphMocks = vi.hoisted(() => ({
       lag: 0,
     },
   ]),
+  dependencyEdgeKey: vi.fn((from: string, to: string) => `${from}->${to}`),
   detectCycles: vi.fn(() => []),
   getEdgeCoordinates: vi.fn(() => ({ path: "M 0 0 L 10 10" })),
+  calculateCriticalPath: vi.fn(() => ({
+    taskTimings: {},
+    criticalTaskIds: [],
+    criticalEdgeKeys: [],
+    projectDurationDays: 0,
+    cycles: [],
+  })),
 }));
 
 vi.mock("../lib/dependency-graph.js", () => dependencyGraphMocks);

--- a/packages/ui/src/components/GanttBar.tsx
+++ b/packages/ui/src/components/GanttBar.tsx
@@ -27,6 +27,9 @@ interface GanttBarProps {
   priorityFieldName?: string;
   isDimmed?: boolean;
   highlightType?: RelationType | null;
+  isCriticalPath?: boolean;
+  criticalPathColor?: string;
+  totalFloatDays?: number;
   onTooltipShow?: (task: Task, e: React.MouseEvent | React.FocusEvent) => void;
   onTooltipHide?: () => void;
 }
@@ -53,6 +56,9 @@ export function GanttBar({
   priorityFieldName,
   isDimmed,
   highlightType,
+  isCriticalPath,
+  criticalPathColor = "var(--color-danger)",
+  totalFloatDays,
   onTooltipShow,
   onTooltipHide,
 }: GanttBarProps) {
@@ -89,11 +95,22 @@ export function GanttBar({
 
   const hl = highlightStroke(highlightType);
   const isDone = task.state === "closed";
+  const stroke = isSelected
+    ? "var(--color-text)"
+    : hl
+      ? hl.stroke
+      : isCriticalPath
+        ? criticalPathColor
+        : scheduleStroke;
+  const strokeWidth = isSelected ? 2 : hl ? hl.strokeWidth : isCriticalPath ? 2.5 : 1;
+  const fill = isCriticalPath && !overdue && !atRisk ? criticalPathColor : backgroundFill;
+  const fillOpacity = isCriticalPath && !overdue && !atRisk ? 0.22 : backgroundOpacity;
 
   return (
     <g
       role="graphics-symbol"
-      aria-label={`${task.title}, from ${task.start_date} to ${task.end_date}${overdue ? `, overdue ${overdueDays} days` : atRisk && daysUntilDue != null ? `, due in ${daysUntilDue} days` : ""}${isDone ? ", done" : ""}`}
+      aria-label={`${task.title}, from ${task.start_date} to ${task.end_date}${isCriticalPath ? `, critical path, float ${totalFloatDays ?? 0} days` : ""}${overdue ? `, overdue ${overdueDays} days` : atRisk && daysUntilDue != null ? `, due in ${daysUntilDue} days` : ""}${isDone ? ", done" : ""}`}
+      data-critical-path={isCriticalPath ? "true" : undefined}
       tabIndex={0}
       onClick={onClick}
       onMouseEnter={(e) => onTooltipShow?.(task, e)}
@@ -111,10 +128,10 @@ export function GanttBar({
         width={width}
         height={barHeight}
         rx={3}
-        fill={backgroundFill}
-        fillOpacity={backgroundOpacity}
-        stroke={isSelected ? "var(--color-text)" : hl ? hl.stroke : scheduleStroke}
-        strokeWidth={isSelected ? 2 : hl ? hl.strokeWidth : 1}
+        fill={fill}
+        fillOpacity={fillOpacity}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
         strokeDasharray={!isSelected && !hl && overdue ? "4 2" : undefined}
       />
       {/* Priority indicator (left stripe) */}

--- a/packages/ui/src/components/GanttBlockLines.tsx
+++ b/packages/ui/src/components/GanttBlockLines.tsx
@@ -2,7 +2,12 @@ import React, { useMemo } from "react";
 import type { ScaleTime } from "d3-scale";
 import type { Task } from "../types/index.js";
 import type { TreeNode } from "../hooks/useTaskTree.js";
-import { buildDependencyEdges, detectCycles, getEdgeCoordinates } from "../lib/dependency-graph.js";
+import {
+  buildDependencyEdges,
+  dependencyEdgeKey,
+  detectCycles,
+  getEdgeCoordinates,
+} from "../lib/dependency-graph.js";
 import { parseDate } from "../lib/date-utils.js";
 import { ROW_HEIGHT } from "./TaskTree.js";
 
@@ -13,6 +18,8 @@ interface GanttBlockLinesProps {
   totalWidth: number;
   totalHeight: number;
   hoveredTaskId: string | null;
+  criticalEdgeKeys?: Set<string>;
+  criticalPathColor?: string;
 }
 
 export function GanttBlockLines({
@@ -22,6 +29,8 @@ export function GanttBlockLines({
   totalWidth,
   totalHeight,
   hoveredTaskId,
+  criticalEdgeKeys,
+  criticalPathColor = "var(--color-danger)",
 }: GanttBlockLinesProps) {
   const edges = useMemo(() => buildDependencyEdges(tasks), [tasks]);
   const cycles = useMemo(() => {
@@ -45,11 +54,14 @@ export function GanttBlockLines({
     return map;
   }, [flatList, xScale]);
 
-  // Only show arrows when hovering a task; filter to edges involving the hovered task
+  // ホバー対象の依存線に加え、critical path 上の依存線は常時表示する。
   const visibleEdges = useMemo(() => {
-    if (!hoveredTaskId) return [];
-    return edges.filter((edge) => edge.from === hoveredTaskId || edge.to === hoveredTaskId);
-  }, [edges, hoveredTaskId]);
+    return edges.filter((edge) => {
+      const isCriticalEdge = criticalEdgeKeys?.has(dependencyEdgeKey(edge.from, edge.to)) ?? false;
+      if (isCriticalEdge) return true;
+      return hoveredTaskId != null && (edge.from === hoveredTaskId || edge.to === hoveredTaskId);
+    });
+  }, [criticalEdgeKeys, edges, hoveredTaskId]);
 
   if (visibleEdges.length === 0) return null;
 
@@ -67,23 +79,48 @@ export function GanttBlockLines({
         <marker id="arrowhead-red" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
           <polygon points="0 0, 8 3, 0 6" fill="var(--color-danger)" />
         </marker>
+        <marker
+          id="arrowhead-critical"
+          markerWidth="8"
+          markerHeight="6"
+          refX="7"
+          refY="3"
+          orient="auto"
+        >
+          <polygon points="0 0, 8 3, 0 6" fill={criticalPathColor} />
+        </marker>
       </defs>
       {visibleEdges.map((edge, i) => {
         const coords = getEdgeCoordinates(edge, taskPositions, ROW_HEIGHT);
         if (!coords) return null;
 
         const isCycleEdge = cycles.has(edge.from) && cycles.has(edge.to);
+        const isCriticalEdge =
+          criticalEdgeKeys?.has(dependencyEdgeKey(edge.from, edge.to)) ?? false;
 
         return (
           <path
             key={i}
+            data-critical-path={isCriticalEdge ? "true" : undefined}
             d={coords.path}
             fill="none"
-            stroke={isCycleEdge ? "var(--color-danger)" : "var(--color-text-secondary)"}
-            strokeWidth={1.5}
+            stroke={
+              isCycleEdge
+                ? "var(--color-danger)"
+                : isCriticalEdge
+                  ? criticalPathColor
+                  : "var(--color-text-secondary)"
+            }
+            strokeWidth={isCriticalEdge ? 2.5 : 1.5}
             strokeDasharray={edge.lag > 0 ? "4 2" : undefined}
-            markerEnd={isCycleEdge ? "url(#arrowhead-red)" : "url(#arrowhead)"}
-            opacity={0.7}
+            markerEnd={
+              isCycleEdge
+                ? "url(#arrowhead-red)"
+                : isCriticalEdge
+                  ? "url(#arrowhead-critical)"
+                  : "url(#arrowhead)"
+            }
+            opacity={isCriticalEdge ? 0.95 : 0.7}
           />
         );
       })}

--- a/packages/ui/src/components/GanttChart.tsx
+++ b/packages/ui/src/components/GanttChart.tsx
@@ -6,6 +6,7 @@ import React, {
   forwardRef,
   useEffect,
   useLayoutEffect,
+  useMemo,
 } from "react";
 import { GanttTimeline } from "./GanttTimeline.js";
 import { GanttGrid } from "./GanttGrid.js";
@@ -16,6 +17,7 @@ import { GanttBlockLines } from "./GanttBlockLines.js";
 import { GanttTooltip } from "./GanttTooltip.js";
 import { useGanttScale } from "../hooks/useGanttScale.js";
 import type { ViewScale } from "@gh-gantt/shared";
+import { calculateCriticalPath } from "../lib/dependency-graph.js";
 import { useDragResize } from "../hooks/useDragResize.js";
 import { useDrawBar } from "../hooks/useDrawBar.js";
 import { useGanttTooltip } from "../hooks/useGanttTooltip.js";
@@ -135,6 +137,16 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
   }, [config.sprints, header, xScale, dateRange, viewScale, totalWidth]);
 
   const totalHeight = flatList.length * ROW_HEIGHT;
+  const criticalPath = useMemo(() => calculateCriticalPath(tasks), [tasks]);
+  const criticalTaskIds = useMemo(
+    () => new Set(criticalPath.criticalTaskIds),
+    [criticalPath.criticalTaskIds],
+  );
+  const criticalEdgeKeys = useMemo(
+    () => new Set(criticalPath.criticalEdgeKeys),
+    [criticalPath.criticalEdgeKeys],
+  );
+  const criticalPathColor = config.gantt.colors.critical_path;
 
   const handleDragCommit = useCallback(
     (taskId: string, updates: { start_date?: string; end_date?: string }) => {
@@ -246,6 +258,26 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
       onMouseDown={handleMouseDown}
       style={{ width: totalWidth, height: totalHeight, position: "relative" }}
     >
+      {criticalPath.cycles.length > 0 && (
+        <div
+          role="alert"
+          style={{
+            position: "absolute",
+            top: 8,
+            left: 8,
+            zIndex: 20,
+            padding: "6px 10px",
+            borderRadius: 6,
+            fontSize: 11,
+            color: "var(--color-danger)",
+            background: "var(--color-danger-bg)",
+            border: "1px solid var(--color-danger)",
+            pointerEvents: "none",
+          }}
+        >
+          循環依存があるためクリティカルパスを計算できません
+        </div>
+      )}
       <GanttGrid
         xScale={xScale}
         dateRange={dateRange}
@@ -263,6 +295,8 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
           totalWidth={totalWidth}
           totalHeight={totalHeight}
           hoveredTaskId={hoveredTaskId ?? null}
+          criticalEdgeKeys={criticalEdgeKeys}
+          criticalPathColor={criticalPathColor}
         />
       )}
       <svg
@@ -348,6 +382,8 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
             : null;
           const isDimmed =
             dependencyHighlightEnabled && hoveredTaskId != null && !isHoveredTask && !highlightType;
+          const criticalPathTiming = criticalPath.taskTimings[task.id];
+          const isCriticalPath = criticalTaskIds.has(task.id);
 
           if (display === "summary") {
             return (
@@ -418,6 +454,9 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
               priorityFieldName={priorityFieldName}
               isDimmed={isDimmed}
               highlightType={highlightType}
+              isCriticalPath={isCriticalPath}
+              criticalPathColor={criticalPathColor}
+              totalFloatDays={criticalPathTiming?.totalFloat}
               onTooltipShow={showTooltip}
               onTooltipHide={hideTooltip}
             />
@@ -451,6 +490,7 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
           x={tooltip.x}
           y={tooltip.y}
           summaryDates={tooltipSummaryDates}
+          criticalPathTiming={criticalPath.taskTimings[tooltip.task.id]}
         />
       )}
     </div>

--- a/packages/ui/src/components/GanttTooltip.tsx
+++ b/packages/ui/src/components/GanttTooltip.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Task, TaskType } from "../types/index.js";
+import type { CriticalPathTaskTiming } from "../lib/dependency-graph.js";
 import { parseDate } from "../lib/date-utils.js";
 
 interface GanttTooltipProps {
@@ -9,6 +10,7 @@ interface GanttTooltipProps {
   y: number;
   /** Summary date range from parent calculation (for summary bars) */
   summaryDates?: { start: string; end: string } | null;
+  criticalPathTiming?: CriticalPathTaskTiming;
 }
 
 export function calcDurationDays(startStr: string, endStr: string): number {
@@ -24,7 +26,14 @@ export function formatDateLabel(dateStr: string): string {
   return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
 }
 
-export function GanttTooltip({ task, taskType, x, y, summaryDates }: GanttTooltipProps) {
+export function GanttTooltip({
+  task,
+  taskType,
+  x,
+  y,
+  summaryDates,
+  criticalPathTiming,
+}: GanttTooltipProps) {
   const display = taskType?.display ?? "bar";
   const progress = task._progress ?? 0;
 
@@ -132,6 +141,17 @@ export function GanttTooltip({ task, taskType, x, y, summaryDates }: GanttToolti
           <span style={{ fontSize: 10, color: "var(--color-text-muted)", minWidth: 28 }}>
             {progress}%
           </span>
+        </div>
+      )}
+
+      {/* Critical path */}
+      {display !== "milestone" && criticalPathTiming && (
+        <div style={{ marginTop: 4, fontSize: 10, color: "var(--color-text-muted)" }}>
+          {criticalPathTiming.isCritical && (
+            <span style={{ color: "var(--color-danger)", fontWeight: 600 }}>Critical path</span>
+          )}
+          {criticalPathTiming.isCritical && <span style={{ margin: "0 4px" }}>·</span>}
+          <span>Float: {criticalPathTiming.totalFloat}d</span>
         </div>
       )}
 

--- a/packages/ui/src/lib/dependency-graph.ts
+++ b/packages/ui/src/lib/dependency-graph.ts
@@ -1,7 +1,12 @@
-// shared パッケージから re-export（detectCycles, buildDependencyEdges）
+// shared パッケージから re-export（detectCycles, buildDependencyEdges, critical path）
 // UI 固有の getEdgeCoordinates のみこのファイルで定義
-export { detectCycles, buildDependencyEdges } from "@gh-gantt/shared";
-export type { DependencyEdge } from "@gh-gantt/shared";
+export {
+  detectCycles,
+  buildDependencyEdges,
+  calculateCriticalPath,
+  dependencyEdgeKey,
+} from "@gh-gantt/shared";
+export type { DependencyEdge, CriticalPathTaskTiming, CriticalPathResult } from "@gh-gantt/shared";
 import type { DependencyEdge } from "@gh-gantt/shared";
 
 export function getEdgeCoordinates(


### PR DESCRIPTION
## Summary

- shared dependency graph に CPM ベースの critical task / edge / total float 計算を追加
- GanttChart で critical path のバーと blocked_by edge を `gantt.colors.critical_path` で強調
- tooltip の Float 表示と循環依存時の chart warning を追加
- requirements に `FR-VIS-014` を追加し、shared/UI tests で trace

Closes #18

## Test Plan

- `pnpm --filter @gh-gantt/shared exec vp test run src/__tests__/dependency-graph.test.ts`
- `pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/critical-path-display.test.tsx src/__tests__/dependency-highlight-toggle.test.tsx`
- `pnpm lint`
- `pnpm build`
- `pnpm run test:json`
- `pnpm req:trace`
- `pnpm req:validate`
- `pnpm docs:gen`
- `git diff --cached --check`
- pre-push hook
