### PR TITLE
fix(sync): close 後のメタデータを再取得する (#213)

### DIFF
--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -67,7 +67,12 @@ function makeBatchIssueResponse(
   if (handler) return handler("batch", undefined);
   const repo: Record<string, any> = {};
   issueNumbers.forEach((n, i) => {
-    repo[`i${i}`] = { number: n, updatedAt: "2026-01-01T00:00:00Z" };
+    repo[`i${i}`] = {
+      number: n,
+      updatedAt: "2026-01-01T00:00:00Z",
+      stateReason: null,
+      closedAt: null,
+    };
   });
   return { repository: repo };
 }
@@ -493,6 +498,79 @@ describe("executePush", () => {
       );
 
       expect(newSyncState.snapshots["o/r#1"]?.updated_at).toBe("2026-04-01T00:00:00Z");
+    });
+
+    it("[Issue #213] close push 後に state_reason と closed_at をローカルへ反映する", async () => {
+      const oldUpdatedAt = "2026-01-01T00:00:00Z";
+      const freshUpdatedAt = "2026-05-03T17:48:29Z";
+      const closedAt = "2026-05-03T17:48:29Z";
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        state: "closed",
+        state_reason: null,
+        closed_at: null,
+        updated_at: oldUpdatedAt,
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: {},
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(makeTask("o/r#1", { github_issue: 1, updated_at: oldUpdatedAt })),
+            synced_at: "",
+            syncFields: extractSyncFields(
+              makeTask("o/r#1", { github_issue: 1, updated_at: oldUpdatedAt }),
+            ),
+            updated_at: oldUpdatedAt,
+          },
+        },
+      };
+
+      let batchCallCount = 0;
+      const mockGql = makeMockGql({
+        batchUpdatedAt: () => {
+          batchCallCount++;
+          if (batchCallCount === 1) {
+            return {
+              repository: {
+                i0: { number: 1, updatedAt: oldUpdatedAt, stateReason: null, closedAt: null },
+              },
+            };
+          }
+          return {
+            repository: {
+              i0: {
+                number: 1,
+                updatedAt: freshUpdatedAt,
+                stateReason: "COMPLETED",
+                closedAt,
+              },
+            },
+          };
+        },
+      });
+
+      const { tasksFile: newTasksFile, syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        syncState,
+      );
+
+      expect(newTasksFile.tasks[0]?.state_reason).toBe("COMPLETED");
+      expect(newTasksFile.tasks[0]?.closed_at).toBe(closedAt);
+      expect(newTasksFile.tasks[0]?.updated_at).toBe(freshUpdatedAt);
+      expect(newSyncState.snapshots["o/r#1"]?.updated_at).toBe(freshUpdatedAt);
+      expect(newSyncState.snapshots["o/r#1"]?.syncFields?.state).toBe("closed");
+      expect(computeLocalDiff(newTasksFile.tasks, newSyncState)).toEqual([]);
     });
 
     it("field updates skipped when project_item_id is missing (Fix 1-3)", async () => {

--- a/packages/cli/src/github/queries.ts
+++ b/packages/cli/src/github/queries.ts
@@ -125,7 +125,7 @@ export function buildIssueUpdatedAtQuery(
   issueNumbers: number[],
 ): string {
   const fields = issueNumbers
-    .map((n, i) => `i${i}: issue(number: ${n}) { number updatedAt }`)
+    .map((n, i) => `i${i}: issue(number: ${n}) { number updatedAt stateReason closedAt }`)
     .join("\n      ");
   return `query {
     repository(owner: "${owner}", name: "${repo}") {

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -711,7 +711,13 @@ export async function executePush(
     }
   }
 
-  const freshUpdatedAt = await fetchFreshUpdatedAt(gql, owner, repo, tasksFile, pushedTaskIds);
+  const freshIssueMetadata = await fetchFreshIssueMetadata(
+    gql,
+    owner,
+    repo,
+    tasksFile,
+    pushedTaskIds,
+  );
 
   // Update snapshots — only for tasks that were actually pushed
   const newSnapshots: SyncState["snapshots"] = { ...syncState.snapshots };
@@ -726,6 +732,12 @@ export async function executePush(
     const task = tasksFile.tasks.find((t) => t.id === id);
     if (task) {
       const existing = newSnapshots[id];
+      const freshMetadata = freshIssueMetadata.get(id);
+      if (freshMetadata) {
+        task.updated_at = freshMetadata.updatedAt;
+        task.state_reason = freshMetadata.stateReason;
+        task.closed_at = freshMetadata.closedAt;
+      }
       let syncFields = extractSyncFields(task);
 
       const issueTypeFailure = failedIssueTypes.get(id);
@@ -737,7 +749,7 @@ export async function executePush(
             newSnapshots[id] = {
               ...existing,
               synced_at: new Date().toISOString(),
-              updated_at: freshUpdatedAt.get(id) ?? existing.updated_at,
+              updated_at: freshMetadata?.updatedAt ?? existing.updated_at,
             };
           } else {
             delete newSnapshots[id];
@@ -769,7 +781,7 @@ export async function executePush(
         hash: snapshotHash,
         synced_at: new Date().toISOString(),
         syncFields,
-        updated_at: freshUpdatedAt.get(id) ?? existing?.updated_at,
+        updated_at: freshMetadata?.updatedAt ?? existing?.updated_at,
         remoteHash: snapshotHash,
       };
     }
@@ -813,13 +825,19 @@ function resolvePriorityOptionId(
 
 const BATCH_SIZE = 100;
 
-async function fetchBatchUpdatedAt(
+interface FreshIssueMetadata {
+  updatedAt: string;
+  stateReason: string | null;
+  closedAt: string | null;
+}
+
+async function fetchBatchIssueMetadata(
   gql: typeof graphql,
   owner: string,
   repo: string,
   issueNumbers: number[],
-): Promise<Map<number, string>> {
-  const result = new Map<number, string>();
+): Promise<Map<number, FreshIssueMetadata>> {
+  const result = new Map<number, FreshIssueMetadata>();
   if (issueNumbers.length === 0) return result;
 
   for (let i = 0; i < issueNumbers.length; i += BATCH_SIZE) {
@@ -827,12 +845,24 @@ async function fetchBatchUpdatedAt(
     try {
       const query = buildIssueUpdatedAtQuery(owner, repo, batch);
       const data = await gql<{
-        repository: Record<string, { number: number; updatedAt: string } | null>;
+        repository: Record<
+          string,
+          {
+            number: number;
+            updatedAt: string;
+            stateReason?: string | null;
+            closedAt?: string | null;
+          } | null
+        >;
       }>(query);
       for (let j = 0; j < batch.length; j++) {
         const issue = data.repository[`i${j}`];
         if (issue?.updatedAt) {
-          result.set(issue.number, issue.updatedAt);
+          result.set(issue.number, {
+            updatedAt: issue.updatedAt,
+            stateReason: issue.stateReason ?? null,
+            closedAt: issue.closedAt ?? null,
+          });
         }
       }
     } catch (err) {
@@ -844,14 +874,24 @@ async function fetchBatchUpdatedAt(
   return result;
 }
 
-async function fetchFreshUpdatedAt(
+async function fetchBatchUpdatedAt(
+  gql: typeof graphql,
+  owner: string,
+  repo: string,
+  issueNumbers: number[],
+): Promise<Map<number, string>> {
+  const metadata = await fetchBatchIssueMetadata(gql, owner, repo, issueNumbers);
+  return new Map([...metadata].map(([number, issue]) => [number, issue.updatedAt]));
+}
+
+async function fetchFreshIssueMetadata(
   gql: typeof graphql,
   owner: string,
   repo: string,
   tasksFile: TasksFile,
   pushedTaskIds: Set<string>,
-): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
+): Promise<Map<string, FreshIssueMetadata>> {
+  const result = new Map<string, FreshIssueMetadata>();
   const taskById = new Map(tasksFile.tasks.map((t) => [t.id, t]));
   const ids = [...pushedTaskIds].filter((id) => !isDraftTask(id) && !isMilestoneSyntheticTask(id));
   const numberToId = new Map<number, string>();
@@ -860,10 +900,10 @@ async function fetchFreshUpdatedAt(
     if (task?.github_issue) numberToId.set(task.github_issue, id);
   }
 
-  const updatedAtByNumber = await fetchBatchUpdatedAt(gql, owner, repo, [...numberToId.keys()]);
-  for (const [number, ts] of updatedAtByNumber) {
+  const metadataByNumber = await fetchBatchIssueMetadata(gql, owner, repo, [...numberToId.keys()]);
+  for (const [number, metadata] of metadataByNumber) {
     const id = numberToId.get(number);
-    if (id) result.set(id, ts);
+    if (id) result.set(id, metadata);
   }
   return result;
 }


### PR DESCRIPTION
## Summary

- post-push refresh で GitHub の stateReason / closedAt も取得
- pushed task の local metadata と snapshot.updated_at を fresh remote metadata に更新
- close push 後に local state_reason / closed_at が反映され、次回 diff が空になる regression test を追加

Closes #213

## Test Plan

- `pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/push-executor.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm run test:json`
- `pnpm req:trace`
- `pnpm req:validate`
- `pnpm docs:gen`
- `git diff --cached --check`
- pre-push hook
