### PR TITLE
feat(cli): close evidence を記録する (#145)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -411,6 +411,7 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/command-structure.test.ts
+              - packages/cli/src/__tests__/task-close-command.test.ts
               - packages/cli/src/__tests__/task-commands.test.ts
           - id: FR-CLI-016-AC2
             description: require_close_evidence 設定が有効な場合は evidence なし close を拒否できる

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -403,6 +403,31 @@ areas:
             tests:
               - packages/cli/src/__tests__/doctor.test.ts
               - packages/cli/src/__tests__/push-executor.test.ts
+      - id: FR-CLI-016
+        summary: エビデンスベースのタスク close
+        acceptance_criteria:
+          - id: FR-CLI-016-AC1
+            description: close --evidence は close 時の証跡を Issue body に記録できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/command-structure.test.ts
+              - packages/cli/src/__tests__/task-commands.test.ts
+          - id: FR-CLI-016-AC2
+            description: require_close_evidence 設定が有効な場合は evidence なし close を拒否できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/task-commands.test.ts
+              - packages/shared/src/__tests__/schema.test.ts
+          - id: FR-CLI-016-AC3
+            description: acceptance criteria が first-class field として存在する場合、未完了 AC がある task close を拒否できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/task-commands.test.ts
+          - id: FR-CLI-016-AC4
+            description: close evidence block は GitHub Issue body 往復で保持できる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/task-close-evidence.test.ts
   - id: API
     name: REST API
     description: UI と CLI の間のデータアクセス層

--- a/packages/cli/src/__tests__/command-structure.test.ts
+++ b/packages/cli/src/__tests__/command-structure.test.ts
@@ -7,40 +7,40 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/cl
 
   // --- フラット化されたトップレベルコマンド ---
 
-  it("has 'list' as a top-level command", () => {
+  it("list がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("list");
   });
 
-  it("has 'show' as a top-level command", () => {
+  it("show がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("show");
   });
 
-  it("has 'update' as a top-level command", () => {
+  it("update がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("update");
   });
 
-  it("has 'link' as a top-level command", () => {
+  it("link がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("link");
   });
 
-  it("[FR-CLI-014-AC3] has 'close' as a top-level command", () => {
+  it("[FR-CLI-014-AC3] close がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("close");
   });
 
-  it("[FR-CLI-016-AC1] close command exposes --evidence", () => {
+  it("[FR-CLI-016-AC1] close コマンドに --evidence オプションが定義されている", () => {
     const closeCommand = program.commands.find((c) => c.name() === "close")!;
     expect(closeCommand.options.map((option) => option.long)).toContain("--evidence");
   });
 
-  it("has 'context' as a top-level command", () => {
+  it("context がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("context");
   });
 
-  it("has 'sprint' as a top-level command", () => {
+  it("sprint がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("sprint");
   });
 
-  it("has 'ac' as a top-level command", () => {
+  it("ac がトップレベルコマンドとして定義されている", () => {
     expect(commandNames).toContain("ac");
     const acCmd = program.commands.find((c) => c.name() === "ac")!;
     const acSubNames = acCmd.commands.map((c) => c.name());
@@ -50,7 +50,7 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/cl
 
   // --- 既存のトップレベルコマンドは維持 ---
 
-  it("keeps existing top-level commands", () => {
+  it("既存のトップレベルコマンドを維持している", () => {
     for (const name of [
       "init",
       "pull",
@@ -67,7 +67,7 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/cl
 
   // --- 後方互換: task サブコマンドがエイリアスとして残る ---
 
-  it("has 'task' as a backward-compat alias group", () => {
+  it("task が後方互換のエイリアスグループとして定義されている", () => {
     expect(commandNames).toContain("task");
     const taskCmd = program.commands.find((c) => c.name() === "task")!;
     const taskSubNames = taskCmd.commands.map((c) => c.name());
@@ -80,13 +80,13 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/cl
 
   // --- milestone サブコマンドは廃止 ---
 
-  it("does not have 'milestone' as a top-level command", () => {
+  it("milestone はトップレベルコマンドとして定義されていない", () => {
     expect(commandNames).not.toContain("milestone");
   });
 
   // --- トップレベルとエイリアスのコマンドは独立したインスタンス ---
 
-  it("top-level and task-alias commands are distinct instances", () => {
+  it("トップレベルコマンドと task エイリアス配下のコマンドは別インスタンスである", () => {
     const taskCmd = program.commands.find((c) => c.name() === "task")!;
     for (const name of ["list", "show", "update", "link", "close"]) {
       const topLevel = program.commands.find((c) => c.name() === name);

--- a/packages/cli/src/__tests__/command-structure.test.ts
+++ b/packages/cli/src/__tests__/command-structure.test.ts
@@ -27,6 +27,11 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/cl
     expect(commandNames).toContain("close");
   });
 
+  it("[FR-CLI-016-AC1] close command exposes --evidence", () => {
+    const closeCommand = program.commands.find((c) => c.name() === "close")!;
+    expect(closeCommand.options.map((option) => option.long)).toContain("--evidence");
+  });
+
   it("has 'context' as a top-level command", () => {
     expect(commandNames).toContain("context");
   });

--- a/packages/cli/src/__tests__/task-close-command.test.ts
+++ b/packages/cli/src/__tests__/task-close-command.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTaskCloseCommand } from "../commands/task/close.js";
+import type { Config, Task, TasksFile } from "@gh-gantt/shared";
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    version: "1",
+    project: { name: "test", github: { owner: "owner", repo: "repo", project_number: 1 } },
+    sync: {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    },
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+    },
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "owner/repo#1",
+    type: "task",
+    github_issue: 1,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: "Test task",
+    body: null,
+    acceptance_criteria: [],
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeTasksFile(task: Task): TasksFile {
+  return { tasks: [task], cache: { comments: {}, reactions: {} } };
+}
+
+let currentConfig = makeConfig();
+let currentTasksFile = makeTasksFile(makeTask());
+let writtenTasksFile: TasksFile | null = null;
+
+vi.mock("../store/config.js", () => ({
+  ConfigStore: class {
+    async read() {
+      return currentConfig;
+    }
+  },
+}));
+
+vi.mock("../store/tasks.js", () => ({
+  TasksStore: class {
+    async read() {
+      return clone(currentTasksFile);
+    }
+
+    async write(data: TasksFile) {
+      writtenTasksFile = clone(data);
+      currentTasksFile = clone(data);
+    }
+  },
+}));
+
+vi.mock("../util/task-id.js", () => ({
+  resolveTaskId: () => "owner/repo#1",
+}));
+
+describe("[FR-CLI-016-AC1] close command の evidence warning", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    currentConfig = makeConfig();
+    currentTasksFile = makeTasksFile(makeTask());
+    writtenTasksFile = null;
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("空白だけの --evidence は実効証跡なしとして警告する", async () => {
+    const cmd = createTaskCloseCommand();
+
+    await cmd.parseAsync(["close", "1", "--evidence", "   "], { from: "user" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("Closed task: owner/repo#1");
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: closing without evidence. Use --evidence "<summary>".',
+    );
+    expect(writtenTasksFile?.tasks[0].state).toBe("closed");
+    expect(writtenTasksFile?.tasks[0].body).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/task-commands.test.ts
+++ b/packages/cli/src/__tests__/task-commands.test.ts
@@ -549,6 +549,53 @@ describe("applyTaskUpdate", () => {
     expect(result.task.review_approved_at).toBeTruthy();
   });
 
+  it("[FR-CLI-016-AC1] close evidence を Issue body に記録する", () => {
+    const task = makeTask({ body: "実装メモ" });
+    const result = applyTaskUpdate(
+      task,
+      { state: "closed", evidence: "pnpm test:json pass" },
+      config,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.task.state).toBe("closed");
+    expect(result.task.body).toContain("<!-- gh-gantt:close-evidence:start -->");
+    expect(result.task.body).toContain("Evidence:\npnpm test:json pass");
+  });
+
+  it("[FR-CLI-016-AC2] require_close_evidence が true なら evidence なし close を拒否する", () => {
+    const configWithEvidence = makeConfig({ require_close_evidence: true });
+    const task = makeTask();
+    const result = applyTaskUpdate(task, { state: "closed" }, configWithEvidence);
+
+    expect(result.error).toContain("Close evidence is required");
+    expect(result.task).toBe(task);
+  });
+
+  it("[FR-CLI-016-AC3] 未完了の acceptance criteria があれば close を拒否する", () => {
+    const task = makeTask({
+      acceptance_criteria: [
+        { description: "テストが通る", checked: true },
+        { description: "PR が merge 済み", checked: false },
+      ],
+    });
+    const result = applyTaskUpdate(task, { state: "closed", evidence: "テストのみ確認" }, config);
+
+    expect(result.error).toContain("Acceptance criteria must be checked");
+    expect(result.error).toContain("PR が merge 済み");
+    expect(result.task).toBe(task);
+  });
+
+  it("[FR-CLI-016-AC3] acceptance criteria がすべて checked なら close できる", () => {
+    const task = makeTask({
+      acceptance_criteria: [{ description: "テストが通る", checked: true }],
+    });
+    const result = applyTaskUpdate(task, { state: "closed", evidence: "AC checked" }, config);
+
+    expect(result.error).toBeUndefined();
+    expect(result.task.state).toBe("closed");
+  });
+
   it("[FR-CLI-014-AC3] reviewer 以外による承認を拒否する", () => {
     const task = makeTask({ reviewer: "alice" });
     const result = applyTaskUpdate(task, { approveReview: "bob" }, config);

--- a/packages/cli/src/commands/task/close.ts
+++ b/packages/cli/src/commands/task/close.ts
@@ -9,6 +9,7 @@ export function createTaskCloseCommand(): Command {
     .description("Close a task after review checks")
     .argument("<id>", "Task ID (e.g. 6, #6, owner/repo#6)")
     .option("--approve-review <login>", "Mark review as approved by the assigned reviewer")
+    .option("--evidence <summary>", "Record close evidence in the issue body")
     .option("--json", "Output closed task as JSON")
     .action(async (id: string, opts) => {
       try {
@@ -30,6 +31,7 @@ export function createTaskCloseCommand(): Command {
         const updateOpts: TaskUpdateOptions = {
           state: "closed",
           approveReview: opts.approveReview,
+          evidence: opts.evidence,
         };
         const result = applyTaskUpdate(tasksFile.tasks[taskIndex], updateOpts, config);
         if (result.error) {
@@ -40,6 +42,10 @@ export function createTaskCloseCommand(): Command {
 
         tasksFile.tasks[taskIndex] = result.task;
         await tasksStore.write(tasksFile);
+
+        if (!opts.evidence && config.require_close_evidence !== true) {
+          console.warn('Warning: closing without evidence. Use --evidence "<summary>".');
+        }
 
         if (opts.json) {
           console.log(JSON.stringify(result.task, null, 2));

--- a/packages/cli/src/commands/task/close.ts
+++ b/packages/cli/src/commands/task/close.ts
@@ -43,7 +43,8 @@ export function createTaskCloseCommand(): Command {
         tasksFile.tasks[taskIndex] = result.task;
         await tasksStore.write(tasksFile);
 
-        if (!opts.evidence && config.require_close_evidence !== true) {
+        const evidence = typeof opts.evidence === "string" ? opts.evidence.trim() : "";
+        if (evidence.length === 0 && config.require_close_evidence !== true) {
           console.warn('Warning: closing without evidence. Use --evidence "<summary>".');
         }
 

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -3,7 +3,12 @@ import { ConfigStore } from "../../store/config.js";
 import { TasksStore } from "../../store/tasks.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import type { Config, Task } from "@gh-gantt/shared";
-import { computeStatusDateUpdates, normalizeTaskRoleLogin } from "@gh-gantt/shared";
+import {
+  computeStatusDateUpdates,
+  normalizeAcceptanceCriteria,
+  normalizeTaskRoleLogin,
+  serializeTaskCloseEvidenceBody,
+} from "@gh-gantt/shared";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -23,6 +28,7 @@ export interface TaskUpdateOptions {
   requireReview?: boolean;
   approveReview?: string;
   clearReviewApproval?: boolean;
+  evidence?: string;
   milestone?: string;
   label?: string;
   removeLabel?: string;
@@ -48,6 +54,10 @@ export function applyTaskUpdate(
 
   if (opts.state && opts.state !== "open" && opts.state !== "closed") {
     return { task, error: `Invalid state: "${opts.state}". Must be "open" or "closed".` };
+  }
+
+  if (opts.evidence !== undefined && opts.state !== "closed") {
+    return { task, error: "--evidence can only be used when closing a task." };
   }
 
   if (opts.startDate && opts.startDate !== "none" && !DATE_RE.test(opts.startDate)) {
@@ -210,6 +220,23 @@ export function applyTaskUpdate(
     if (reviewError) {
       return { task, error: reviewError };
     }
+
+    const acceptanceCriteriaError = validateTaskCloseAcceptanceCriteria(updated);
+    if (acceptanceCriteriaError) {
+      return { task, error: acceptanceCriteriaError };
+    }
+
+    const evidence = opts.evidence?.trim() ?? "";
+    if (config.require_close_evidence === true && evidence.length === 0) {
+      return { task, error: 'Close evidence is required. Provide --evidence "<summary>".' };
+    }
+    if (evidence.length > 0) {
+      updated.body = serializeTaskCloseEvidenceBody(
+        updated.body,
+        evidence,
+        new Date().toISOString(),
+      );
+    }
   }
 
   updated.updated_at = new Date().toISOString();
@@ -261,6 +288,18 @@ export function validateTaskCloseReview(task: Task, config: Config): string | un
     return `Review must be approved by assigned reviewer "${task.reviewer}".`;
   }
   return undefined;
+}
+
+export function validateTaskCloseAcceptanceCriteria(task: Task): string | undefined {
+  const unchecked = normalizeAcceptanceCriteria(task.acceptance_criteria).filter(
+    (criterion) => !criterion.checked,
+  );
+  if (unchecked.length === 0) {
+    return undefined;
+  }
+  return `Acceptance criteria must be checked before closing: ${unchecked
+    .map((criterion) => criterion.description)
+    .join(", ")}`;
 }
 
 export interface BulkFilterOptions {
@@ -346,6 +385,7 @@ export function createTaskUpdateCommand(): Command {
           requireReview: opts.requireReview,
           approveReview: opts.approveReview,
           clearReviewApproval: opts.clearReviewApproval,
+          evidence: undefined,
           milestone: opts.milestone,
           label: opts.label,
           removeLabel: opts.removeLabel,

--- a/packages/shared/src/__tests__/schema.test.ts
+++ b/packages/shared/src/__tests__/schema.test.ts
@@ -319,6 +319,23 @@ describe("[FR-CLI-015-AC1] タスクサイズ閾値と見積もり field mapping
   });
 });
 
+describe("[FR-CLI-016-AC2] close evidence requirement の設定検証", () => {
+  it("require_close_evidence を設定として受理する", () => {
+    const parsed = ConfigSchema.parse({
+      ...validConfig,
+      require_close_evidence: true,
+    });
+
+    expect(parsed.require_close_evidence).toBe(true);
+  });
+
+  it("require_close_evidence 未指定時は false として扱う", () => {
+    const parsed = ConfigSchema.parse(validConfig);
+
+    expect(parsed.require_close_evidence).toBe(false);
+  });
+});
+
 describe("TasksFileSchema", () => {
   it("[FR-CLI-011-AC1] acceptance_criteria 未指定の既存 task を空配列として受理する", () => {
     const data = {

--- a/packages/shared/src/__tests__/task-close-evidence.test.ts
+++ b/packages/shared/src/__tests__/task-close-evidence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTaskCloseEvidenceBody,
+  serializeTaskCloseEvidenceBody,
+  TASK_CLOSE_EVIDENCE_END_MARKER,
+  TASK_CLOSE_EVIDENCE_START_MARKER,
+} from "../index.js";
+
+describe("[FR-CLI-016-AC4] close evidence の Issue body 往復", () => {
+  it("close evidence block を body に追加して parse できる", () => {
+    const body = serializeTaskCloseEvidenceBody(
+      "本文",
+      "pnpm test:json と PR #222 merge を確認",
+      "2026-05-03T22:30:00.000Z",
+    );
+
+    expect(body).toContain(TASK_CLOSE_EVIDENCE_START_MARKER);
+    expect(body).toContain("Recorded-At: 2026-05-03T22:30:00.000Z");
+    expect(body).toContain("pnpm test:json と PR #222 merge を確認");
+    expect(body).toContain(TASK_CLOSE_EVIDENCE_END_MARKER);
+
+    const parsed = parseTaskCloseEvidenceBody(body);
+    expect(parsed.body).toBe("本文");
+    expect(parsed.evidence).toBe("pnpm test:json と PR #222 merge を確認");
+    expect(parsed.recorded_at).toBe("2026-05-03T22:30:00.000Z");
+    expect(parsed.has_close_evidence_block).toBe(true);
+  });
+
+  it("既存の close evidence block を置き換える", () => {
+    const first = serializeTaskCloseEvidenceBody("本文", "古い証跡", "2026-05-03T22:00:00.000Z");
+    const second = serializeTaskCloseEvidenceBody(first, "新しい証跡", "2026-05-03T22:30:00.000Z");
+
+    expect(second).not.toContain("古い証跡");
+    expect(parseTaskCloseEvidenceBody(second).evidence).toBe("新しい証跡");
+  });
+});

--- a/packages/shared/src/__tests__/task-close-evidence.test.ts
+++ b/packages/shared/src/__tests__/task-close-evidence.test.ts
@@ -33,4 +33,24 @@ describe("[FR-CLI-016-AC4] close evidence の Issue body 往復", () => {
     expect(second).not.toContain("古い証跡");
     expect(parseTaskCloseEvidenceBody(second).evidence).toBe("新しい証跡");
   });
+
+  it("手編集された大小文字違いの管理ブロックを parse できる", () => {
+    const body = [
+      "本文",
+      TASK_CLOSE_EVIDENCE_START_MARKER.toUpperCase(),
+      "## 完了証跡",
+      "",
+      "recorded-at: 2026-05-03T22:30:00.000Z",
+      "evidence:",
+      "pnpm test:json pass",
+      TASK_CLOSE_EVIDENCE_END_MARKER.toUpperCase(),
+    ].join("\n");
+
+    const parsed = parseTaskCloseEvidenceBody(body);
+
+    expect(parsed.body).toBe("本文");
+    expect(parsed.recorded_at).toBe("2026-05-03T22:30:00.000Z");
+    expect(parsed.evidence).toBe("pnpm test:json pass");
+    expect(parsed.has_close_evidence_block).toBe(true);
+  });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./comments.js";
 export * from "./acceptance-criteria.js";
 export * from "./task-roles.js";
 export * from "./task-review.js";
+export * from "./task-close-evidence.js";
 export * from "./task-size.js";
 export * from "./status-dates.js";
 export * from "./dependency-graph.js";

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -168,6 +168,7 @@ export const ConfigSchema: z.ZodType<Config> = z.object({
   task_templates: TaskTemplatesSchema.optional(),
   doctor: DoctorConfigSchema.optional(),
   require_review_for_types: z.array(z.string().trim().min(1)).default([]),
+  require_close_evidence: z.boolean().default(false),
   max_task_size_hours: z.number().positive().optional(),
 });
 

--- a/packages/shared/src/task-close-evidence.ts
+++ b/packages/shared/src/task-close-evidence.ts
@@ -5,7 +5,7 @@ const TASK_CLOSE_EVIDENCE_BLOCK_RE = new RegExp(
   `\\n*${escapeRegExp(TASK_CLOSE_EVIDENCE_START_MARKER)}[\\s\\S]*?${escapeRegExp(
     TASK_CLOSE_EVIDENCE_END_MARKER,
   )}\\n*`,
-  "m",
+  "im",
 );
 
 function escapeRegExp(value: string): string {
@@ -40,18 +40,20 @@ export function parseTaskCloseEvidenceBody(body: string | null): {
   let recordedAt: string | null = null;
   let collectingEvidence = false;
   const evidenceLines: string[] = [];
+  const endMarker = TASK_CLOSE_EVIDENCE_END_MARKER.toLowerCase();
   for (const line of match[0].split(/\r?\n/)) {
-    if (line.trim() === TASK_CLOSE_EVIDENCE_END_MARKER) break;
+    const trimmedLine = line.trim();
+    if (trimmedLine.toLowerCase() === endMarker) break;
     if (collectingEvidence) {
       evidenceLines.push(line);
       continue;
     }
-    const recordedAtLine = line.match(/^Recorded-At:\s*(.*)$/);
+    const recordedAtLine = line.match(/^Recorded-At:\s*(.*)$/i);
     if (recordedAtLine) {
       recordedAt = recordedAtLine[1].trim() || null;
       continue;
     }
-    if (line.trim() === "Evidence:") {
+    if (/^Evidence:\s*$/i.test(trimmedLine)) {
       collectingEvidence = true;
     }
   }

--- a/packages/shared/src/task-close-evidence.ts
+++ b/packages/shared/src/task-close-evidence.ts
@@ -1,0 +1,103 @@
+export const TASK_CLOSE_EVIDENCE_START_MARKER = "<!-- gh-gantt:close-evidence:start -->";
+export const TASK_CLOSE_EVIDENCE_END_MARKER = "<!-- gh-gantt:close-evidence:end -->";
+
+const TASK_CLOSE_EVIDENCE_BLOCK_RE = new RegExp(
+  `\\n*${escapeRegExp(TASK_CLOSE_EVIDENCE_START_MARKER)}[\\s\\S]*?${escapeRegExp(
+    TASK_CLOSE_EVIDENCE_END_MARKER,
+  )}\\n*`,
+  "m",
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function parseTaskCloseEvidenceBody(body: string | null): {
+  body: string | null;
+  evidence: string | null;
+  recorded_at: string | null;
+  has_close_evidence_block: boolean;
+} {
+  if (body == null) {
+    return {
+      body: null,
+      evidence: null,
+      recorded_at: null,
+      has_close_evidence_block: false,
+    };
+  }
+
+  const match = body.match(TASK_CLOSE_EVIDENCE_BLOCK_RE);
+  if (!match) {
+    return {
+      body,
+      evidence: null,
+      recorded_at: null,
+      has_close_evidence_block: false,
+    };
+  }
+
+  let recordedAt: string | null = null;
+  let collectingEvidence = false;
+  const evidenceLines: string[] = [];
+  for (const line of match[0].split(/\r?\n/)) {
+    if (line.trim() === TASK_CLOSE_EVIDENCE_END_MARKER) break;
+    if (collectingEvidence) {
+      evidenceLines.push(line);
+      continue;
+    }
+    const recordedAtLine = line.match(/^Recorded-At:\s*(.*)$/);
+    if (recordedAtLine) {
+      recordedAt = recordedAtLine[1].trim() || null;
+      continue;
+    }
+    if (line.trim() === "Evidence:") {
+      collectingEvidence = true;
+    }
+  }
+
+  const stripped = body
+    .replace(TASK_CLOSE_EVIDENCE_BLOCK_RE, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  const evidence = evidenceLines.join("\n").trim();
+
+  return {
+    body: stripped.length > 0 ? stripped : null,
+    evidence: evidence.length > 0 ? evidence : null,
+    recorded_at: recordedAt,
+    has_close_evidence_block: true,
+  };
+}
+
+export function renderTaskCloseEvidenceBlock(evidence: string, recordedAt: string): string | null {
+  const trimmedEvidence = evidence.trim();
+  const trimmedRecordedAt = recordedAt.trim();
+  if (trimmedEvidence.length === 0 || trimmedRecordedAt.length === 0) {
+    return null;
+  }
+
+  return [
+    TASK_CLOSE_EVIDENCE_START_MARKER,
+    "## 完了証跡",
+    "",
+    `Recorded-At: ${trimmedRecordedAt}`,
+    "Evidence:",
+    trimmedEvidence,
+    TASK_CLOSE_EVIDENCE_END_MARKER,
+  ].join("\n");
+}
+
+export function serializeTaskCloseEvidenceBody(
+  body: string | null,
+  evidence: string | null | undefined,
+  recordedAt: string,
+): string | null {
+  const cleanedBody = parseTaskCloseEvidenceBody(body).body;
+  const block = renderTaskCloseEvidenceBlock(evidence ?? "", recordedAt);
+  if (!block) {
+    return cleanedBody;
+  }
+
+  return cleanedBody ? `${cleanedBody.trim()}\n\n${block}` : block;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -161,6 +161,7 @@ export interface Config {
   task_templates?: TaskTemplates;
   doctor?: DoctorConfig;
   require_review_for_types?: string[];
+  require_close_evidence?: boolean;
   max_task_size_hours?: number;
 }
 

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -110,6 +110,7 @@ export interface Config {
   grouping?: GroupingConfig;
   sprints?: SprintConfig[];
   require_review_for_types?: string[];
+  require_close_evidence?: boolean;
   max_task_size_hours?: number;
 }
 


### PR DESCRIPTION
## 概要
- gh-gantt close に --evidence を追加し、完了証跡を Issue body の管理ブロックへ記録
- require_close_evidence 設定で証跡なし close を拒否し、既定では warning を表示
- close 時に未完了 acceptance criteria を拒否し、FR-CLI-016 の trace を追加

## 検証
- pre-push: test / build / req-trace / req-validate / docs-gen all passed
- req:trace: covered=100, uncovered=21, failing=0
- req:validate: 24 warnings, 0 errors

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * タスククローズ時に `--evidence` オプションでエビデンスを記録できるようになりました
  * `require_close_evidence` 設定オプションを追加し、エビデンス記録の必須化が可能になりました
  * チェック未了の受け入れ基準がある場合、タスククローズを拒否するようになりました
  * GitHubのIssue本文を通じてエビデンスブロックの情報を保持・復元できるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->