### PR TITLE
feat(ui): 1カラム詳細パネルでメタ情報を編集可能にする

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -532,6 +532,16 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/updated-at-display.test.tsx
+          - id: FR-VIS-006-AC3
+            description: 1カラムレイアウトでもタスクの Status、Priority、Type、日付を編集できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
+          - id: FR-VIS-006-AC4
+            description: 1カラムレイアウトで Open/Closed の state を重複表示しない
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
       - id: FR-VIS-007
         summary: 日付計算ユーティリティ
         acceptance_criteria:

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -88,6 +88,14 @@ const sprintConfig: Config = {
   ],
 };
 
+const priorityConfig: Config = {
+  ...config,
+  sync: {
+    ...config.sync,
+    field_mapping: { ...config.sync.field_mapping, priority: "Priority" },
+  },
+};
+
 describe("TaskDetailPanel", () => {
   afterEach(() => {
     cleanup();
@@ -211,5 +219,120 @@ describe("TaskDetailPanel", () => {
     );
 
     expect(queryByLabelText("Sprint")).toBeNull();
+  });
+});
+
+describe("[FR-VIS-006-AC3] 1カラムレイアウトでもタスクの Status、Priority、Type、日付を編集できる", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("1カラムで Status、Priority、Type、Start Date、End Date を変更できる", () => {
+    const task = makeTask({ custom_fields: { Status: "In Progress", Priority: "medium" } });
+    const onUpdate = vi.fn();
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={priorityConfig}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+        width={400}
+      />,
+    );
+
+    fireEvent.change(getByLabelText("Status"), { target: { value: "Done" } });
+    fireEvent.change(getByLabelText("Priority"), { target: { value: "high" } });
+    fireEvent.change(getByLabelText("Type"), { target: { value: "epic" } });
+    fireEvent.change(getByLabelText("Start Date"), { target: { value: "2026-02-01" } });
+    fireEvent.change(getByLabelText("End Date"), { target: { value: "2026-02-14" } });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      custom_fields: { Status: "Done", Priority: "medium" },
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      custom_fields: { Status: "In Progress", Priority: "high" },
+    });
+    expect(onUpdate).toHaveBeenCalledWith({ type: "epic" });
+    expect(onUpdate).toHaveBeenCalledWith({ start_date: "2026-02-01" });
+    expect(onUpdate).toHaveBeenCalledWith({ end_date: "2026-02-14" });
+  });
+
+  it("1カラムで milestone の Due Date を変更できる", () => {
+    const milestone = makeTask({
+      type: "milestone",
+      id: "stanah/gh-gantt#7",
+      github_issue: null,
+      title: "Milestone",
+      date: "2026-03-01",
+      start_date: null,
+      end_date: null,
+    });
+    const onUpdate = vi.fn();
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={milestone}
+        config={priorityConfig}
+        comments={[]}
+        allTasks={[milestone]}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+        width={400}
+      />,
+    );
+
+    fireEvent.change(getByLabelText("Due Date"), { target: { value: "2026-03-15" } });
+
+    expect(onUpdate).toHaveBeenCalledWith({ date: "2026-03-15" });
+  });
+
+  it("2カラムの既存メタ編集も維持する", () => {
+    const task = makeTask({ custom_fields: { Status: "In Progress", Priority: "medium" } });
+    const onUpdate = vi.fn();
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={priorityConfig}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+        width={640}
+      />,
+    );
+
+    fireEvent.change(getByLabelText("Status"), { target: { value: "Done" } });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      custom_fields: { Status: "Done", Priority: "medium" },
+    });
+  });
+});
+
+describe("[FR-VIS-006-AC4] 1カラムレイアウトで Open/Closed の state を重複表示しない", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("1カラムでは state badge を DetailHeader の1件だけ表示する", () => {
+    const task = makeTask();
+    const { getAllByText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={priorityConfig}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+        width={400}
+      />,
+    );
+
+    expect(getAllByText("Open")).toHaveLength(1);
   });
 });

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -253,7 +253,7 @@ describe("[FR-VIS-006-AC3] 1カラムレイアウトでもタスクの Status、
       custom_fields: { Status: "Done", Priority: "medium" },
     });
     expect(onUpdate).toHaveBeenCalledWith({
-      custom_fields: { Status: "In Progress", Priority: "high" },
+      custom_fields: { Status: "Done", Priority: "high" },
     });
     expect(onUpdate).toHaveBeenCalledWith({ type: "epic" });
     expect(onUpdate).toHaveBeenCalledWith({ start_date: "2026-02-01" });

--- a/packages/ui/src/components/TaskDetailPanel.tsx
+++ b/packages/ui/src/components/TaskDetailPanel.tsx
@@ -6,8 +6,6 @@ import { DetailHeader } from "./detail/DetailHeader.js";
 import { DetailMetaSidebar } from "./detail/DetailMetaSidebar.js";
 import { DetailSubTasks } from "./detail/DetailSubTasks.js";
 import { DetailRelations } from "./detail/DetailRelations.js";
-import { DetailSprintControl } from "./detail/DetailSprintControl.js";
-import { formatUpdatedAt } from "../lib/date-utils.js";
 
 const MIN_PANEL_WIDTH = 320;
 const MAX_PANEL_WIDTH = 800;
@@ -46,7 +44,6 @@ export function TaskDetailPanel({
   const taskType = config.task_types[task.type];
   const isMilestone = task.type === "milestone";
   const isTwoColumn = width >= TWO_COLUMN_THRESHOLD;
-  const updatedAt = formatUpdatedAt(task.updated_at);
   const renderPreview =
     renderMarkdownPreview ?? ((value: string) => <MarkdownRenderer markdown={value} />);
 
@@ -136,23 +133,6 @@ export function TaskDetailPanel({
       }
     };
   }, []);
-
-  // Priority for inline badges (1-column)
-  const priorityFieldName = config.sync?.field_mapping?.priority;
-  const rawPriority = priorityFieldName ? task.custom_fields[priorityFieldName] : undefined;
-  const currentPriority = typeof rawPriority === "string" ? rawPriority : "";
-
-  const dateRange = isMilestone
-    ? task.date
-      ? task.date.slice(0, 10)
-      : null
-    : task.start_date && task.end_date
-      ? `${task.start_date.slice(0, 10)} \u2013 ${task.end_date.slice(0, 10)}`
-      : task.start_date
-        ? task.start_date.slice(0, 10)
-        : task.end_date
-          ? task.end_date.slice(0, 10)
-          : null;
 
   return (
     <div
@@ -414,99 +394,19 @@ export function TaskDetailPanel({
             taskTypeColor={taskType?.color}
           />
 
-          {/* Inline badges */}
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 5, alignItems: "center" }}>
-            <span
-              style={{
-                padding: "2px 8px",
-                fontSize: 10,
-                background:
-                  task.state === "open"
-                    ? "var(--color-success-bg)"
-                    : "var(--color-complete-bg, var(--color-border-light))",
-                color:
-                  task.state === "open"
-                    ? "var(--color-success)"
-                    : "var(--color-complete, var(--color-text-muted))",
-                borderRadius: 12,
-              }}
-            >
-              ● {task.state === "open" ? "Open" : "Closed"}
-            </span>
-            {currentStatus && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  fontSize: 10,
-                  background: "var(--color-border-light)",
-                  borderRadius: 12,
-                }}
-              >
-                {currentStatus}
-              </span>
-            )}
-            {currentPriority && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  fontSize: 10,
-                  background: "var(--color-border-light)",
-                  borderRadius: 12,
-                }}
-              >
-                {currentPriority}
-              </span>
-            )}
-            {!isMilestone && taskType && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  fontSize: 10,
-                  background: "var(--color-border-light)",
-                  borderRadius: 12,
-                }}
-              >
-                {taskType.label}
-              </span>
-            )}
-            {dateRange && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  fontSize: 10,
-                  background: "var(--color-border-light)",
-                  borderRadius: 12,
-                }}
-              >
-                {dateRange}
-              </span>
-            )}
-            <span
-              style={{
-                padding: "2px 8px",
-                fontSize: 10,
-                background: "var(--color-border-light)",
-                borderRadius: 12,
-              }}
-            >
-              Updated {updatedAt}
-            </span>
-            {task.assignees.map((a) => (
-              <span
-                key={a}
-                style={{
-                  padding: "2px 8px",
-                  fontSize: 10,
-                  background: "var(--color-selected-bg)",
-                  borderRadius: 12,
-                }}
-              >
-                {a}
-              </span>
-            ))}
+          <div
+            style={{
+              borderTop: "1px solid var(--color-border-light)",
+              paddingTop: 12,
+            }}
+          >
+            <DetailMetaSidebar
+              task={task}
+              config={config}
+              onUpdate={onUpdate}
+              isMilestone={isMilestone}
+            />
           </div>
-
-          {!isMilestone && <DetailSprintControl task={task} config={config} onUpdate={onUpdate} />}
 
           {/* Description */}
           <div>

--- a/packages/ui/src/components/detail/DetailMetaSidebar.tsx
+++ b/packages/ui/src/components/detail/DetailMetaSidebar.tsx
@@ -59,6 +59,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
         <div style={{ marginBottom: 14 }}>
           <label style={labelStyle}>Status</label>
           <select
+            aria-label="Status"
             value={currentStatus ?? ""}
             onChange={(e) =>
               onUpdate({
@@ -81,6 +82,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
         <div style={{ marginBottom: 14 }}>
           <label style={labelStyle}>Priority</label>
           <select
+            aria-label="Priority"
             value={currentPriority}
             onChange={(e) =>
               onUpdate({
@@ -106,6 +108,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
         <div style={{ marginBottom: 14 }}>
           <label style={labelStyle}>Type</label>
           <select
+            aria-label="Type"
             value={task.type}
             onChange={(e) => onUpdate({ type: e.target.value })}
             style={selectStyle}
@@ -129,6 +132,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
           <div style={{ marginBottom: 14 }}>
             <label style={labelStyle}>Due Date</label>
             <input
+              aria-label="Due Date"
               type="date"
               value={(task.date ?? "").slice(0, 10)}
               onChange={(e) => onUpdate({ date: e.target.value || null })}
@@ -140,6 +144,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
             <div style={{ marginBottom: 14 }}>
               <label style={labelStyle}>Start Date</label>
               <input
+                aria-label="Start Date"
                 type="date"
                 value={(task.start_date ?? "").slice(0, 10)}
                 onChange={(e) => onUpdate({ start_date: e.target.value || null })}
@@ -149,6 +154,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
             <div style={{ marginBottom: 14 }}>
               <label style={labelStyle}>End Date</label>
               <input
+                aria-label="End Date"
                 type="date"
                 value={(task.end_date ?? "").slice(0, 10)}
                 onChange={(e) => onUpdate({ end_date: e.target.value || null })}

--- a/packages/ui/src/components/detail/DetailMetaSidebar.tsx
+++ b/packages/ui/src/components/detail/DetailMetaSidebar.tsx
@@ -44,13 +44,27 @@ const separatorStyle: React.CSSProperties = {
 };
 
 export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: DetailMetaSidebarProps) {
+  const [customFieldsDraft, setCustomFieldsDraft] = React.useState(task.custom_fields);
+  const customFieldsDraftRef = React.useRef(task.custom_fields);
   const statusFieldName = config.statuses.field_name;
-  const currentStatus = task.custom_fields[statusFieldName] as string | undefined;
+  const currentStatus = customFieldsDraft[statusFieldName] as string | undefined;
   const statusOptions = Object.keys(config.statuses.values);
   const priorityFieldName = config.sync?.field_mapping?.priority;
-  const rawPriority = priorityFieldName ? task.custom_fields[priorityFieldName] : undefined;
+  const rawPriority = priorityFieldName ? customFieldsDraft[priorityFieldName] : undefined;
   const currentPriority = typeof rawPriority === "string" ? rawPriority.toLowerCase() : "";
   const updatedAt = formatUpdatedAt(task.updated_at);
+
+  React.useEffect(() => {
+    customFieldsDraftRef.current = task.custom_fields;
+    setCustomFieldsDraft(task.custom_fields);
+  }, [task.id, task.custom_fields]);
+
+  const updateCustomField = (fieldName: string, value: unknown) => {
+    const nextCustomFields = { ...customFieldsDraftRef.current, [fieldName]: value };
+    customFieldsDraftRef.current = nextCustomFields;
+    setCustomFieldsDraft(nextCustomFields);
+    onUpdate({ custom_fields: nextCustomFields });
+  };
 
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
@@ -61,11 +75,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
           <select
             aria-label="Status"
             value={currentStatus ?? ""}
-            onChange={(e) =>
-              onUpdate({
-                custom_fields: { ...task.custom_fields, [statusFieldName]: e.target.value },
-              })
-            }
+            onChange={(e) => updateCustomField(statusFieldName, e.target.value)}
             style={selectStyle}
           >
             {statusOptions.map((s) => (
@@ -84,14 +94,7 @@ export function DetailMetaSidebar({ task, config, onUpdate, isMilestone }: Detai
           <select
             aria-label="Priority"
             value={currentPriority}
-            onChange={(e) =>
-              onUpdate({
-                custom_fields: {
-                  ...task.custom_fields,
-                  [priorityFieldName]: e.target.value || undefined,
-                },
-              })
-            }
+            onChange={(e) => updateCustomField(priorityFieldName, e.target.value || undefined)}
             style={selectStyle}
           >
             <option value="">None</option>


### PR DESCRIPTION
## 概要

- 1カラムのタスク詳細パネルでも `DetailMetaSidebar` を表示し、Status / Priority / Type / 日付 / Sprint を編集可能にしました。
- 1カラム専用の読み取り専用 inline badges を削除し、Open/Closed の state が重複表示されないようにしました。
- `DetailMetaSidebar` の編集コントロールに `aria-label` を追加し、1カラム/2カラム双方の操作をテストで確認しました。
- `FR-VIS-006-AC3` / `FR-VIS-006-AC4` を requirements に追加しました。

## 検証

- `pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/detail-panel.test.tsx`
- `pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/detail-panel.test.tsx src/__tests__/detail-relations.test.tsx src/__tests__/detail-sub-tasks.test.tsx src/__tests__/updated-at-display.test.tsx`
- `pnpm lint`
- `pnpm test:json`
- `pnpm req:trace`
- `pnpm req:validate`
- `pnpm build`
- `pnpm docs:gen`
- git push の pre-push gate

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * タスク詳細パネルの1列レイアウトで、ステータス、優先度、種別、開始日、終了日を直接編集できるようになりました。

* **Accessibility**
  * フォーム要素にアクセシビリティラベルを追加し、支援技術との互換性を向上させました。

* **Tests**
  * タスク詳細パネルの新機能に対するテストカバレッジを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->