### PR TITLE
feat(ui): 国別祝日プリセットを追加 (#228)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -698,6 +698,24 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/working-calendar.test.tsx
+      - id: FR-VIS-017
+        summary: 稼働カレンダーの国別祝日プリセット
+        acceptance_criteria:
+          - id: FR-VIS-017-AC1
+            description: Calendar Settings で祝日プリセットを選択しプリセット休日を表示できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/working-calendar.test.tsx
+          - id: FR-VIS-017-AC2
+            description: 2026 年の日本と米国連邦祝日をプリセットとして提供する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/working-calendar.test.tsx
+          - id: FR-VIS-017-AC3
+            description: 選択した祝日プリセットを localStorage に保存し GanttChart の非稼働日表示に反映する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/working-calendar.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -19,6 +19,7 @@ import { useUndoRedo } from "./hooks/useUndoRedo.js";
 import { SkeletonLoader } from "./components/SkeletonLoader.js";
 import { ThemeProvider } from "./contexts/ThemeContext.js";
 import { useCustomNonWorkingDays } from "./hooks/useCustomNonWorkingDays.js";
+import { useHolidayPreset } from "./hooks/useHolidayPreset.js";
 
 const EMPTY_TASK_TYPES: Record<string, never> = {};
 
@@ -84,6 +85,8 @@ export function App() {
   } | null>(null);
   const [syncing, setSyncing] = useState<"pull" | "push" | null>(null);
   const { customDaysOff, addCustomDayOff, removeCustomDayOff } = useCustomNonWorkingDays();
+  const { holidayPresetOptions, selectedHolidayPresetId, presetHolidays, selectHolidayPreset } =
+    useHolidayPreset();
   const {
     canUndo,
     canRedo,
@@ -616,6 +619,10 @@ export function App() {
             enabledTypes={enabled}
             onToggleType={toggleType}
             configuredHolidays={config.gantt.holidays ?? []}
+            holidayPresetOptions={holidayPresetOptions}
+            selectedHolidayPresetId={selectedHolidayPresetId}
+            presetHolidays={presetHolidays}
+            onSelectHolidayPreset={selectHolidayPreset}
             customDaysOff={customDaysOff}
             onAddCustomDayOff={addCustomDayOff}
             onRemoveCustomDayOff={removeCustomDayOff}
@@ -673,6 +680,7 @@ export function App() {
                     onHoverTask={setHoveredTaskId}
                     dependencyHighlightEnabled={dependencyHighlightEnabled}
                     highlightRelationMap={highlightRelationMap}
+                    presetHolidays={presetHolidays}
                     customDaysOff={customDaysOff}
                   />
                 }

--- a/packages/ui/src/__tests__/working-calendar.test.tsx
+++ b/packages/ui/src/__tests__/working-calendar.test.tsx
@@ -9,7 +9,11 @@ import { GanttGrid } from "../components/GanttGrid.js";
 import { CalendarSettingsMenu } from "../components/toolbar/CalendarSettingsMenu.js";
 import { useCustomNonWorkingDays } from "../hooks/useCustomNonWorkingDays.js";
 import { useHolidayPreset, HOLIDAY_PRESET_STORAGE_KEY } from "../hooks/useHolidayPreset.js";
-import { HOLIDAY_PRESETS, getHolidayPresetHolidays } from "../lib/holiday-presets.js";
+import {
+  HOLIDAY_PRESETS,
+  getHolidayPresetHolidays,
+  type HolidayPresetId,
+} from "../lib/holiday-presets.js";
 import type { Config, Task } from "../types/index.js";
 import type { TreeNode } from "../hooks/useTaskTree.js";
 
@@ -59,6 +63,24 @@ function HolidayPresetHarness() {
       selectedHolidayPresetId={selectedHolidayPresetId}
       presetHolidays={presetHolidays}
       onSelectHolidayPreset={selectHolidayPreset}
+      customDaysOff={[]}
+      onAddCustomDayOff={() => {}}
+      onRemoveCustomDayOff={() => {}}
+    />
+  );
+}
+
+function ControlledHolidayPresetHarness() {
+  const [selectedHolidayPresetId, setSelectedHolidayPresetId] =
+    React.useState<HolidayPresetId>("jp-2026");
+
+  return (
+    <CalendarSettingsMenu
+      configuredHolidays={[]}
+      holidayPresetOptions={HOLIDAY_PRESETS}
+      selectedHolidayPresetId={selectedHolidayPresetId}
+      presetHolidays={getHolidayPresetHolidays(selectedHolidayPresetId)}
+      onSelectHolidayPreset={setSelectedHolidayPresetId}
       customDaysOff={[]}
       onAddCustomDayOff={() => {}}
       onRemoveCustomDayOff={() => {}}
@@ -184,32 +206,16 @@ describe("[FR-VIS-017-AC1] 国別祝日プリセット選択", () => {
   });
 
   it("Calendar Settings で祝日プリセットを選択しプリセット休日を表示できる", () => {
-    const onSelectHolidayPreset = vi.fn();
-    const { getByTitle, getByLabelText, getByText } = render(
-      <CalendarSettingsMenu
-        configuredHolidays={[]}
-        customDaysOff={[]}
-        onAddCustomDayOff={() => {}}
-        onRemoveCustomDayOff={() => {}}
-        holidayPresetOptions={[
-          { id: "none", label: "None", holidays: [] },
-          {
-            id: "jp-2026",
-            label: "Japan 2026",
-            holidays: [{ date: "2026-01-12", name: "成人の日" }],
-          },
-        ]}
-        selectedHolidayPresetId="jp-2026"
-        presetHolidays={[{ date: "2026-01-12", name: "成人の日" }]}
-        onSelectHolidayPreset={onSelectHolidayPreset}
-      />,
+    const { getByTitle, getByLabelText, getByText, queryByText } = render(
+      <ControlledHolidayPresetHarness />,
     );
 
     fireEvent.click(getByTitle("Calendar Settings"));
+    expect(getByText("2026-01-12 成人の日")).toBeTruthy();
+
     fireEvent.change(getByLabelText("Holiday preset"), { target: { value: "none" } });
 
-    expect(onSelectHolidayPreset).toHaveBeenCalledWith("none");
-    expect(getByText("2026-01-12 成人の日")).toBeTruthy();
+    expect(queryByText("2026-01-12 成人の日")).toBeNull();
   });
 });
 
@@ -255,6 +261,40 @@ describe("[FR-VIS-017-AC3] 祝日プリセットの localStorage 管理とグリ
 
     expect(localStorage.getItem(HOLIDAY_PRESET_STORAGE_KEY)).toBe("us-federal-2026");
     expect(getByText("2026-07-03 Independence Day")).toBeTruthy();
+  });
+
+  it("localStorage 読み取り失敗時は none で初期化する", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("blocked");
+    });
+
+    try {
+      const { getByTitle, getByLabelText } = render(<HolidayPresetHarness />);
+
+      fireEvent.click(getByTitle("Calendar Settings"));
+      expect((getByLabelText("Holiday preset") as HTMLSelectElement).value).toBe("none");
+    } finally {
+      getItemSpy.mockRestore();
+    }
+  });
+
+  it("localStorage 書き込み失敗時も画面上の選択状態を更新する", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded");
+    });
+
+    try {
+      const { getByTitle, getByLabelText, getByText } = render(<HolidayPresetHarness />);
+
+      fireEvent.click(getByTitle("Calendar Settings"));
+      fireEvent.change(getByLabelText("Holiday preset"), {
+        target: { value: "us-federal-2026" },
+      });
+
+      expect(getByText("2026-07-03 Independence Day")).toBeTruthy();
+    } finally {
+      setItemSpy.mockRestore();
+    }
   });
 
   it("選択プリセット休日を GanttChart の非稼働日表示に反映する", () => {

--- a/packages/ui/src/__tests__/working-calendar.test.tsx
+++ b/packages/ui/src/__tests__/working-calendar.test.tsx
@@ -4,9 +4,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup, fireEvent } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { scaleTime } from "d3-scale";
+import { GanttChart } from "../components/GanttChart.js";
 import { GanttGrid } from "../components/GanttGrid.js";
 import { CalendarSettingsMenu } from "../components/toolbar/CalendarSettingsMenu.js";
 import { useCustomNonWorkingDays } from "../hooks/useCustomNonWorkingDays.js";
+import { useHolidayPreset, HOLIDAY_PRESET_STORAGE_KEY } from "../hooks/useHolidayPreset.js";
+import { HOLIDAY_PRESETS, getHolidayPresetHolidays } from "../lib/holiday-presets.js";
+import type { Config, Task } from "../types/index.js";
+import type { TreeNode } from "../hooks/useTaskTree.js";
 
 describe("[FR-VIS-016-AC3] Gantt grid の休日・休暇日表示", () => {
   it("休日・休暇日を週末とは別の非稼働日として描画する", () => {
@@ -43,6 +48,91 @@ function CalendarSettingsHarness() {
     />
   );
 }
+
+function HolidayPresetHarness() {
+  const { selectedHolidayPresetId, presetHolidays, selectHolidayPreset } = useHolidayPreset();
+
+  return (
+    <CalendarSettingsMenu
+      configuredHolidays={[]}
+      holidayPresetOptions={HOLIDAY_PRESETS}
+      selectedHolidayPresetId={selectedHolidayPresetId}
+      presetHolidays={presetHolidays}
+      onSelectHolidayPreset={selectHolidayPreset}
+      customDaysOff={[]}
+      onAddCustomDayOff={() => {}}
+      onRemoveCustomDayOff={() => {}}
+    />
+  );
+}
+
+const workingCalendarTask: Task = {
+  id: "stanah/gh-gantt#228",
+  type: "task",
+  github_issue: 228,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "国別祝日プリセット",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: {},
+  start_date: "2026-01-05",
+  end_date: "2026-01-16",
+  date: null,
+  blocked_by: [],
+};
+
+const workingCalendarConfig: Config = {
+  version: "1",
+  project: {
+    name: "Test Project",
+    github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: {
+      start_date: "Start Date",
+      end_date: "End Date",
+      status: "Status",
+    },
+  },
+  task_types: {
+    task: {
+      label: "Task",
+      display: "bar",
+      color: "#27AE60",
+      github_label: null,
+    },
+  },
+  type_hierarchy: { task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+const workingCalendarFlatList: TreeNode[] = [{ task: workingCalendarTask, children: [], depth: 0 }];
 
 describe("[FR-VIS-016-AC4] カスタム休暇日の localStorage 管理", () => {
   beforeEach(() => {
@@ -85,5 +175,120 @@ describe("[FR-VIS-016-AC4] カスタム休暇日の localStorage 管理", () => 
     expect(queryByText("not json")).toBeNull();
 
     errorSpy.mockRestore();
+  });
+});
+
+describe("[FR-VIS-017-AC1] 国別祝日プリセット選択", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("Calendar Settings で祝日プリセットを選択しプリセット休日を表示できる", () => {
+    const onSelectHolidayPreset = vi.fn();
+    const { getByTitle, getByLabelText, getByText } = render(
+      <CalendarSettingsMenu
+        configuredHolidays={[]}
+        customDaysOff={[]}
+        onAddCustomDayOff={() => {}}
+        onRemoveCustomDayOff={() => {}}
+        holidayPresetOptions={[
+          { id: "none", label: "None", holidays: [] },
+          {
+            id: "jp-2026",
+            label: "Japan 2026",
+            holidays: [{ date: "2026-01-12", name: "成人の日" }],
+          },
+        ]}
+        selectedHolidayPresetId="jp-2026"
+        presetHolidays={[{ date: "2026-01-12", name: "成人の日" }]}
+        onSelectHolidayPreset={onSelectHolidayPreset}
+      />,
+    );
+
+    fireEvent.click(getByTitle("Calendar Settings"));
+    fireEvent.change(getByLabelText("Holiday preset"), { target: { value: "none" } });
+
+    expect(onSelectHolidayPreset).toHaveBeenCalledWith("none");
+    expect(getByText("2026-01-12 成人の日")).toBeTruthy();
+  });
+});
+
+describe("[FR-VIS-017-AC2] 国別祝日プリセット定義", () => {
+  it("2026 年の日本と米国連邦祝日を公式日付で提供する", () => {
+    expect(getHolidayPresetHolidays("jp-2026")).toEqual(
+      expect.arrayContaining([
+        { date: "2026-01-01", name: "元日" },
+        { date: "2026-09-22", name: "休日" },
+        { date: "2026-11-23", name: "勤労感謝の日" },
+      ]),
+    );
+    expect(getHolidayPresetHolidays("jp-2026")).toHaveLength(18);
+
+    expect(getHolidayPresetHolidays("us-federal-2026")).toEqual(
+      expect.arrayContaining([
+        { date: "2026-01-19", name: "Birthday of Martin Luther King, Jr." },
+        { date: "2026-07-03", name: "Independence Day" },
+        { date: "2026-12-25", name: "Christmas Day" },
+      ]),
+    );
+    expect(getHolidayPresetHolidays("us-federal-2026")).toHaveLength(11);
+  });
+});
+
+describe("[FR-VIS-017-AC3] 祝日プリセットの localStorage 管理とグリッド反映", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("選択した祝日プリセットを localStorage に保存する", () => {
+    const { getByTitle, getByLabelText, getByText } = render(<HolidayPresetHarness />);
+
+    fireEvent.click(getByTitle("Calendar Settings"));
+    fireEvent.change(getByLabelText("Holiday preset"), {
+      target: { value: "us-federal-2026" },
+    });
+
+    expect(localStorage.getItem(HOLIDAY_PRESET_STORAGE_KEY)).toBe("us-federal-2026");
+    expect(getByText("2026-07-03 Independence Day")).toBeTruthy();
+  });
+
+  it("選択プリセット休日を GanttChart の非稼働日表示に反映する", () => {
+    const originalConsoleError = console.error.bind(console);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation((message, ...args) => {
+      if (
+        typeof message === "string" &&
+        message.includes("useLayoutEffect does nothing on the server")
+      ) {
+        return;
+      }
+      originalConsoleError(message, ...args);
+    });
+
+    let html = "";
+    try {
+      html = renderToStaticMarkup(
+        <GanttChart
+          tasks={[workingCalendarTask]}
+          flatList={workingCalendarFlatList}
+          config={workingCalendarConfig}
+          selectedTaskId={null}
+          onSelectTask={() => {}}
+          header={() => {}}
+          dependencyHighlightEnabled={false}
+          presetHolidays={[{ date: "2026-01-12", name: "成人の日" }]}
+        />,
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(html).toContain('data-calendar-day="holiday"');
+    expect(html).toContain('data-date="2026-01-12"');
+    expect(html).toContain("成人の日");
   });
 });

--- a/packages/ui/src/components/GanttChart.tsx
+++ b/packages/ui/src/components/GanttChart.tsx
@@ -49,6 +49,7 @@ interface GanttChartProps {
   onHoverTask?: (taskId: string | null) => void;
   dependencyHighlightEnabled?: boolean;
   highlightRelationMap?: Map<string, RelationType>;
+  presetHolidays?: CalendarHoliday[];
   customDaysOff?: CalendarHoliday[];
 }
 
@@ -68,6 +69,7 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
     onHoverTask,
     dependencyHighlightEnabled = true,
     highlightRelationMap,
+    presetHolidays = [],
     customDaysOff = [],
   },
   ref,
@@ -140,8 +142,8 @@ export const GanttChart = forwardRef<GanttChartHandle, GanttChartProps>(function
 
   const totalHeight = flatList.length * ROW_HEIGHT;
   const holidays = useMemo(
-    () => [...(config.gantt.holidays ?? []), ...customDaysOff],
-    [config.gantt.holidays, customDaysOff],
+    () => [...(config.gantt.holidays ?? []), ...presetHolidays, ...customDaysOff],
+    [config.gantt.holidays, presetHolidays, customDaysOff],
   );
   const criticalPath = useMemo(() => calculateCriticalPath(tasks), [tasks]);
   const criticalTaskIds = useMemo(

--- a/packages/ui/src/components/toolbar/CalendarSettingsMenu.tsx
+++ b/packages/ui/src/components/toolbar/CalendarSettingsMenu.tsx
@@ -1,20 +1,19 @@
 import React, { useEffect, useRef, useState } from "react";
 import { CalendarDays, Plus, X } from "lucide-react";
 import type { CalendarHoliday } from "../../types/index.js";
+import {
+  isHolidayPresetId,
+  type HolidayPreset,
+  type HolidayPresetId,
+} from "../../lib/holiday-presets.js";
 import { IconButton } from "./IconButton.js";
-
-export interface HolidayPresetOption {
-  id: string;
-  label: string;
-  holidays: CalendarHoliday[];
-}
 
 interface CalendarSettingsMenuProps {
   configuredHolidays: CalendarHoliday[];
-  holidayPresetOptions?: HolidayPresetOption[];
-  selectedHolidayPresetId?: string;
+  holidayPresetOptions?: HolidayPreset[];
+  selectedHolidayPresetId?: HolidayPresetId;
   presetHolidays?: CalendarHoliday[];
-  onSelectHolidayPreset?: (presetId: string) => void;
+  onSelectHolidayPreset?: (presetId: HolidayPresetId) => void;
   customDaysOff: CalendarHoliday[];
   onAddCustomDayOff: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff: (date: string) => void;
@@ -111,6 +110,12 @@ export function CalendarSettingsMenu({
     setName("");
   };
 
+  const handlePresetChange = (presetId: string) => {
+    if (isHolidayPresetId(presetId)) {
+      onSelectHolidayPreset?.(presetId);
+    }
+  };
+
   return (
     <div ref={wrapperRef} style={{ position: "relative" }}>
       <IconButton
@@ -129,7 +134,7 @@ export function CalendarSettingsMenu({
               <select
                 aria-label="Holiday preset"
                 value={selectedHolidayPresetId}
-                onChange={(e) => onSelectHolidayPreset(e.target.value)}
+                onChange={(e) => handlePresetChange(e.target.value)}
                 style={inputStyle}
               >
                 {holidayPresetOptions.map((preset) => (

--- a/packages/ui/src/components/toolbar/CalendarSettingsMenu.tsx
+++ b/packages/ui/src/components/toolbar/CalendarSettingsMenu.tsx
@@ -3,8 +3,18 @@ import { CalendarDays, Plus, X } from "lucide-react";
 import type { CalendarHoliday } from "../../types/index.js";
 import { IconButton } from "./IconButton.js";
 
+export interface HolidayPresetOption {
+  id: string;
+  label: string;
+  holidays: CalendarHoliday[];
+}
+
 interface CalendarSettingsMenuProps {
   configuredHolidays: CalendarHoliday[];
+  holidayPresetOptions?: HolidayPresetOption[];
+  selectedHolidayPresetId?: string;
+  presetHolidays?: CalendarHoliday[];
+  onSelectHolidayPreset?: (presetId: string) => void;
   customDaysOff: CalendarHoliday[];
   onAddCustomDayOff: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff: (date: string) => void;
@@ -62,6 +72,10 @@ function holidayLabel(day: CalendarHoliday): string {
 
 export function CalendarSettingsMenu({
   configuredHolidays,
+  holidayPresetOptions = [],
+  selectedHolidayPresetId = "none",
+  presetHolidays = [],
+  onSelectHolidayPreset,
   customDaysOff,
   onAddCustomDayOff,
   onRemoveCustomDayOff,
@@ -111,6 +125,20 @@ export function CalendarSettingsMenu({
         <div role="menu" style={panelStyle}>
           <div style={sectionLabel}>Calendar</div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 6 }}>
+            {holidayPresetOptions.length > 0 && onSelectHolidayPreset && (
+              <select
+                aria-label="Holiday preset"
+                value={selectedHolidayPresetId}
+                onChange={(e) => onSelectHolidayPreset(e.target.value)}
+                style={inputStyle}
+              >
+                {holidayPresetOptions.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.label}
+                  </option>
+                ))}
+              </select>
+            )}
             <input
               aria-label="Custom day off date"
               type="date"
@@ -143,6 +171,22 @@ export function CalendarSettingsMenu({
               Add
             </button>
           </div>
+
+          {holidayPresetOptions.length > 0 && (
+            <>
+              <div style={separator} />
+              <div style={sectionLabel}>Preset holidays</div>
+              {presetHolidays.length === 0 ? (
+                <div style={rowStyle}>None</div>
+              ) : (
+                presetHolidays.map((day) => (
+                  <div key={day.date} style={rowStyle}>
+                    <span>{holidayLabel(day)}</span>
+                  </div>
+                ))
+              )}
+            </>
+          )}
 
           <div style={separator} />
           <div style={sectionLabel}>Configured</div>

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -15,7 +15,7 @@ import { ThemeToggle } from "./ThemeToggle.js";
 import { IconButton } from "./IconButton.js";
 import { CalendarSettingsMenu } from "./CalendarSettingsMenu.js";
 import type { CalendarHoliday } from "../../types/index.js";
-import type { HolidayPreset } from "../../lib/holiday-presets.js";
+import type { HolidayPreset, HolidayPresetId } from "../../lib/holiday-presets.js";
 
 interface ToolbarProps {
   projectName: string;
@@ -63,9 +63,9 @@ interface ToolbarProps {
   undoRedoBusy?: boolean;
   configuredHolidays?: CalendarHoliday[];
   holidayPresetOptions?: HolidayPreset[];
-  selectedHolidayPresetId?: string;
+  selectedHolidayPresetId?: HolidayPresetId;
   presetHolidays?: CalendarHoliday[];
-  onSelectHolidayPreset?: (presetId: string) => void;
+  onSelectHolidayPreset?: (presetId: HolidayPresetId) => void;
   customDaysOff?: CalendarHoliday[];
   onAddCustomDayOff?: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff?: (date: string) => void;

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -15,6 +15,7 @@ import { ThemeToggle } from "./ThemeToggle.js";
 import { IconButton } from "./IconButton.js";
 import { CalendarSettingsMenu } from "./CalendarSettingsMenu.js";
 import type { CalendarHoliday } from "../../types/index.js";
+import type { HolidayPreset } from "../../lib/holiday-presets.js";
 
 interface ToolbarProps {
   projectName: string;
@@ -61,6 +62,10 @@ interface ToolbarProps {
   redoCount?: number;
   undoRedoBusy?: boolean;
   configuredHolidays?: CalendarHoliday[];
+  holidayPresetOptions?: HolidayPreset[];
+  selectedHolidayPresetId?: string;
+  presetHolidays?: CalendarHoliday[];
+  onSelectHolidayPreset?: (presetId: string) => void;
   customDaysOff?: CalendarHoliday[];
   onAddCustomDayOff?: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff?: (date: string) => void;
@@ -176,6 +181,10 @@ export function Toolbar(props: ToolbarProps) {
       {props.onAddCustomDayOff && props.onRemoveCustomDayOff && (
         <CalendarSettingsMenu
           configuredHolidays={props.configuredHolidays ?? []}
+          holidayPresetOptions={props.holidayPresetOptions}
+          selectedHolidayPresetId={props.selectedHolidayPresetId}
+          presetHolidays={props.presetHolidays}
+          onSelectHolidayPreset={props.onSelectHolidayPreset}
           customDaysOff={props.customDaysOff ?? []}
           onAddCustomDayOff={props.onAddCustomDayOff}
           onRemoveCustomDayOff={props.onRemoveCustomDayOff}

--- a/packages/ui/src/hooks/useHolidayPreset.ts
+++ b/packages/ui/src/hooks/useHolidayPreset.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  getHolidayPreset,
+  HOLIDAY_PRESETS,
+  isHolidayPresetId,
+  type HolidayPresetId,
+} from "../lib/holiday-presets.js";
+
+export const HOLIDAY_PRESET_STORAGE_KEY = "gh-gantt:holiday-preset";
+
+function readStoredHolidayPresetId(): HolidayPresetId {
+  if (typeof window === "undefined") return "none";
+  const stored = window.localStorage.getItem(HOLIDAY_PRESET_STORAGE_KEY);
+  if (!stored || !isHolidayPresetId(stored)) return "none";
+  return stored;
+}
+
+function writeStoredHolidayPresetId(presetId: HolidayPresetId): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(HOLIDAY_PRESET_STORAGE_KEY, presetId);
+}
+
+export function useHolidayPreset() {
+  const [selectedHolidayPresetId, setSelectedHolidayPresetId] =
+    useState<HolidayPresetId>(readStoredHolidayPresetId);
+
+  const selectHolidayPreset = useCallback((presetId: string) => {
+    const nextPresetId = isHolidayPresetId(presetId) ? presetId : "none";
+    setSelectedHolidayPresetId(nextPresetId);
+    writeStoredHolidayPresetId(nextPresetId);
+  }, []);
+
+  const selectedHolidayPreset = useMemo(
+    () => getHolidayPreset(selectedHolidayPresetId),
+    [selectedHolidayPresetId],
+  );
+
+  return {
+    holidayPresetOptions: HOLIDAY_PRESETS,
+    selectedHolidayPresetId,
+    selectedHolidayPreset,
+    presetHolidays: selectedHolidayPreset.holidays,
+    selectHolidayPreset,
+  };
+}

--- a/packages/ui/src/hooks/useHolidayPreset.ts
+++ b/packages/ui/src/hooks/useHolidayPreset.ts
@@ -10,24 +10,31 @@ export const HOLIDAY_PRESET_STORAGE_KEY = "gh-gantt:holiday-preset";
 
 function readStoredHolidayPresetId(): HolidayPresetId {
   if (typeof window === "undefined") return "none";
-  const stored = window.localStorage.getItem(HOLIDAY_PRESET_STORAGE_KEY);
-  if (!stored || !isHolidayPresetId(stored)) return "none";
-  return stored;
+  try {
+    const stored = window.localStorage.getItem(HOLIDAY_PRESET_STORAGE_KEY);
+    if (!stored || !isHolidayPresetId(stored)) return "none";
+    return stored;
+  } catch {
+    return "none";
+  }
 }
 
 function writeStoredHolidayPresetId(presetId: HolidayPresetId): void {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(HOLIDAY_PRESET_STORAGE_KEY, presetId);
+  try {
+    window.localStorage.setItem(HOLIDAY_PRESET_STORAGE_KEY, presetId);
+  } catch {
+    // 永続化できない環境では、メモリ上の選択状態だけを維持する。
+  }
 }
 
 export function useHolidayPreset() {
   const [selectedHolidayPresetId, setSelectedHolidayPresetId] =
     useState<HolidayPresetId>(readStoredHolidayPresetId);
 
-  const selectHolidayPreset = useCallback((presetId: string) => {
-    const nextPresetId = isHolidayPresetId(presetId) ? presetId : "none";
-    setSelectedHolidayPresetId(nextPresetId);
-    writeStoredHolidayPresetId(nextPresetId);
+  const selectHolidayPreset = useCallback((presetId: HolidayPresetId) => {
+    setSelectedHolidayPresetId(presetId);
+    writeStoredHolidayPresetId(presetId);
   }, []);
 
   const selectedHolidayPreset = useMemo(

--- a/packages/ui/src/lib/holiday-presets.ts
+++ b/packages/ui/src/lib/holiday-presets.ts
@@ -1,0 +1,74 @@
+import type { CalendarHoliday } from "../types/index.js";
+
+export type HolidayPresetId = "none" | "jp-2026" | "us-federal-2026";
+
+export interface HolidayPreset {
+  id: HolidayPresetId;
+  label: string;
+  holidays: CalendarHoliday[];
+}
+
+const NONE_HOLIDAY_PRESET: HolidayPreset = {
+  id: "none",
+  label: "None",
+  holidays: [],
+};
+
+export const HOLIDAY_PRESETS: HolidayPreset[] = [
+  NONE_HOLIDAY_PRESET,
+  {
+    id: "jp-2026",
+    label: "Japan 2026",
+    holidays: [
+      { date: "2026-01-01", name: "元日" },
+      { date: "2026-01-12", name: "成人の日" },
+      { date: "2026-02-11", name: "建国記念の日" },
+      { date: "2026-02-23", name: "天皇誕生日" },
+      { date: "2026-03-20", name: "春分の日" },
+      { date: "2026-04-29", name: "昭和の日" },
+      { date: "2026-05-03", name: "憲法記念日" },
+      { date: "2026-05-04", name: "みどりの日" },
+      { date: "2026-05-05", name: "こどもの日" },
+      { date: "2026-05-06", name: "休日" },
+      { date: "2026-07-20", name: "海の日" },
+      { date: "2026-08-11", name: "山の日" },
+      { date: "2026-09-21", name: "敬老の日" },
+      { date: "2026-09-22", name: "休日" },
+      { date: "2026-09-23", name: "秋分の日" },
+      { date: "2026-10-12", name: "スポーツの日" },
+      { date: "2026-11-03", name: "文化の日" },
+      { date: "2026-11-23", name: "勤労感謝の日" },
+    ],
+  },
+  {
+    id: "us-federal-2026",
+    label: "United States Federal 2026",
+    holidays: [
+      { date: "2026-01-01", name: "New Year's Day" },
+      { date: "2026-01-19", name: "Birthday of Martin Luther King, Jr." },
+      { date: "2026-02-16", name: "Washington's Birthday" },
+      { date: "2026-05-25", name: "Memorial Day" },
+      { date: "2026-06-19", name: "Juneteenth National Independence Day" },
+      { date: "2026-07-03", name: "Independence Day" },
+      { date: "2026-09-07", name: "Labor Day" },
+      { date: "2026-10-12", name: "Columbus Day" },
+      { date: "2026-11-11", name: "Veterans Day" },
+      { date: "2026-11-26", name: "Thanksgiving Day" },
+      { date: "2026-12-25", name: "Christmas Day" },
+    ],
+  },
+];
+
+const holidayPresetIds = new Set<string>(HOLIDAY_PRESETS.map((preset) => preset.id));
+
+export function isHolidayPresetId(value: string): value is HolidayPresetId {
+  return holidayPresetIds.has(value);
+}
+
+export function getHolidayPreset(id: string | null | undefined): HolidayPreset {
+  return HOLIDAY_PRESETS.find((preset) => preset.id === id) ?? NONE_HOLIDAY_PRESET;
+}
+
+export function getHolidayPresetHolidays(id: string | null | undefined): CalendarHoliday[] {
+  return getHolidayPreset(id).holidays;
+}


### PR DESCRIPTION
## Summary
- Calendar Settings に祝日プリセット選択を追加
- Japan 2026 / United States Federal 2026 の祝日をプリセット化
- 選択プリセットを localStorage に保存し、Gantt grid の非稼働日表示に合成
- FR-VIS-017 を requirements.yaml に追加

## Verification
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/working-calendar.test.tsx
- pnpm lint
- pnpm build
- pnpm test:json
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen
- local Playwright smoke: us-federal-2026 selection persisted and preset holiday text visible

## Sources
- Japan: https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html
- United States: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=2026

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 稼働カレンダーに祝日プリセット機能を追加しました。カレンダー設定で2026年の日本および米国連邦祝日を選択できるようになりました。
  * 選択したプリセット祝日がガントチャートに自動的に反映されます。
  * プリセット選択状態がブラウザに保存されます。

* **ドキュメント**
  * 祝日プリセット機能の要件ドキュメントを追加しました。

* **テスト**
  * 祝日プリセット機能の統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->