### PR TITLE
feat(export): SVG/PNGエクスポートを追加 (#20)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -736,6 +736,34 @@ areas:
               - packages/shared/src/__tests__/schema.test.ts
               - packages/ui/src/__tests__/date-utils.test.ts
               - packages/ui/src/__tests__/overdue-highlight.test.tsx
+      - id: FR-VIS-019
+        summary: SVG/PNG エクスポート
+        acceptance_criteria:
+          - id: FR-VIS-019-AC1
+            description: export 用タスク列は親子階層を depth 付きで並べられる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/export-renderer.test.ts
+          - id: FR-VIS-019-AC2
+            description: SVG export はツリー列とガント列を 1 つの SVG に含める
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/export-renderer.test.ts
+          - id: FR-VIS-019-AC3
+            description: current scope は表示中ノードだけを export 対象にできる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/export-renderer.test.ts
+          - id: FR-VIS-019-AC4
+            description: Toolbar から SVG/PNG、current/project、2x を選んで export を実行できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/export-menu.test.tsx
+          - id: FR-VIS-019-AC5
+            description: CLI export command は SVG と PNG をファイルへ書き出し、PNG では 2x 指定を渡せる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/export-command.test.ts
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "cli-table3": "^0.6.5",
     "commander": "^12.0.0",
     "express": "^4.21.0",
+    "playwright": "^1.58.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/export-command.test.ts
+++ b/packages/cli/src/__tests__/export-command.test.ts
@@ -76,7 +76,7 @@ async function writeProject(): Promise<string> {
   return root;
 }
 
-describe("[FR-VIS-019-AC5] CLI export command", () => {
+describe("[FR-VIS-019-AC5] CLI エクスポートコマンド", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });

--- a/packages/cli/src/__tests__/export-command.test.ts
+++ b/packages/cli/src/__tests__/export-command.test.ts
@@ -134,6 +134,15 @@ describe("[FR-VIS-019-AC5] CLI export command", () => {
     await expect(readFile(outputPath)).resolves.toEqual(Buffer.from("png"));
   });
 
+  it("PNG export の Playwright は CLI の runtime dependency として宣言する", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../../package.json", import.meta.url), "utf-8"),
+    ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+
+    expect(packageJson.dependencies?.playwright).toBeDefined();
+    expect(packageJson.devDependencies?.playwright).toBeUndefined();
+  });
+
   it("CLI では UI の表示中ビューを持たないため current scope を拒否する", async () => {
     const root = await writeProject();
 

--- a/packages/cli/src/__tests__/export-command.test.ts
+++ b/packages/cli/src/__tests__/export-command.test.ts
@@ -1,0 +1,149 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CONFIG_FILE, GANTT_DIR, TASKS_FILE, type Config, type Task } from "@gh-gantt/shared";
+import { createExportCommand, runExportCommand, type PngRenderer } from "../commands/export.js";
+
+const config: Config = {
+  version: "1",
+  project: {
+    name: "CLI Export Project",
+    github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+  },
+  type_hierarchy: { task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+const task: Task = {
+  id: "stanah/gh-gantt#20",
+  type: "task",
+  github_issue: 20,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "SVG/PNGエクスポート",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: { Status: "Todo" },
+  start_date: "2026-05-04",
+  end_date: "2026-05-08",
+  date: null,
+  blocked_by: [],
+};
+
+async function writeProject(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "gh-gantt-export-"));
+  const ganttDir = join(root, GANTT_DIR);
+  await mkdir(ganttDir, { recursive: true });
+  await Promise.all([
+    writeFile(join(ganttDir, CONFIG_FILE), JSON.stringify(config, null, 2)),
+    writeFile(
+      join(ganttDir, TASKS_FILE),
+      JSON.stringify({ tasks: [task], cache: { comments: {}, reactions: {} } }, null, 2),
+    ),
+  ]);
+  return root;
+}
+
+describe("[FR-VIS-019-AC5] CLI export command", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("export コマンドに format/scope/output/2x オプションが定義されている", () => {
+    const command = createExportCommand();
+    const optionNames = command.options.map((option) => option.long);
+
+    expect(optionNames).toContain("--format");
+    expect(optionNames).toContain("--scope");
+    expect(optionNames).toContain("--output");
+    expect(optionNames).toContain("--high-resolution");
+  });
+
+  it("SVG 形式でツリーとガントを含むファイルを書き出す", async () => {
+    const root = await writeProject();
+    const outputPath = join(root, "out.svg");
+
+    await runExportCommand(root, {
+      format: "svg",
+      scope: "project",
+      output: outputPath,
+      highResolution: false,
+    });
+
+    const svg = await readFile(outputPath, "utf-8");
+    expect(svg).toContain("CLI Export Project");
+    expect(svg).toContain("Tree");
+    expect(svg).toContain("Gantt");
+    expect(svg).toContain("SVG/PNGエクスポート");
+  });
+
+  it("PNG 形式では SVG から PNG への変換に 2x 指定を渡す", async () => {
+    const root = await writeProject();
+    const outputPath = join(root, "out.png");
+    const pngRenderer = vi.fn<PngRenderer>().mockResolvedValue(Buffer.from("png"));
+
+    await runExportCommand(
+      root,
+      {
+        format: "png",
+        scope: "project",
+        output: outputPath,
+        highResolution: true,
+      },
+      { pngRenderer },
+    );
+
+    expect(pngRenderer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scaleFactor: 2,
+        svg: expect.stringContaining("SVG/PNGエクスポート"),
+      }),
+    );
+    await expect(readFile(outputPath)).resolves.toEqual(Buffer.from("png"));
+  });
+
+  it("CLI では UI の表示中ビューを持たないため current scope を拒否する", async () => {
+    const root = await writeProject();
+
+    await expect(
+      runExportCommand(root, {
+        format: "svg",
+        scope: "current",
+        output: join(root, "out.svg"),
+        highResolution: false,
+      }),
+    ).rejects.toThrow("--scope current");
+  });
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,148 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { Command } from "commander";
+import {
+  buildExportTaskNodes,
+  renderGanttExportSvg,
+  type GanttExportFormat,
+  type GanttExportScope,
+  type ViewScale,
+} from "@gh-gantt/shared";
+import { ConfigStore } from "../store/config.js";
+import { TasksStore } from "../store/tasks.js";
+
+export interface PngRenderInput {
+  svg: string;
+  width: number;
+  height: number;
+  scaleFactor: 1 | 2;
+}
+
+export type PngRenderer = (input: PngRenderInput) => Promise<Buffer>;
+
+interface ExportCommandOptions {
+  format?: string;
+  scope?: string;
+  output?: string;
+  highResolution?: boolean;
+  scale?: string;
+}
+
+interface ExportCommandDeps {
+  pngRenderer?: PngRenderer;
+}
+
+function normalizeFormat(value: string | undefined): GanttExportFormat {
+  if (value === undefined) return "svg";
+  if (value === "svg" || value === "png") return value;
+  throw new Error("--format は svg または png を指定してください");
+}
+
+function normalizeScope(value: string | undefined): GanttExportScope {
+  if (value === undefined) return "project";
+  if (value === "project") return value;
+  if (value === "current") {
+    throw new Error(
+      "--scope current は UI の表示中ビュー専用です。CLI では --scope project を指定してください",
+    );
+  }
+  throw new Error("--scope は project を指定してください");
+}
+
+function normalizeScale(value: string | undefined, fallback: ViewScale): ViewScale {
+  if (value === undefined) return fallback;
+  if (value === "week" || value === "month" || value === "quarter" || value === "year") {
+    return value;
+  }
+  throw new Error("--scale は week, month, quarter, year のいずれかを指定してください");
+}
+
+async function renderPngWithPlaywright({
+  svg,
+  width,
+  height,
+  scaleFactor,
+}: PngRenderInput): Promise<Buffer> {
+  let chromium: typeof import("@playwright/test").chromium;
+  try {
+    ({ chromium } = await import("@playwright/test"));
+  } catch (err) {
+    throw new Error(
+      `PNG export requires @playwright/test. 依存関係をインストールしてから再実行してください: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({
+      viewport: { width, height },
+      deviceScaleFactor: scaleFactor,
+    });
+    await page.setContent(`<html><body style="margin:0;background:white">${svg}</body></html>`, {
+      waitUntil: "load",
+    });
+    return await page.locator("svg").screenshot({ type: "png" });
+  } catch (err) {
+    throw new Error(
+      `PNG export に失敗しました。Playwright browser が利用可能か確認してください: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    await browser?.close();
+  }
+}
+
+export async function runExportCommand(
+  projectRoot: string,
+  options: ExportCommandOptions,
+  deps: ExportCommandDeps = {},
+): Promise<void> {
+  const config = await new ConfigStore(projectRoot).read();
+  const tasksFile = await new TasksStore(projectRoot).read();
+  const format = normalizeFormat(options.format);
+  const scope = normalizeScope(options.scope);
+  const viewScale = normalizeScale(options.scale, config.gantt.default_view);
+  const outputPath = resolve(projectRoot, options.output ?? `gh-gantt-export.${format}`);
+  const rendered = renderGanttExportSvg({
+    nodes: buildExportTaskNodes(tasksFile.tasks),
+    config,
+    scope,
+    viewScale,
+  });
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  if (format === "svg") {
+    await writeFile(outputPath, rendered.svg);
+  } else {
+    const pngRenderer = deps.pngRenderer ?? renderPngWithPlaywright;
+    const png = await pngRenderer({
+      svg: rendered.svg,
+      width: rendered.width,
+      height: rendered.height,
+      scaleFactor: options.highResolution ? 2 : 1,
+    });
+    await writeFile(outputPath, png);
+  }
+
+  console.log(`Exported ${format.toUpperCase()} to ${outputPath}`);
+}
+
+export function createExportCommand(): Command {
+  return new Command("export")
+    .description("Export the Gantt view as SVG or PNG")
+    .option("-f, --format <format>", "Export format: svg or png", "svg")
+    .option("--scope <scope>", "Export scope: project (current is UI-only)", "project")
+    .option("-o, --output <path>", "Output file path")
+    .option("--high-resolution", "Render PNG at 2x resolution")
+    .option("--scale <scale>", "Gantt scale: week, month, quarter, year")
+    .action(async (options: ExportCommandOptions) => {
+      try {
+        await runExportCommand(process.cwd(), options);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
+}
+
+export const exportCommand = createExportCommand();

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -63,12 +63,12 @@ async function renderPngWithPlaywright({
   height,
   scaleFactor,
 }: PngRenderInput): Promise<Buffer> {
-  let chromium: typeof import("@playwright/test").chromium;
+  let chromium: typeof import("playwright").chromium;
   try {
-    ({ chromium } = await import("@playwright/test"));
+    ({ chromium } = await import("playwright"));
   } catch (err) {
     throw new Error(
-      `PNG export requires @playwright/test. 依存関係をインストールしてから再実行してください: ${err instanceof Error ? err.message : String(err)}`,
+      `PNG export requires playwright. 依存関係をインストールしてから再実行してください: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -16,6 +16,7 @@ import { doctorCommand } from "./commands/doctor.js";
 import { contextCommand } from "./commands/context.js";
 import { sprintCommand } from "./commands/sprint.js";
 import { acceptanceCriteriaCommand } from "./commands/ac.js";
+import { exportCommand } from "./commands/export.js";
 
 export function buildProgram(): Command {
   const program = new Command();
@@ -34,6 +35,7 @@ export function buildProgram(): Command {
   program.addCommand(contextCommand);
   program.addCommand(sprintCommand);
   program.addCommand(acceptanceCriteriaCommand);
+  program.addCommand(exportCommand);
 
   // Flattened task commands (formerly under `task` subcommand)
   program.addCommand(createTaskListCommand());

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -6,5 +6,16 @@ export default defineConfig({
     format: ["esm"],
     dts: false,
     fixedExtension: false,
+    deps: {
+      neverBundle: [
+        /^@playwright\/test$/,
+        /^playwright$/,
+        /^playwright-core$/,
+        /^playwright\//,
+        /^playwright-core\//,
+        /^chromium-bidi\//,
+        /^fsevents$/,
+      ],
+    },
   },
 });

--- a/packages/shared/src/__tests__/export-renderer.test.ts
+++ b/packages/shared/src/__tests__/export-renderer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { buildExportTaskNodes, renderGanttExportSvg, type Config, type Task } from "../index.js";
+
+const config: Config = {
+  version: "1",
+  project: {
+    name: "Export Project",
+    github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+  },
+  task_types: {
+    epic: { label: "Epic", display: "summary", color: "#8E44AD", github_label: "epic" },
+    task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+  },
+  type_hierarchy: { epic: ["task"], task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false },
+      Done: { color: "#2ECC71", done: true },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: Number(id.split("#")[1] ?? "0"),
+    github_repo: "stanah/gh-gantt",
+    parent: null,
+    sub_tasks: [],
+    title: id,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: { Status: "Todo" },
+    start_date: "2026-05-04",
+    end_date: "2026-05-08",
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+describe("[FR-VIS-019] SVG/PNG エクスポート", () => {
+  it("[FR-VIS-019-AC1] buildExportTaskNodes は親子階層を depth 付きで並べる", () => {
+    const epic = makeTask("stanah/gh-gantt#30", {
+      type: "epic",
+      title: "可視化拡張",
+      sub_tasks: ["stanah/gh-gantt#20"],
+    });
+    const task = makeTask("stanah/gh-gantt#20", {
+      title: "SVG/PNGエクスポート",
+      parent: "stanah/gh-gantt#30",
+    });
+
+    expect(buildExportTaskNodes([task, epic]).map((node) => [node.task.title, node.depth])).toEqual(
+      [
+        ["可視化拡張", 0],
+        ["SVG/PNGエクスポート", 1],
+      ],
+    );
+  });
+
+  it("[FR-VIS-019-AC2] renderGanttExportSvg はツリー列とガント列を 1 つの SVG に含める", () => {
+    const epic = makeTask("stanah/gh-gantt#30", {
+      type: "epic",
+      title: "可視化拡張",
+      start_date: "2026-05-04",
+      end_date: "2026-05-15",
+      sub_tasks: ["stanah/gh-gantt#20"],
+    });
+    const task = makeTask("stanah/gh-gantt#20", {
+      title: "SVG/PNGエクスポート",
+      parent: "stanah/gh-gantt#30",
+    });
+
+    const result = renderGanttExportSvg({
+      nodes: buildExportTaskNodes([epic, task]),
+      config,
+      scope: "project",
+      viewScale: "month",
+    });
+
+    expect(result.svg).toContain('data-export-scope="project"');
+    expect(result.svg).toContain("Export Project");
+    expect(result.svg).toContain("Tree");
+    expect(result.svg).toContain("Gantt");
+    expect(result.svg).toContain("#20");
+    expect(result.svg).toContain("SVG/PNGエクスポート");
+    expect(result.width).toBeGreaterThan(800);
+    expect(result.height).toBeGreaterThan(120);
+  });
+
+  it("[FR-VIS-019-AC3] current scope は渡された表示中ノードだけを SVG に含める", () => {
+    const visible = makeTask("stanah/gh-gantt#20", { title: "表示中タスク" });
+    const hidden = makeTask("stanah/gh-gantt#51", { title: "非表示タスク" });
+
+    const result = renderGanttExportSvg({
+      nodes: buildExportTaskNodes([visible]),
+      config,
+      scope: "current",
+      viewScale: "week",
+    });
+
+    expect(result.svg).toContain('data-export-scope="current"');
+    expect(result.svg).toContain("表示中タスク");
+    expect(result.svg).not.toContain(hidden.title);
+  });
+});

--- a/packages/shared/src/__tests__/export-renderer.test.ts
+++ b/packages/shared/src/__tests__/export-renderer.test.ts
@@ -128,4 +128,23 @@ describe("[FR-VIS-019] SVG/PNG エクスポート", () => {
     expect(result.svg).toContain("表示中タスク");
     expect(result.svg).not.toContain(hidden.title);
   });
+
+  it("[FR-VIS-019-AC2] グリッドの日付ラベルは export 範囲の翌日を出力しない", () => {
+    const task = makeTask("stanah/gh-gantt#20", {
+      title: "単日タスク",
+      start_date: "2026-05-04",
+      end_date: "2026-05-04",
+    });
+
+    const result = renderGanttExportSvg({
+      nodes: buildExportTaskNodes([task]),
+      config,
+      scope: "project",
+      viewScale: "month",
+    });
+
+    expect(result.svg).toContain("2026-05-03");
+    expect(result.svg).toContain("2026-05-05");
+    expect(result.svg).not.toContain("2026-05-06");
+  });
 });

--- a/packages/shared/src/export-renderer.ts
+++ b/packages/shared/src/export-renderer.ts
@@ -208,10 +208,10 @@ function renderGrid(
 ): string {
   const days = Math.max(1, diffDays(startDate, endDate) + 1);
   const lines: string[] = [];
-  for (let day = 0; day <= days; day += 1) {
+  for (let day = 0; day < days; day += 1) {
     const x = chartX + day * dayWidth;
     const date = addDays(startDate, day);
-    const major = date.getUTCDate() === 1 || day === 0 || day === days;
+    const major = date.getUTCDate() === 1 || day === 0 || day === days - 1;
     lines.push(
       `<line x1="${x}" y1="${chartY}" x2="${x}" y2="${chartY + chartHeight}" class="${major ? "grid-major" : "grid"}" />`,
     );
@@ -221,6 +221,9 @@ function renderGrid(
       );
     }
   }
+  lines.push(
+    `<line x1="${chartX + chartWidth}" y1="${chartY}" x2="${chartX + chartWidth}" y2="${chartY + chartHeight}" class="grid-major" />`,
+  );
   return lines.join("");
 }
 

--- a/packages/shared/src/export-renderer.ts
+++ b/packages/shared/src/export-renderer.ts
@@ -1,24 +1,40 @@
 import type { Config, Task, ViewScale } from "./types.js";
 
+/** ガントビューのエクスポート形式。 */
 export type GanttExportFormat = "svg" | "png";
+
+/** エクスポート対象の範囲。 */
 export type GanttExportScope = "current" | "project";
 
+/** エクスポート対象タスクとツリー上の階層深度。 */
 export interface GanttExportTaskNode {
+  /** 描画対象のタスク。 */
   task: Task;
+  /** ツリー上の深度。ルートタスクは 0。 */
   depth: number;
 }
 
+/** SVG エクスポートのレンダリング入力。 */
 export interface RenderGanttExportSvgOptions {
+  /** 描画順に並べたタスクノード。 */
   nodes: GanttExportTaskNode[];
+  /** 色・タスク種別・プロジェクト名を解決する設定。 */
   config: Config;
+  /** SVG に記録するエクスポート範囲。 */
   scope: GanttExportScope;
+  /** ガント列の日幅を決める表示スケール。 */
   viewScale?: ViewScale;
+  /** メタ情報に記録する生成日時。 */
   generatedAt?: Date;
 }
 
+/** SVG エクスポートのレンダリング結果。 */
 export interface RenderedGanttExport {
+  /** 生成された SVG 文字列。 */
   svg: string;
+  /** SVG の幅。 */
   width: number;
+  /** SVG の高さ。 */
   height: number;
 }
 
@@ -67,10 +83,6 @@ function escapeXml(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-function escapeAttr(value: string): string {
-  return escapeXml(value);
-}
-
 function dateRangeForTask(task: Task): { start: Date; end: Date } | null {
   const start = parseDate(task.start_date ?? task.date ?? task.end_date);
   const end = parseDate(task.end_date ?? task.date ?? task.start_date);
@@ -104,6 +116,12 @@ function childrenForTask(task: Task, byParent: Map<string, Task[]>): Task[] {
   return [...ordered, ...rest];
 }
 
+/**
+ * タスクリストを親子階層順のエクスポートノード列へ変換する。
+ *
+ * @param tasks エクスポート対象のタスク配列。
+ * @returns 親子関係と深度を保持したタスクノード列。
+ */
 export function buildExportTaskNodes(tasks: Task[]): GanttExportTaskNode[] {
   const byId = new Map(tasks.map((task) => [task.id, task]));
   const byParent = new Map<string, Task[]>();
@@ -268,17 +286,17 @@ function renderTaskRow(
   if (taskType?.display === "milestone") {
     const size = 14;
     elements.push(
-      `<polygon points="${barX + size / 2},${barY} ${barX + size},${barY + size / 2} ${barX + size / 2},${barY + size} ${barX},${barY + size / 2}" fill="${escapeAttr(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></polygon>`,
+      `<polygon points="${barX + size / 2},${barY} ${barX + size},${barY + size / 2} ${barX + size / 2},${barY + size} ${barX},${barY + size / 2}" fill="${escapeXml(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></polygon>`,
     );
   } else {
     const rx = taskType?.display === "summary" ? 2 : 4;
     elements.push(
-      `<rect x="${barX}" y="${barY}" width="${barWidth}" height="14" rx="${rx}" fill="${escapeAttr(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></rect>`,
+      `<rect x="${barX}" y="${barY}" width="${barWidth}" height="14" rx="${rx}" fill="${escapeXml(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></rect>`,
     );
     if (taskType?.display === "summary") {
       elements.push(
-        `<rect x="${barX}" y="${barY - 3}" width="6" height="20" fill="${escapeAttr(color)}" opacity="${opacity}" />`,
-        `<rect x="${barX + barWidth - 6}" y="${barY - 3}" width="6" height="20" fill="${escapeAttr(color)}" opacity="${opacity}" />`,
+        `<rect x="${barX}" y="${barY - 3}" width="6" height="20" fill="${escapeXml(color)}" opacity="${opacity}" />`,
+        `<rect x="${barX + barWidth - 6}" y="${barY - 3}" width="6" height="20" fill="${escapeXml(color)}" opacity="${opacity}" />`,
       );
     }
   }
@@ -288,6 +306,12 @@ function renderTaskRow(
   return elements.join("");
 }
 
+/**
+ * タスクツリー列とガント列を 1 つの SVG として描画する。
+ *
+ * @param options エクスポート対象ノード、設定、範囲、表示スケール。
+ * @returns SVG 文字列と画像寸法。
+ */
 export function renderGanttExportSvg({
   nodes,
   config,

--- a/packages/shared/src/export-renderer.ts
+++ b/packages/shared/src/export-renderer.ts
@@ -1,0 +1,341 @@
+import type { Config, Task, ViewScale } from "./types.js";
+
+export type GanttExportFormat = "svg" | "png";
+export type GanttExportScope = "current" | "project";
+
+export interface GanttExportTaskNode {
+  task: Task;
+  depth: number;
+}
+
+export interface RenderGanttExportSvgOptions {
+  nodes: GanttExportTaskNode[];
+  config: Config;
+  scope: GanttExportScope;
+  viewScale?: ViewScale;
+  generatedAt?: Date;
+}
+
+export interface RenderedGanttExport {
+  svg: string;
+  width: number;
+  height: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const ROW_HEIGHT = 32;
+const TITLE_HEIGHT = 44;
+const HEADER_HEIGHT = 34;
+const FOOTER_HEIGHT = 22;
+const OUTER_PADDING = 18;
+const TREE_WIDTH = 340;
+const MIN_GANTT_WIDTH = 560;
+
+function taskIssueLabel(task: Task): string {
+  return task.github_issue ? `#${task.github_issue}` : task.id;
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+function diffDays(start: Date, end: Date): number {
+  return Math.round((end.getTime() - start.getTime()) / DAY_MS);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function escapeAttr(value: string): string {
+  return escapeXml(value);
+}
+
+function dateRangeForTask(task: Task): { start: Date; end: Date } | null {
+  const start = parseDate(task.start_date ?? task.date ?? task.end_date);
+  const end = parseDate(task.end_date ?? task.date ?? task.start_date);
+  if (!start || !end) return null;
+  return start.getTime() <= end.getTime() ? { start, end } : { start: end, end: start };
+}
+
+function taskSortKey(task: Task): string {
+  return [
+    task.start_date ?? task.date ?? task.end_date ?? "9999-99-99",
+    String(task.github_issue ?? Number.MAX_SAFE_INTEGER).padStart(10, "0"),
+    task.title,
+  ].join("|");
+}
+
+function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => taskSortKey(a).localeCompare(taskSortKey(b)));
+}
+
+function childrenForTask(task: Task, byParent: Map<string, Task[]>): Task[] {
+  const children = byParent.get(task.id) ?? [];
+  if (task.sub_tasks.length === 0) return sortTasks(children);
+
+  const byId = new Map(children.map((child) => [child.id, child]));
+  const ordered = task.sub_tasks.flatMap((childId) => {
+    const child = byId.get(childId);
+    return child ? [child] : [];
+  });
+  const orderedIds = new Set(ordered.map((child) => child.id));
+  const rest = sortTasks(children.filter((child) => !orderedIds.has(child.id)));
+  return [...ordered, ...rest];
+}
+
+export function buildExportTaskNodes(tasks: Task[]): GanttExportTaskNode[] {
+  const byId = new Map(tasks.map((task) => [task.id, task]));
+  const byParent = new Map<string, Task[]>();
+  for (const task of tasks) {
+    if (!task.parent || !byId.has(task.parent)) continue;
+    const children = byParent.get(task.parent) ?? [];
+    children.push(task);
+    byParent.set(task.parent, children);
+  }
+
+  const roots = sortTasks(tasks.filter((task) => !task.parent || !byId.has(task.parent)));
+  const visited = new Set<string>();
+  const nodes: GanttExportTaskNode[] = [];
+
+  const visit = (task: Task, depth: number) => {
+    if (visited.has(task.id)) return;
+    visited.add(task.id);
+    nodes.push({ task, depth });
+    for (const child of childrenForTask(task, byParent)) {
+      visit(child, depth + 1);
+    }
+  };
+
+  for (const root of roots) {
+    visit(root, 0);
+  }
+  for (const task of sortTasks(tasks)) {
+    visit(task, 0);
+  }
+
+  return nodes;
+}
+
+function viewScaleDayWidth(viewScale: ViewScale | undefined): number {
+  switch (viewScale) {
+    case "week":
+      return 28;
+    case "quarter":
+      return 7;
+    case "year":
+      return 4;
+    case "month":
+    default:
+      return 14;
+  }
+}
+
+function resolveDateRange(
+  nodes: GanttExportTaskNode[],
+  generatedAt: Date,
+): { start: Date; end: Date } {
+  const ranges = nodes.flatMap((node) => {
+    const range = dateRangeForTask(node.task);
+    return range ? [range] : [];
+  });
+  if (ranges.length === 0) {
+    const today = new Date(
+      Date.UTC(generatedAt.getUTCFullYear(), generatedAt.getUTCMonth(), generatedAt.getUTCDate()),
+    );
+    return { start: today, end: addDays(today, 7) };
+  }
+
+  const start = new Date(Math.min(...ranges.map((range) => range.start.getTime())));
+  const end = new Date(Math.max(...ranges.map((range) => range.end.getTime())));
+  return { start: addDays(start, -1), end: addDays(end, 1) };
+}
+
+function statusDone(task: Task, config: Config): boolean {
+  if (task.state === "closed") return true;
+  const statusFieldName = config.statuses.field_name;
+  const statusName = task.custom_fields[statusFieldName];
+  if (typeof statusName !== "string") return false;
+  return config.statuses.values[statusName]?.done ?? false;
+}
+
+function taskColor(task: Task, config: Config): string {
+  const taskType = config.task_types[task.type];
+  if (statusDone(task, config)) return "#95A5A6";
+  return taskType?.color ?? config.gantt.colors.on_track;
+}
+
+function renderHeader(
+  projectName: string,
+  scope: GanttExportScope,
+  generatedAt: Date,
+  width: number,
+): string {
+  return [
+    `<text x="${OUTER_PADDING}" y="24" class="title">${escapeXml(projectName)}</text>`,
+    `<text x="${width - OUTER_PADDING}" y="24" text-anchor="end" class="meta">${escapeXml(scope)} export · ${escapeXml(generatedAt.toISOString())}</text>`,
+  ].join("");
+}
+
+function renderGrid(
+  chartX: number,
+  chartY: number,
+  chartWidth: number,
+  chartHeight: number,
+  startDate: Date,
+  endDate: Date,
+  dayWidth: number,
+): string {
+  const days = Math.max(1, diffDays(startDate, endDate) + 1);
+  const lines: string[] = [];
+  for (let day = 0; day <= days; day += 1) {
+    const x = chartX + day * dayWidth;
+    const date = addDays(startDate, day);
+    const major = date.getUTCDate() === 1 || day === 0 || day === days;
+    lines.push(
+      `<line x1="${x}" y1="${chartY}" x2="${x}" y2="${chartY + chartHeight}" class="${major ? "grid-major" : "grid"}" />`,
+    );
+    if (major) {
+      lines.push(
+        `<text x="${x + 4}" y="${chartY - 9}" class="date-label">${escapeXml(formatDate(date))}</text>`,
+      );
+    }
+  }
+  return lines.join("");
+}
+
+function renderTaskRow(
+  node: GanttExportTaskNode,
+  rowIndex: number,
+  chartX: number,
+  treeX: number,
+  rowY: number,
+  startDate: Date,
+  dayWidth: number,
+  config: Config,
+): string {
+  const { task, depth } = node;
+  const range = dateRangeForTask(task);
+  const y = rowY + rowIndex * ROW_HEIGHT;
+  const centerY = y + ROW_HEIGHT / 2;
+  const issueLabel = taskIssueLabel(task);
+  const color = taskColor(task, config);
+  const opacity = statusDone(task, config) ? 0.55 : 1;
+  const taskType = config.task_types[task.type];
+  const treeLabelX = treeX + 8 + depth * 16;
+  const title = `${task.title}, ${range ? `${formatDate(range.start)} to ${formatDate(range.end)}` : "unscheduled"}`;
+  const elements = [
+    `<rect x="${treeX}" y="${y}" width="${TREE_WIDTH}" height="${ROW_HEIGHT}" class="row-bg" />`,
+    `<text x="${treeLabelX}" y="${centerY + 4}" class="issue">${escapeXml(issueLabel)}</text>`,
+    `<text x="${treeLabelX + 52}" y="${centerY + 4}" class="task-title">${escapeXml(task.title)}</text>`,
+  ];
+
+  if (!range) {
+    elements.push(
+      `<text x="${chartX + 8}" y="${centerY + 4}" class="unscheduled">No schedule</text>`,
+    );
+    return elements.join("");
+  }
+
+  const barX = chartX + diffDays(startDate, range.start) * dayWidth;
+  const durationDays = Math.max(1, diffDays(range.start, range.end) + 1);
+  const barWidth = Math.max(10, durationDays * dayWidth);
+  const barY = centerY - 7;
+
+  if (taskType?.display === "milestone") {
+    const size = 14;
+    elements.push(
+      `<polygon points="${barX + size / 2},${barY} ${barX + size},${barY + size / 2} ${barX + size / 2},${barY + size} ${barX},${barY + size / 2}" fill="${escapeAttr(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></polygon>`,
+    );
+  } else {
+    const rx = taskType?.display === "summary" ? 2 : 4;
+    elements.push(
+      `<rect x="${barX}" y="${barY}" width="${barWidth}" height="14" rx="${rx}" fill="${escapeAttr(color)}" opacity="${opacity}"><title>${escapeXml(title)}</title></rect>`,
+    );
+    if (taskType?.display === "summary") {
+      elements.push(
+        `<rect x="${barX}" y="${barY - 3}" width="6" height="20" fill="${escapeAttr(color)}" opacity="${opacity}" />`,
+        `<rect x="${barX + barWidth - 6}" y="${barY - 3}" width="6" height="20" fill="${escapeAttr(color)}" opacity="${opacity}" />`,
+      );
+    }
+  }
+  elements.push(
+    `<text x="${barX + barWidth + 6}" y="${centerY + 4}" class="bar-label">${escapeXml(task.title)}</text>`,
+  );
+  return elements.join("");
+}
+
+export function renderGanttExportSvg({
+  nodes,
+  config,
+  scope,
+  viewScale = config.gantt.default_view,
+  generatedAt = new Date(),
+}: RenderGanttExportSvgOptions): RenderedGanttExport {
+  const { start, end } = resolveDateRange(nodes, generatedAt);
+  const dayWidth = viewScaleDayWidth(viewScale);
+  const days = Math.max(1, diffDays(start, end) + 1);
+  const chartWidth = Math.max(MIN_GANTT_WIDTH, days * dayWidth);
+  const width = OUTER_PADDING * 2 + TREE_WIDTH + chartWidth;
+  const rowCount = Math.max(1, nodes.length);
+  const chartHeight = HEADER_HEIGHT + rowCount * ROW_HEIGHT;
+  const height = OUTER_PADDING + TITLE_HEIGHT + chartHeight + FOOTER_HEIGHT;
+  const treeX = OUTER_PADDING;
+  const chartX = OUTER_PADDING + TREE_WIDTH;
+  const headerY = OUTER_PADDING + TITLE_HEIGHT;
+  const rowY = headerY + HEADER_HEIGHT;
+
+  const rows =
+    nodes.length === 0
+      ? `<text x="${treeX + 8}" y="${rowY + 20}" class="unscheduled">No tasks</text>`
+      : nodes
+          .map((node, index) =>
+            renderTaskRow(node, index, chartX, treeX, rowY, start, dayWidth, config),
+          )
+          .join("");
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" data-export-format="svg" data-export-scope="${scope}">
+  <style>
+    .title { font: 700 18px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #111827; }
+    .meta, .date-label, .bar-label, .unscheduled { font: 10px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #6B7280; }
+    .column-label { font: 700 11px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #374151; letter-spacing: 0; }
+    .issue { font: 700 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; fill: #4B5563; }
+    .task-title { font: 11px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #111827; }
+    .row-bg { fill: #FFFFFF; stroke: #E5E7EB; stroke-width: 1; }
+    .panel { fill: #F9FAFB; stroke: #D1D5DB; stroke-width: 1; }
+    .grid { stroke: #EEF2F7; stroke-width: 1; }
+    .grid-major { stroke: #D1D5DB; stroke-width: 1; }
+  </style>
+  <rect x="0" y="0" width="${width}" height="${height}" fill="#FFFFFF" />
+  ${renderHeader(config.project.name, scope, generatedAt, width)}
+  <rect x="${treeX}" y="${headerY}" width="${TREE_WIDTH}" height="${chartHeight}" class="panel" />
+  <rect x="${chartX}" y="${headerY}" width="${chartWidth}" height="${chartHeight}" class="panel" />
+  <text x="${treeX + 8}" y="${headerY + 22}" class="column-label">Tree</text>
+  <text x="${chartX + 8}" y="${headerY + 22}" class="column-label">Gantt</text>
+  ${renderGrid(chartX, rowY, chartWidth, rowCount * ROW_HEIGHT, start, end, dayWidth)}
+  ${rows}
+  <text x="${OUTER_PADDING}" y="${height - 8}" class="meta">${escapeXml(formatDate(start))} - ${escapeXml(formatDate(end))} · ${nodes.length} tasks</text>
+</svg>`;
+
+  return { svg, width, height };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export * from "./task-size.js";
 export * from "./status-dates.js";
 export * from "./dependency-graph.js";
 export * from "./adr-schema.js";
+export * from "./export-renderer.js";

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -20,6 +20,8 @@ import { SkeletonLoader } from "./components/SkeletonLoader.js";
 import { ThemeProvider } from "./contexts/ThemeContext.js";
 import { useCustomNonWorkingDays } from "./hooks/useCustomNonWorkingDays.js";
 import { useHolidayPreset } from "./hooks/useHolidayPreset.js";
+import { downloadGanttExport } from "./lib/export-download.js";
+import type { ExportRequest } from "./components/toolbar/ExportMenu.js";
 
 const EMPTY_TASK_TYPES: Record<string, never> = {};
 
@@ -193,6 +195,11 @@ export function App() {
 
   const visibleTaskMap = useMemo(
     () => new Map(visibleTaskNodes.map((node) => [node.task.id, node])),
+    [visibleTaskNodes],
+  );
+
+  const exportVisibleNodes = useMemo(
+    () => visibleTaskNodes.map((node) => ({ task: node.task, depth: node.depth })),
     [visibleTaskNodes],
   );
 
@@ -475,6 +482,25 @@ export function App() {
     }
   }, [clearHistory, refresh, showToast]);
 
+  const handleExport = useCallback(
+    async (request: ExportRequest) => {
+      if (!config) return;
+      try {
+        await downloadGanttExport({
+          tasks,
+          visibleNodes: exportVisibleNodes,
+          config,
+          request,
+          viewScale,
+        });
+        showToast(`Exported ${request.format.toUpperCase()}`, "success");
+      } catch (err) {
+        showToast(`Export failed: ${err instanceof Error ? err.message : String(err)}`, "error");
+      }
+    },
+    [config, exportVisibleNodes, showToast, tasks, viewScale],
+  );
+
   const hasActiveFilters = useMemo(() => {
     const allTypeCount = Object.keys(config?.task_types ?? {}).length;
     return (
@@ -626,6 +652,9 @@ export function App() {
             customDaysOff={customDaysOff}
             onAddCustomDayOff={addCustomDayOff}
             onRemoveCustomDayOff={removeCustomDayOff}
+            onExport={(request) => {
+              void handleExport(request);
+            }}
           />
           <div style={{ flex: 1, overflow: "hidden", display: "flex" }}>
             <div

--- a/packages/ui/src/__tests__/export-menu.test.tsx
+++ b/packages/ui/src/__tests__/export-menu.test.tsx
@@ -2,15 +2,77 @@
 import React from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Config, Task } from "@gh-gantt/shared";
 import { Toolbar } from "../components/toolbar/Toolbar.js";
+import { downloadGanttExport } from "../lib/export-download.js";
 
 vi.mock("../components/toolbar/ThemeToggle.js", () => ({
   ThemeToggle: () => null,
 }));
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
   cleanup();
 });
+
+const config: Config = {
+  version: "1",
+  project: {
+    name: "Export Project",
+    github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+  },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+  },
+  type_hierarchy: { task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+};
+
+const task: Task = {
+  id: "stanah/gh-gantt#20",
+  type: "task",
+  github_issue: 20,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "SVG/PNGエクスポート",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: { Status: "Todo" },
+  start_date: "2026-05-04",
+  end_date: "2026-05-08",
+  date: null,
+  blocked_by: [],
+};
 
 describe("[FR-VIS-019-AC4] Toolbar のエクスポートメニュー", () => {
   it("形式・範囲・2x オプションを選んで export handler に渡せる", () => {
@@ -58,5 +120,29 @@ describe("[FR-VIS-019-AC4] Toolbar のエクスポートメニュー", () => {
       scope: "project",
       scaleFactor: 2,
     });
+  });
+
+  it("SVG ダウンロードの Blob URL はクリック直後ではなく次 tick で revoke する", async () => {
+    vi.useFakeTimers();
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:gh-gantt-export"),
+      revokeObjectURL,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    await downloadGanttExport({
+      tasks: [task],
+      visibleNodes: [{ task, depth: 0 }],
+      config,
+      request: { format: "svg", scope: "project", scaleFactor: 1 },
+      viewScale: "month",
+    });
+
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:gh-gantt-export");
   });
 });

--- a/packages/ui/src/__tests__/export-menu.test.tsx
+++ b/packages/ui/src/__tests__/export-menu.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Toolbar } from "../components/toolbar/Toolbar.js";
+
+vi.mock("../components/toolbar/ThemeToggle.js", () => ({
+  ThemeToggle: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("[FR-VIS-019-AC4] Toolbar のエクスポートメニュー", () => {
+  it("形式・範囲・2x オプションを選んで export handler に渡せる", () => {
+    const onExport = vi.fn();
+    const { getByLabelText, getByTitle } = render(
+      <Toolbar
+        projectName="Test Project"
+        taskCount={1}
+        activeScale="month"
+        onScaleChange={() => {}}
+        onScrollToToday={() => {}}
+        onPull={() => {}}
+        onPush={() => {}}
+        syncing={null}
+        displayOptions={new Set()}
+        onToggleDisplayOption={() => {}}
+        dependencyHighlightEnabled={false}
+        onToggleDependencyHighlight={() => {}}
+        hideClosed={false}
+        onToggleHideClosed={() => {}}
+        taskTypes={{
+          task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
+        }}
+        enabledTypes={new Set(["task"])}
+        onToggleType={() => {}}
+        selectedAssignee={null}
+        allAssignees={[]}
+        onSelectAssignee={() => {}}
+        searchQuery=""
+        onSearchChange={() => {}}
+        taskSortMode="default"
+        onTaskSortModeChange={() => {}}
+        onExport={onExport}
+      />,
+    );
+
+    fireEvent.click(getByTitle("Export"));
+    fireEvent.change(getByLabelText("Export format"), { target: { value: "png" } });
+    fireEvent.change(getByLabelText("Export scope"), { target: { value: "project" } });
+    fireEvent.click(getByLabelText("High resolution 2x"));
+    fireEvent.click(getByLabelText("Run export"));
+
+    expect(onExport).toHaveBeenCalledWith({
+      format: "png",
+      scope: "project",
+      scaleFactor: 2,
+    });
+  });
+});

--- a/packages/ui/src/components/toolbar/ExportMenu.tsx
+++ b/packages/ui/src/components/toolbar/ExportMenu.tsx
@@ -3,13 +3,19 @@ import { Download } from "lucide-react";
 import type { GanttExportFormat, GanttExportScope } from "@gh-gantt/shared";
 import { IconButton } from "./IconButton.js";
 
+/** エクスポート実行時に UI から渡す選択内容。 */
 export interface ExportRequest {
+  /** 出力形式。 */
   format: GanttExportFormat;
+  /** 出力範囲。 */
   scope: GanttExportScope;
+  /** PNG 変換時の解像度倍率。 */
   scaleFactor: 1 | 2;
 }
 
+/** エクスポートメニューの props。 */
 interface ExportMenuProps {
+  /** 選択内容でエクスポートを実行するハンドラ。 */
   onExport: (request: ExportRequest) => void;
 }
 
@@ -45,6 +51,12 @@ const inputStyle: React.CSSProperties = {
   padding: "3px 6px",
 };
 
+/**
+ * ガントビューの形式・範囲・解像度を選ぶエクスポートメニュー。
+ *
+ * @param props エクスポート実行ハンドラを含む props。
+ * @returns ツールバー内に表示するエクスポート操作 UI。
+ */
 export function ExportMenu({ onExport }: ExportMenuProps) {
   const [open, setOpen] = useState(false);
   const [format, setFormat] = useState<GanttExportFormat>("svg");
@@ -82,11 +94,11 @@ export function ExportMenu({ onExport }: ExportMenuProps) {
         title="Export"
         onClick={() => setOpen((prev) => !prev)}
         active={open}
-        aria-haspopup="menu"
+        aria-haspopup="dialog"
         aria-expanded={open}
       />
       {open && (
-        <div role="menu" style={panelStyle}>
+        <div role="dialog" aria-label="エクスポート設定" style={panelStyle}>
           <div style={sectionLabel}>Export</div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 6 }}>
             <select

--- a/packages/ui/src/components/toolbar/ExportMenu.tsx
+++ b/packages/ui/src/components/toolbar/ExportMenu.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Download } from "lucide-react";
+import type { GanttExportFormat, GanttExportScope } from "@gh-gantt/shared";
+import { IconButton } from "./IconButton.js";
+
+export interface ExportRequest {
+  format: GanttExportFormat;
+  scope: GanttExportScope;
+  scaleFactor: 1 | 2;
+}
+
+interface ExportMenuProps {
+  onExport: (request: ExportRequest) => void;
+}
+
+const panelStyle: React.CSSProperties = {
+  position: "absolute",
+  top: "calc(100% + 4px)",
+  right: 0,
+  zIndex: 20,
+  width: 220,
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 4,
+  boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+  padding: 8,
+};
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: 9,
+  color: "var(--color-text-muted)",
+  textTransform: "uppercase",
+  letterSpacing: 0.5,
+  marginBottom: 4,
+  userSelect: "none",
+};
+
+const inputStyle: React.CSSProperties = {
+  minHeight: 24,
+  border: "1px solid var(--color-border)",
+  borderRadius: 3,
+  background: "var(--color-bg)",
+  color: "var(--color-text)",
+  fontSize: 11,
+  padding: "3px 6px",
+};
+
+export function ExportMenu({ onExport }: ExportMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [format, setFormat] = useState<GanttExportFormat>("svg");
+  const [scope, setScope] = useState<GanttExportScope>("current");
+  const [highResolution, setHighResolution] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleExport = () => {
+    onExport({ format, scope, scaleFactor: highResolution ? 2 : 1 });
+    setOpen(false);
+  };
+
+  return (
+    <div ref={wrapperRef} style={{ position: "relative" }}>
+      <IconButton
+        icon={<Download size={14} />}
+        title="Export"
+        onClick={() => setOpen((prev) => !prev)}
+        active={open}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      />
+      {open && (
+        <div role="menu" style={panelStyle}>
+          <div style={sectionLabel}>Export</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 6 }}>
+            <select
+              aria-label="Export format"
+              value={format}
+              onChange={(e) => setFormat(e.target.value as GanttExportFormat)}
+              style={inputStyle}
+            >
+              <option value="svg">SVG</option>
+              <option value="png">PNG</option>
+            </select>
+            <select
+              aria-label="Export scope"
+              value={scope}
+              onChange={(e) => setScope(e.target.value as GanttExportScope)}
+              style={inputStyle}
+            >
+              <option value="current">Current view</option>
+              <option value="project">Project</option>
+            </select>
+            <label
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                color: "var(--color-text-secondary)",
+                fontSize: 11,
+              }}
+            >
+              <input
+                type="checkbox"
+                aria-label="High resolution 2x"
+                checked={highResolution}
+                onChange={(e) => setHighResolution(e.target.checked)}
+              />
+              2x
+            </label>
+            <button
+              type="button"
+              aria-label="Run export"
+              onClick={handleExport}
+              style={{
+                ...inputStyle,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 4,
+                cursor: "pointer",
+              }}
+            >
+              <Download size={12} />
+              Export
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/toolbar/IconButton.tsx
+++ b/packages/ui/src/components/toolbar/IconButton.tsx
@@ -32,7 +32,7 @@ const baseStyle: React.CSSProperties = {
 const activeStyle: React.CSSProperties = {
   background: "var(--color-selected-bg)",
   color: "var(--color-selected-fg)",
-  borderColor: "var(--color-selected-border)",
+  border: "1px solid var(--color-selected-border)",
 };
 
 const disabledStyle: React.CSSProperties = {

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -14,6 +14,7 @@ import { MoreMenu } from "./MoreMenu.js";
 import { ThemeToggle } from "./ThemeToggle.js";
 import { IconButton } from "./IconButton.js";
 import { CalendarSettingsMenu } from "./CalendarSettingsMenu.js";
+import { ExportMenu, type ExportRequest } from "./ExportMenu.js";
 import type { CalendarHoliday } from "../../types/index.js";
 import type { HolidayPreset, HolidayPresetId } from "../../lib/holiday-presets.js";
 
@@ -69,6 +70,7 @@ interface ToolbarProps {
   customDaysOff?: CalendarHoliday[];
   onAddCustomDayOff?: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff?: (date: string) => void;
+  onExport?: (request: ExportRequest) => void;
 }
 
 const taskSortOptions: Array<{ value: TaskSortMode; label: string }> = [
@@ -190,6 +192,7 @@ export function Toolbar(props: ToolbarProps) {
           onRemoveCustomDayOff={props.onRemoveCustomDayOff}
         />
       )}
+      {props.onExport && <ExportMenu onExport={props.onExport} />}
       <MoreMenu
         displayOptions={props.displayOptions}
         onToggleDisplayOption={props.onToggleDisplayOption}

--- a/packages/ui/src/lib/export-download.ts
+++ b/packages/ui/src/lib/export-download.ts
@@ -29,7 +29,7 @@ function downloadBlob(blob: Blob, name: string): void {
   document.body.append(anchor);
   anchor.click();
   anchor.remove();
-  URL.revokeObjectURL(url);
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 async function svgToPngBlob(

--- a/packages/ui/src/lib/export-download.ts
+++ b/packages/ui/src/lib/export-download.ts
@@ -1,0 +1,103 @@
+import {
+  buildExportTaskNodes,
+  renderGanttExportSvg,
+  type Config,
+  type GanttExportScope,
+  type GanttExportTaskNode,
+  type Task,
+  type ViewScale,
+} from "@gh-gantt/shared";
+import type { ExportRequest } from "../components/toolbar/ExportMenu.js";
+
+interface DownloadGanttExportOptions {
+  tasks: Task[];
+  visibleNodes: GanttExportTaskNode[];
+  config: Config;
+  request: ExportRequest;
+  viewScale: ViewScale;
+}
+
+function fileName(scope: GanttExportScope, format: "svg" | "png"): string {
+  return `gh-gantt-${scope}.${format}`;
+}
+
+function downloadBlob(blob: Blob, name: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = name;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function svgToPngBlob(
+  svg: string,
+  width: number,
+  height: number,
+  scaleFactor: 1 | 2,
+): Promise<Blob> {
+  const svgBlob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(svgBlob);
+  try {
+    const image = new Image();
+    const loaded = new Promise<void>((resolve, reject) => {
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error("SVG の画像化に失敗しました"));
+    });
+    image.src = url;
+    await loaded;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width * scaleFactor;
+    canvas.height = height * scaleFactor;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Canvas を初期化できません");
+    }
+    context.scale(scaleFactor, scaleFactor);
+    context.drawImage(image, 0, 0, width, height);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("PNG の生成に失敗しました"));
+      }, "image/png");
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export async function downloadGanttExport({
+  tasks,
+  visibleNodes,
+  config,
+  request,
+  viewScale,
+}: DownloadGanttExportOptions): Promise<void> {
+  const nodes = request.scope === "project" ? buildExportTaskNodes(tasks) : visibleNodes;
+  const rendered = renderGanttExportSvg({
+    nodes,
+    config,
+    scope: request.scope,
+    viewScale,
+  });
+
+  if (request.format === "svg") {
+    downloadBlob(
+      new Blob([rendered.svg], { type: "image/svg+xml;charset=utf-8" }),
+      fileName(request.scope, "svg"),
+    );
+    return;
+  }
+
+  const pngBlob = await svgToPngBlob(
+    rendered.svg,
+    rendered.width,
+    rendered.height,
+    request.scaleFactor,
+  );
+  downloadBlob(pngBlob, fileName(request.scope, "png"));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
       zod:
         specifier: ^3.23.0
         version: 3.25.76


### PR DESCRIPTION
## 概要
- ツリー列とガント列を含む共有 SVG export renderer を追加
- UI Toolbar に SVG/PNG、current/project、2x を選べる Export メニューを追加
- CLI に `gh-gantt export --format svg|png` を追加し、PNG は Playwright による 2x 書き出しに対応

## 検証
- pnpm lint
- pnpm test:json
- pnpm build
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen
- built CLI: SVG export / PNG 2x export / CLI current scope rejection
- built UI: localhost:3000 で Export menu controls を確認

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Gantt チャートを SVG または PNG 形式でエクスポート可能になりました
  * 高解像度 2x オプションで PNG エクスポート出力に対応
  * プロジェクト全体またはビュー表示範囲でのエクスポート選択が可能
  * CLI コマンドと UI ツールバーの両方からエクスポート実行に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->