### PR TITLE
feat(ui): フィルタプリセット保存を追加 (#51)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -764,6 +764,19 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/export-command.test.ts
+      - id: FR-VIS-020
+        summary: フィルタプリセット保存・復元
+        acceptance_criteria:
+          - id: FR-VIS-020-AC1
+            description: 現在のフィルタ状態を名前付きプリセットとして localStorage に保存し、選択時に一括復元できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/filter-presets.test.tsx
+          - id: FR-VIS-020-AC2
+            description: Toolbar からプリセットの選択・保存・更新・名前変更・削除・全フィルタクリアを実行できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/filter-presets.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { SkeletonLoader } from "./components/SkeletonLoader.js";
 import { ThemeProvider } from "./contexts/ThemeContext.js";
 import { useCustomNonWorkingDays } from "./hooks/useCustomNonWorkingDays.js";
 import { useHolidayPreset } from "./hooks/useHolidayPreset.js";
+import { useFilterPresets, type FilterPresetState } from "./hooks/useFilterPresets.js";
 import { downloadGanttExport } from "./lib/export-download.js";
 import type { ExportRequest } from "./components/toolbar/ExportMenu.js";
 
@@ -138,16 +139,19 @@ export function App() {
   const {
     enabled,
     toggle: toggleType,
+    setEnabledTypes,
     enableAll: enableAllTypes,
   } = useTypeFilter(config?.task_types ?? {});
   const { displayOptions, toggleDisplayOption } = useDisplayOptions();
   const {
     hideClosed,
+    setHideClosed,
     toggleHideClosed,
     dependencyHighlightEnabled,
     toggleDependencyHighlight,
     selectedAssignee,
     selectedAssignees,
+    setSelectedAssignees,
     setSelectedAssignee,
     allAssignees,
     selectedPriorities,
@@ -181,6 +185,61 @@ export function App() {
     searchQuery,
     taskSortMode,
     labelGrouping,
+  });
+
+  const currentFilterPresetState = useMemo<FilterPresetState>(
+    () => ({
+      hideClosed,
+      selectedAssignees,
+      selectedPriorities,
+      selectedLabels,
+      enabledTypes: [...enabled].sort(),
+      searchQuery,
+      taskSortMode,
+    }),
+    [
+      hideClosed,
+      selectedAssignees,
+      selectedPriorities,
+      selectedLabels,
+      enabled,
+      searchQuery,
+      taskSortMode,
+    ],
+  );
+
+  const applyFilterPresetState = useCallback(
+    (state: FilterPresetState) => {
+      setHideClosed(state.hideClosed);
+      setSelectedAssignees(state.selectedAssignees);
+      setSelectedPriorities(state.selectedPriorities);
+      setSelectedLabels(state.selectedLabels);
+      setEnabledTypes(state.enabledTypes);
+      setSearchQuery(state.searchQuery);
+      setTaskSortMode(state.taskSortMode);
+    },
+    [
+      setEnabledTypes,
+      setHideClosed,
+      setSearchQuery,
+      setSelectedAssignees,
+      setSelectedLabels,
+      setSelectedPriorities,
+    ],
+  );
+
+  const {
+    presets: filterPresets,
+    selectedPresetId: selectedFilterPresetId,
+    savePreset: saveFilterPreset,
+    applyPreset: applyFilterPreset,
+    updatePreset: updateFilterPreset,
+    renamePreset: renameFilterPreset,
+    deletePreset: deleteFilterPreset,
+    clearSelectedPreset: clearSelectedFilterPreset,
+  } = useFilterPresets({
+    currentState: currentFilterPresetState,
+    onApplyPreset: applyFilterPresetState,
   });
 
   const visibleTaskNodes = useMemo(
@@ -504,26 +563,43 @@ export function App() {
   const hasActiveFilters = useMemo(() => {
     const allTypeCount = Object.keys(config?.task_types ?? {}).length;
     return (
+      hideClosed ||
       searchQuery.trim() !== "" ||
       selectedAssignees.length > 0 ||
       selectedPriorities.length > 0 ||
       selectedLabels.length > 0 ||
-      (enabled.size > 0 && enabled.size < allTypeCount)
+      taskSortMode !== "default" ||
+      (allTypeCount > 0 && enabled.size < allTypeCount)
     );
-  }, [searchQuery, selectedAssignees, selectedPriorities, selectedLabels, enabled, config]);
+  }, [
+    hideClosed,
+    searchQuery,
+    selectedAssignees,
+    selectedPriorities,
+    selectedLabels,
+    taskSortMode,
+    enabled,
+    config,
+  ]);
 
   const resetAllFilters = useCallback(() => {
+    setHideClosed(false);
     setSearchQuery("");
     setSelectedAssignee(null);
     setSelectedPriorities([]);
     setSelectedLabels([]);
+    setTaskSortMode("default");
     enableAllTypes();
+    clearSelectedFilterPreset();
   }, [
+    setHideClosed,
     setSearchQuery,
     setSelectedAssignee,
     setSelectedPriorities,
     setSelectedLabels,
+    setTaskSortMode,
     enableAllTypes,
+    clearSelectedFilterPreset,
   ]);
 
   return (
@@ -623,6 +699,14 @@ export function App() {
             labelGroupingPrefix={labelGroupingPrefix}
             labelGroupingEnabled={labelGroupingEnabled}
             onToggleLabelGrouping={() => setLabelGroupingEnabled((prev) => !prev)}
+            filterPresets={filterPresets}
+            selectedFilterPresetId={selectedFilterPresetId}
+            onApplyFilterPreset={applyFilterPreset}
+            onSaveFilterPreset={saveFilterPreset}
+            onUpdateFilterPreset={updateFilterPreset}
+            onRenameFilterPreset={renameFilterPreset}
+            onDeleteFilterPreset={deleteFilterPreset}
+            onClearFilters={resetAllFilters}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
             taskSortMode={taskSortMode}

--- a/packages/ui/src/__tests__/filter-presets.test.tsx
+++ b/packages/ui/src/__tests__/filter-presets.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import React, { useState } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FilterPresetSelector } from "../components/toolbar/FilterPresetSelector.js";
+import {
+  FILTER_PRESETS_STORAGE_KEY,
+  useFilterPresets,
+  type FilterPreset,
+  type FilterPresetState,
+} from "../hooks/useFilterPresets.js";
+
+const filterState: FilterPresetState = {
+  hideClosed: true,
+  selectedAssignees: ["stanah"],
+  selectedPriorities: ["high"],
+  selectedLabels: ["pkg:cli"],
+  enabledTypes: ["task"],
+  searchQuery: "cli",
+  taskSortMode: "updated_at_desc",
+};
+
+const emptyFilterState: FilterPresetState = {
+  hideClosed: false,
+  selectedAssignees: [],
+  selectedPriorities: [],
+  selectedLabels: [],
+  enabledTypes: ["task", "epic"],
+  searchQuery: "",
+  taskSortMode: "default",
+};
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+function PresetProbe({
+  initialState = filterState,
+  onApplyPreset = () => {},
+}: {
+  initialState?: FilterPresetState;
+  onApplyPreset?: (state: FilterPresetState) => void;
+}) {
+  const [currentState, setCurrentState] = useState(initialState);
+  const { presets, savePreset, applyPreset, updatePreset, renamePreset, deletePreset } =
+    useFilterPresets({
+      currentState,
+      onApplyPreset,
+    });
+
+  return (
+    <div>
+      <output aria-label="preset count">{presets.length}</output>
+      <output aria-label="preset names">{presets.map((preset) => preset.name).join(",")}</output>
+      <button type="button" onClick={() => savePreset("自分のCLI")}>
+        save
+      </button>
+      <button type="button" onClick={() => applyPreset("preset-1")}>
+        apply
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setCurrentState(emptyFilterState);
+          updatePreset("preset-1", emptyFilterState);
+        }}
+      >
+        update
+      </button>
+      <button type="button" onClick={() => renamePreset("preset-1", "今週更新")}>
+        rename
+      </button>
+      <button type="button" onClick={() => deletePreset("preset-1")}>
+        delete
+      </button>
+    </div>
+  );
+}
+
+describe("[FR-VIS-020-AC1] フィルタプリセットの localStorage 永続化", () => {
+  it("現在のフィルタ状態を名前付きプリセットとして保存する", () => {
+    const { getByText, getByLabelText } = render(<PresetProbe />);
+
+    fireEvent.click(getByText("save"));
+
+    expect(getByLabelText("preset count").textContent).toBe("1");
+    const stored = JSON.parse(localStorage.getItem(FILTER_PRESETS_STORAGE_KEY) ?? "[]") as Array<{
+      name: string;
+      state: FilterPresetState;
+    }>;
+    expect(stored[0]).toMatchObject({
+      name: "自分のCLI",
+      state: filterState,
+    });
+  });
+
+  it("保存済みプリセットを選択するとフィルタ状態を一括復元する", () => {
+    localStorage.setItem(
+      FILTER_PRESETS_STORAGE_KEY,
+      JSON.stringify([{ id: "preset-1", name: "自分のCLI", state: filterState }]),
+    );
+    const onApplyPreset = vi.fn();
+    const { getByText, getByLabelText } = render(
+      <PresetProbe initialState={emptyFilterState} onApplyPreset={onApplyPreset} />,
+    );
+
+    expect(getByLabelText("preset names").textContent).toBe("自分のCLI");
+
+    fireEvent.click(getByText("apply"));
+
+    expect(onApplyPreset).toHaveBeenCalledWith(filterState);
+  });
+
+  it("プリセットの更新・名前変更・削除を localStorage に反映する", () => {
+    localStorage.setItem(
+      FILTER_PRESETS_STORAGE_KEY,
+      JSON.stringify([{ id: "preset-1", name: "自分のCLI", state: filterState }]),
+    );
+    const { getByText } = render(<PresetProbe />);
+
+    fireEvent.click(getByText("update"));
+    let stored = JSON.parse(localStorage.getItem(FILTER_PRESETS_STORAGE_KEY) ?? "[]") as Array<{
+      state: FilterPresetState;
+    }>;
+    expect(stored[0]?.state).toEqual(emptyFilterState);
+
+    fireEvent.click(getByText("rename"));
+    stored = JSON.parse(localStorage.getItem(FILTER_PRESETS_STORAGE_KEY) ?? "[]") as Array<{
+      name: string;
+    }>;
+    expect(stored[0]?.name).toBe("今週更新");
+
+    fireEvent.click(getByText("delete"));
+    expect(localStorage.getItem(FILTER_PRESETS_STORAGE_KEY)).toBe("[]");
+  });
+
+  it("壊れた localStorage 値は空のプリセットとして扱う", () => {
+    localStorage.setItem(FILTER_PRESETS_STORAGE_KEY, "not json");
+
+    const { getByLabelText } = render(<PresetProbe />);
+
+    expect(getByLabelText("preset count").textContent).toBe("0");
+  });
+});
+
+describe("[FR-VIS-020-AC2] Toolbar のフィルタプリセット UI", () => {
+  const preset: FilterPreset = {
+    id: "preset-1",
+    name: "自分のCLI",
+    state: filterState,
+  };
+
+  it("ドロップダウンでプリセットを選択し、保存・更新・名前変更・削除・clear を実行できる", () => {
+    const onApplyPreset = vi.fn();
+    const onSavePreset = vi.fn();
+    const onUpdatePreset = vi.fn();
+    const onRenamePreset = vi.fn();
+    const onDeletePreset = vi.fn();
+    const onClearFilters = vi.fn();
+    vi.spyOn(window, "prompt")
+      .mockReturnValueOnce("新規プリセット")
+      .mockReturnValueOnce("名前変更後");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    function SelectorHarness() {
+      const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+      return (
+        <FilterPresetSelector
+          presets={[preset]}
+          selectedPresetId={selectedPresetId}
+          onApplyPreset={(id) => {
+            setSelectedPresetId(id);
+            onApplyPreset(id);
+          }}
+          onSavePreset={onSavePreset}
+          onUpdatePreset={onUpdatePreset}
+          onRenamePreset={onRenamePreset}
+          onDeletePreset={onDeletePreset}
+          onClearFilters={onClearFilters}
+        />
+      );
+    }
+
+    const { getByLabelText, getByTitle } = render(<SelectorHarness />);
+
+    fireEvent.change(getByLabelText("Filter preset"), { target: { value: "preset-1" } });
+    fireEvent.click(getByTitle("Save Filter Preset"));
+    fireEvent.click(getByTitle("Update Filter Preset"));
+    fireEvent.click(getByTitle("Rename Filter Preset"));
+    fireEvent.click(getByTitle("Delete Filter Preset"));
+    fireEvent.click(getByTitle("Clear All Filters"));
+
+    expect(onApplyPreset).toHaveBeenCalledWith("preset-1");
+    expect(onSavePreset).toHaveBeenCalledWith("新規プリセット");
+    expect(onUpdatePreset).toHaveBeenCalledWith("preset-1");
+    expect(onRenamePreset).toHaveBeenCalledWith("preset-1", "名前変更後");
+    expect(onDeletePreset).toHaveBeenCalledWith("preset-1");
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/toolbar/FilterPresetSelector.tsx
+++ b/packages/ui/src/components/toolbar/FilterPresetSelector.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Bookmark, Pencil, Plus, Save, Trash2, XCircle } from "lucide-react";
+import type { FilterPreset } from "../../hooks/useFilterPresets.js";
+import { IconButton } from "./IconButton.js";
+
+interface FilterPresetSelectorProps {
+  presets: FilterPreset[];
+  selectedPresetId: string | null;
+  onApplyPreset: (id: string) => void;
+  onSavePreset: (name: string) => void;
+  onUpdatePreset: (id: string) => void;
+  onRenamePreset: (id: string, name: string) => void;
+  onDeletePreset: (id: string) => void;
+  onClearFilters: () => void;
+}
+
+const selectStyle: React.CSSProperties = {
+  minHeight: 24,
+  width: 142,
+  border: "1px solid var(--color-border)",
+  borderRadius: 3,
+  background: "var(--color-bg)",
+  color: "var(--color-text)",
+  fontSize: 11,
+  padding: "3px 6px",
+};
+
+export function FilterPresetSelector({
+  presets,
+  selectedPresetId,
+  onApplyPreset,
+  onSavePreset,
+  onUpdatePreset,
+  onRenamePreset,
+  onDeletePreset,
+  onClearFilters,
+}: FilterPresetSelectorProps) {
+  const selectedPreset = presets.find((preset) => preset.id === selectedPresetId) ?? null;
+
+  const promptForName = (message: string, initialValue = "") => {
+    const name = window.prompt(message, initialValue);
+    return name?.trim() ? name.trim() : null;
+  };
+
+  return (
+    <div style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+      <Bookmark size={13} color="var(--color-text-secondary)" />
+      <select
+        aria-label="Filter preset"
+        value={selectedPresetId ?? ""}
+        onChange={(e) => {
+          if (e.target.value) onApplyPreset(e.target.value);
+        }}
+        style={selectStyle}
+      >
+        <option value="">Preset...</option>
+        {presets.map((preset) => (
+          <option key={preset.id} value={preset.id}>
+            {preset.name}
+          </option>
+        ))}
+      </select>
+      <IconButton
+        icon={<Plus size={13} />}
+        title="Save Filter Preset"
+        onClick={() => {
+          const name = promptForName("Preset name");
+          if (name) onSavePreset(name);
+        }}
+      />
+      <IconButton
+        icon={<Save size={13} />}
+        title="Update Filter Preset"
+        disabled={!selectedPreset}
+        onClick={() => {
+          if (selectedPreset) onUpdatePreset(selectedPreset.id);
+        }}
+      />
+      <IconButton
+        icon={<Pencil size={13} />}
+        title="Rename Filter Preset"
+        disabled={!selectedPreset}
+        onClick={() => {
+          if (!selectedPreset) return;
+          const name = promptForName("Preset name", selectedPreset.name);
+          if (name) onRenamePreset(selectedPreset.id, name);
+        }}
+      />
+      <IconButton
+        icon={<Trash2 size={13} />}
+        title="Delete Filter Preset"
+        disabled={!selectedPreset}
+        onClick={() => {
+          if (!selectedPreset) return;
+          if (window.confirm(`Delete preset "${selectedPreset.name}"?`)) {
+            onDeletePreset(selectedPreset.id);
+          }
+        }}
+      />
+      <IconButton icon={<XCircle size={13} />} title="Clear All Filters" onClick={onClearFilters} />
+    </div>
+  );
+}

--- a/packages/ui/src/components/toolbar/Toolbar.tsx
+++ b/packages/ui/src/components/toolbar/Toolbar.tsx
@@ -15,7 +15,9 @@ import { ThemeToggle } from "./ThemeToggle.js";
 import { IconButton } from "./IconButton.js";
 import { CalendarSettingsMenu } from "./CalendarSettingsMenu.js";
 import { ExportMenu, type ExportRequest } from "./ExportMenu.js";
+import { FilterPresetSelector } from "./FilterPresetSelector.js";
 import type { CalendarHoliday } from "../../types/index.js";
+import type { FilterPreset } from "../../hooks/useFilterPresets.js";
 import type { HolidayPreset, HolidayPresetId } from "../../lib/holiday-presets.js";
 
 interface ToolbarProps {
@@ -71,6 +73,14 @@ interface ToolbarProps {
   onAddCustomDayOff?: (day: CalendarHoliday) => void;
   onRemoveCustomDayOff?: (date: string) => void;
   onExport?: (request: ExportRequest) => void;
+  filterPresets?: FilterPreset[];
+  selectedFilterPresetId?: string | null;
+  onApplyFilterPreset?: (id: string) => void;
+  onSaveFilterPreset?: (name: string) => void;
+  onUpdateFilterPreset?: (id: string) => void;
+  onRenameFilterPreset?: (id: string, name: string) => void;
+  onDeleteFilterPreset?: (id: string) => void;
+  onClearFilters?: () => void;
 }
 
 const taskSortOptions: Array<{ value: TaskSortMode; label: string }> = [
@@ -127,6 +137,24 @@ export function Toolbar(props: ToolbarProps) {
         labelGroupingEnabled={props.labelGroupingEnabled}
         onToggleLabelGrouping={props.onToggleLabelGrouping}
       />
+      {props.filterPresets &&
+        props.onApplyFilterPreset &&
+        props.onSaveFilterPreset &&
+        props.onUpdateFilterPreset &&
+        props.onRenameFilterPreset &&
+        props.onDeleteFilterPreset &&
+        props.onClearFilters && (
+          <FilterPresetSelector
+            presets={props.filterPresets}
+            selectedPresetId={props.selectedFilterPresetId ?? null}
+            onApplyPreset={props.onApplyFilterPreset}
+            onSavePreset={props.onSaveFilterPreset}
+            onUpdatePreset={props.onUpdateFilterPreset}
+            onRenamePreset={props.onRenameFilterPreset}
+            onDeletePreset={props.onDeleteFilterPreset}
+            onClearFilters={props.onClearFilters}
+          />
+        )}
       <SearchBox
         searchQuery={props.searchQuery}
         onSearchChange={props.onSearchChange}

--- a/packages/ui/src/hooks/useFilterPresets.ts
+++ b/packages/ui/src/hooks/useFilterPresets.ts
@@ -1,0 +1,184 @@
+import { useCallback, useState } from "react";
+import type { TaskSortMode } from "./useTaskTree.js";
+
+export const FILTER_PRESETS_STORAGE_KEY = "gh-gantt:filter-presets";
+
+export interface FilterPresetState {
+  hideClosed: boolean;
+  selectedAssignees: string[];
+  selectedPriorities: string[];
+  selectedLabels: string[];
+  enabledTypes: string[];
+  searchQuery: string;
+  taskSortMode: TaskSortMode;
+}
+
+export interface FilterPreset {
+  id: string;
+  name: string;
+  state: FilterPresetState;
+}
+
+interface UseFilterPresetsOptions {
+  currentState: FilterPresetState;
+  onApplyPreset: (state: FilterPresetState) => void;
+}
+
+function cloneState(state: FilterPresetState): FilterPresetState {
+  return {
+    hideClosed: state.hideClosed,
+    selectedAssignees: [...state.selectedAssignees],
+    selectedPriorities: [...state.selectedPriorities],
+    selectedLabels: [...state.selectedLabels],
+    enabledTypes: [...state.enabledTypes],
+    searchQuery: state.searchQuery,
+    taskSortMode: state.taskSortMode,
+  };
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function taskSortMode(value: unknown): TaskSortMode {
+  if (value === "updated_at_asc" || value === "updated_at_desc") return value;
+  return "default";
+}
+
+function normalizeState(value: unknown): FilterPresetState | null {
+  if (typeof value !== "object" || value == null) return null;
+  const record = value as Record<string, unknown>;
+  return {
+    hideClosed: record.hideClosed === true,
+    selectedAssignees: stringArray(record.selectedAssignees),
+    selectedPriorities: stringArray(record.selectedPriorities),
+    selectedLabels: stringArray(record.selectedLabels),
+    enabledTypes: stringArray(record.enabledTypes),
+    searchQuery: typeof record.searchQuery === "string" ? record.searchQuery : "",
+    taskSortMode: taskSortMode(record.taskSortMode),
+  };
+}
+
+function normalizePreset(value: unknown): FilterPreset | null {
+  if (typeof value !== "object" || value == null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== "string" || typeof record.name !== "string") return null;
+  const state = normalizeState(record.state);
+  if (!state) return null;
+  return { id: record.id, name: record.name, state };
+}
+
+function readPresets(): FilterPreset[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(FILTER_PRESETS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item) => {
+      const preset = normalizePreset(item);
+      return preset ? [preset] : [];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function writePresets(presets: FilterPreset[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(FILTER_PRESETS_STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // localStorage が使えない環境でも UI 状態は維持する。
+  }
+}
+
+function createPresetId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `preset-${Date.now().toString(36)}`;
+}
+
+function cleanName(name: string): string | null {
+  const trimmed = name.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function useFilterPresets({ currentState, onApplyPreset }: UseFilterPresetsOptions) {
+  const [presets, setPresets] = useState<FilterPreset[]>(readPresets);
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+
+  const replacePresets = useCallback((next: FilterPreset[]) => {
+    setPresets(next);
+    writePresets(next);
+  }, []);
+
+  const savePreset = useCallback(
+    (name: string) => {
+      const normalizedName = cleanName(name);
+      if (!normalizedName) return;
+      replacePresets([
+        ...presets,
+        { id: createPresetId(), name: normalizedName, state: cloneState(currentState) },
+      ]);
+    },
+    [currentState, presets, replacePresets],
+  );
+
+  const applyPreset = useCallback(
+    (id: string) => {
+      const preset = presets.find((item) => item.id === id);
+      if (!preset) return;
+      setSelectedPresetId(id);
+      onApplyPreset(cloneState(preset.state));
+    },
+    [onApplyPreset, presets],
+  );
+
+  const updatePreset = useCallback(
+    (id: string, state: FilterPresetState = currentState) => {
+      replacePresets(
+        presets.map((preset) =>
+          preset.id === id ? { ...preset, state: cloneState(state) } : preset,
+        ),
+      );
+    },
+    [currentState, presets, replacePresets],
+  );
+
+  const renamePreset = useCallback(
+    (id: string, name: string) => {
+      const normalizedName = cleanName(name);
+      if (!normalizedName) return;
+      replacePresets(
+        presets.map((preset) => (preset.id === id ? { ...preset, name: normalizedName } : preset)),
+      );
+    },
+    [presets, replacePresets],
+  );
+
+  const deletePreset = useCallback(
+    (id: string) => {
+      replacePresets(presets.filter((preset) => preset.id !== id));
+      setSelectedPresetId((prev) => (prev === id ? null : prev));
+    },
+    [presets, replacePresets],
+  );
+
+  const clearSelectedPreset = useCallback(() => {
+    setSelectedPresetId(null);
+  }, []);
+
+  return {
+    presets,
+    selectedPresetId,
+    savePreset,
+    applyPreset,
+    updatePreset,
+    renamePreset,
+    deletePreset,
+    clearSelectedPreset,
+  };
+}

--- a/packages/ui/src/hooks/useTaskFilter.ts
+++ b/packages/ui/src/hooks/useTaskFilter.ts
@@ -143,8 +143,10 @@ export function useTaskFilter(tasks: Task[]) {
 
   return {
     hideClosed,
+    setHideClosed,
     toggleHideClosed,
     dependencyHighlightEnabled,
+    setDependencyHighlightEnabled,
     toggleDependencyHighlight,
     selectedAssignee,
     setSelectedAssignee,

--- a/packages/ui/src/hooks/useTypeFilter.ts
+++ b/packages/ui/src/hooks/useTypeFilter.ts
@@ -24,7 +24,15 @@ export function useTypeFilter(taskTypes: Record<string, TaskType>) {
     });
   }, []);
 
+  const setEnabledTypes = useCallback(
+    (typeNames: string[]) => {
+      const validTypes = new Set(allTypes);
+      setEnabled(new Set(typeNames.filter((typeName) => validTypes.has(typeName))));
+    },
+    [allTypes],
+  );
+
   const enableAll = useCallback(() => setEnabled(new Set(allTypes)), [allTypes]);
 
-  return { enabled, toggle, enableAll };
+  return { enabled, toggle, setEnabledTypes, enableAll };
 }


### PR DESCRIPTION
## Summary
- 現在のフィルタ状態を localStorage に名前付きプリセットとして保存・復元する useFilterPresets を追加
- Toolbar にプリセット選択、保存、更新、名前変更、削除、Clear All Filters の操作 UI を追加
- FR-VIS-020 と UI テストを追加し、壊れた localStorage 値のフォールバックも検証

## Verification
- pnpm lint
- pnpm test:json
- pnpm build
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen
- built UI smoke: localhost:3000 で Smoke preset 保存、localStorage 反映、各操作ボタン描画を確認

Closes #51