### PR TITLE
feat(ui): 選択中タスクの deep link を追加 (#235)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -777,6 +777,24 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/filter-presets.test.tsx
+      - id: FR-VIS-021
+        summary: 選択中タスクの URL deep link
+        acceptance_criteria:
+          - id: FR-VIS-021-AC1
+            description: task query を初期選択として復元できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/task-deeplink.test.tsx
+          - id: FR-VIS-021-AC2
+            description: タスク選択を task query に反映し、既存の filter query を維持できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/task-deeplink.test.tsx
+          - id: FR-VIS-021-AC3
+            description: 選択解除または存在しない task query では task query を削除できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/task-deeplink.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -21,6 +21,7 @@ import { ThemeProvider } from "./contexts/ThemeContext.js";
 import { useCustomNonWorkingDays } from "./hooks/useCustomNonWorkingDays.js";
 import { useHolidayPreset } from "./hooks/useHolidayPreset.js";
 import { useFilterPresets, type FilterPresetState } from "./hooks/useFilterPresets.js";
+import { useTaskDeepLink } from "./hooks/useTaskDeepLink.js";
 import { downloadGanttExport } from "./lib/export-download.js";
 import type { ExportRequest } from "./components/toolbar/ExportMenu.js";
 
@@ -71,7 +72,7 @@ function buildTaskHistoryPatches(
 
 export function App() {
   const { config, tasks, cache, loading, error, updateTask, refresh, reparentTask } = useApi();
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const { selectedTaskId, setSelectedTaskId } = useTaskDeepLink(tasks, { enabled: !loading });
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
   const [detailPanelWidth, setDetailPanelWidth] = useState(400);
   const [viewScale, setViewScale] = useState<ViewScale>("month");

--- a/packages/ui/src/__tests__/task-deeplink.test.tsx
+++ b/packages/ui/src/__tests__/task-deeplink.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SELECTED_TASK_QUERY_KEY, useTaskDeepLink } from "../hooks/useTaskDeepLink.js";
+import type { Task } from "../types/index.js";
+
+const taskId = "stanah/gh-gantt#235";
+
+function makeTask(id = taskId): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: 235,
+    github_repo: "stanah/gh-gantt",
+    parent: null,
+    sub_tasks: [],
+    title: "Deep link task",
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-05-04T00:00:00Z",
+    updated_at: "2026-05-04T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: "2026-05-04",
+    end_date: null,
+    date: null,
+    blocked_by: [],
+  };
+}
+
+function DeepLinkProbe({ tasks = [makeTask()] }: { tasks?: Task[] }) {
+  const { selectedTaskId, setSelectedTaskId } = useTaskDeepLink(tasks);
+  return (
+    <div>
+      <output aria-label="selected task">{selectedTaskId ?? ""}</output>
+      <button type="button" onClick={() => setSelectedTaskId(taskId)}>
+        select
+      </button>
+      <button type="button" onClick={() => setSelectedTaskId(null)}>
+        clear
+      </button>
+    </div>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("[FR-VIS-021] 選択中タスクの URL deep link", () => {
+  it("[FR-VIS-021-AC1] task query を初期選択として復元する", () => {
+    window.history.replaceState({}, "", `/?task=${encodeURIComponent(taskId)}`);
+
+    const { getByLabelText } = render(<DeepLinkProbe />);
+
+    expect(getByLabelText("selected task").textContent).toBe(taskId);
+  });
+
+  it("[FR-VIS-021-AC2] タスク選択を task query に反映し既存 query を維持する", () => {
+    window.history.replaceState({}, "", "/?labels=pkg%3Aui");
+    const { getByText } = render(<DeepLinkProbe />);
+
+    fireEvent.click(getByText("select"));
+
+    const params = new URL(window.location.href).searchParams;
+    expect(params.get(SELECTED_TASK_QUERY_KEY)).toBe(taskId);
+    expect(params.get("labels")).toBe("pkg:ui");
+  });
+
+  it("[FR-VIS-021-AC3] 選択解除または存在しない task query では task query を削除する", async () => {
+    window.history.replaceState({}, "", `/?labels=pkg%3Aui&task=${encodeURIComponent("missing")}`);
+    const { getByLabelText, getByText } = render(<DeepLinkProbe />);
+
+    await waitFor(() => {
+      expect(getByLabelText("selected task").textContent).toBe("");
+    });
+    expect(new URL(window.location.href).searchParams.has(SELECTED_TASK_QUERY_KEY)).toBe(false);
+
+    fireEvent.click(getByText("select"));
+    expect(new URL(window.location.href).searchParams.get(SELECTED_TASK_QUERY_KEY)).toBe(taskId);
+
+    fireEvent.click(getByText("clear"));
+    expect(new URL(window.location.href).searchParams.has(SELECTED_TASK_QUERY_KEY)).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useTaskDeepLink.ts
+++ b/packages/ui/src/hooks/useTaskDeepLink.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import type { Task } from "../types/index.js";
+
+export const SELECTED_TASK_QUERY_KEY = "task";
+
+function readSelectedTaskIdFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URL(window.location.href).searchParams.get(SELECTED_TASK_QUERY_KEY);
+}
+
+function writeSelectedTaskIdToUrl(taskId: string | null): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (taskId) {
+    url.searchParams.set(SELECTED_TASK_QUERY_KEY, taskId);
+  } else {
+    url.searchParams.delete(SELECTED_TASK_QUERY_KEY);
+  }
+  window.history.replaceState({}, "", url.toString());
+}
+
+export function useTaskDeepLink(tasks: Task[], options: { enabled?: boolean } = {}) {
+  const enabled = options.enabled ?? true;
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(readSelectedTaskIdFromUrl);
+
+  useEffect(() => {
+    if (!enabled || !selectedTaskId) return;
+    if (tasks.some((task) => task.id === selectedTaskId)) return;
+    setSelectedTaskId(null);
+  }, [enabled, selectedTaskId, tasks]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    writeSelectedTaskIdToUrl(selectedTaskId);
+  }, [enabled, selectedTaskId]);
+
+  return { selectedTaskId, setSelectedTaskId } as const;
+}


### PR DESCRIPTION
## Summary
- 選択中タスクを URL の task query に同期する useTaskDeepLink を追加
- task query 付き URL の初期復元、選択解除、存在しない task query の削除を実装
- FR-VIS-021 と UI テストを追加し、既存 filter query を壊さないことを検証

## Verification
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/task-deeplink.test.tsx
- pnpm exec vp check packages/ui/src/hooks/useTaskDeepLink.ts packages/ui/src/__tests__/task-deeplink.test.tsx docs/requirements.yaml
- pnpm --filter @gh-gantt/ui test:json
- pnpm test:json
- pnpm build
- pnpm lint
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen
- built UI smoke: http://127.0.0.1:3000/?labels=pkg%3Aui&task=stanah%2Fgh-gantt%23235 で詳細パネル復元、invalid task query 削除、labels query 維持を headless Chromium で確認

Closes #235