### PR TITLE
fix(ui): 詳細パネル操作ボタンのラベルを整備 (#237)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -795,6 +795,14 @@ areas:
             status: covered
             tests:
               - packages/ui/src/__tests__/task-deeplink.test.tsx
+      - id: FR-VIS-022
+        summary: 詳細パネル操作ボタンのアクセシブルラベル
+        acceptance_criteria:
+          - id: FR-VIS-022-AC1
+            description: 詳細パネルの copy / close 操作ボタンに aria-label と title を付与する
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -799,7 +799,7 @@ areas:
         summary: 詳細パネル操作ボタンのアクセシブルラベル
         acceptance_criteria:
           - id: FR-VIS-022-AC1
-            description: 詳細パネルの copy / close 操作ボタンに aria-label と title を付与する
+            description: 詳細パネルの copy / close 操作ボタンに aria-label と title を付与し、copy 結果をライブリージョンで通知する
             status: covered
             tests:
               - packages/ui/src/__tests__/detail-panel.test.tsx

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -138,7 +138,7 @@ describe("TaskDetailPanel", () => {
 
   it("[FR-VIS-022-AC1] 詳細パネルの操作ボタンにアクセシブルラベルを付与する", () => {
     const task = makeTask();
-    const { getByLabelText } = render(
+    const { getByRole } = render(
       <TaskDetailPanel
         task={task}
         config={config}
@@ -150,10 +150,63 @@ describe("TaskDetailPanel", () => {
       />,
     );
 
-    expect(getByLabelText("Copy task info as JSON").getAttribute("title")).toBe(
-      "Copy task info as JSON",
+    const copyButton = getByRole("button", { name: "Copy task info as JSON" });
+    expect(copyButton.getAttribute("aria-label")).toBe("Copy task info as JSON");
+    expect(copyButton.getAttribute("title")).toBe("Copy task info as JSON");
+
+    const closeButton = getByRole("button", { name: "Close task details" });
+    expect(closeButton.getAttribute("aria-label")).toBe("Close task details");
+    expect(closeButton.getAttribute("title")).toBe("Close task details");
+  });
+
+  it("[FR-VIS-022-AC1] コピー成功をライブリージョンで通知する", async () => {
+    const task = makeTask();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const { findByRole, getByRole } = render(
+      <TaskDetailPanel
+        task={task}
+        config={config}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
     );
-    expect(getByLabelText("Close task details").getAttribute("title")).toBe("Close task details");
+
+    fireEvent.click(getByRole("button", { name: "Copy task info as JSON" }));
+
+    expect((await findByRole("status")).textContent).toBe("Task info copied");
+  });
+
+  it("[FR-VIS-022-AC1] コピー失敗をライブリージョンで通知する", async () => {
+    const task = makeTask();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error("clipboard unavailable")),
+      },
+    });
+    const { findByRole, getByRole } = render(
+      <TaskDetailPanel
+        task={task}
+        config={config}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Copy task info as JSON" }));
+
+    expect((await findByRole("status")).textContent).toBe("Could not copy task info");
   });
 
   it("renders sub-tasks with titles", () => {

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -136,6 +136,26 @@ describe("TaskDetailPanel", () => {
     expect(html).toContain("Important description text");
   });
 
+  it("[FR-VIS-022-AC1] 詳細パネルの操作ボタンにアクセシブルラベルを付与する", () => {
+    const task = makeTask();
+    const { getByLabelText } = render(
+      <TaskDetailPanel
+        task={task}
+        config={config}
+        comments={[]}
+        allTasks={[task]}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        onSelectTask={() => {}}
+      />,
+    );
+
+    expect(getByLabelText("Copy task info as JSON").getAttribute("title")).toBe(
+      "Copy task info as JSON",
+    );
+    expect(getByLabelText("Close task details").getAttribute("title")).toBe("Close task details");
+  });
+
   it("renders sub-tasks with titles", () => {
     const childTask = makeTask({ id: "TASK-2", title: "Child Task Title", parent: "TASK-1" });
     const parentTask = makeTask({ sub_tasks: ["TASK-2"] });

--- a/packages/ui/src/components/TaskDetailPanel.tsx
+++ b/packages/ui/src/components/TaskDetailPanel.tsx
@@ -46,6 +46,12 @@ export function TaskDetailPanel({
   const isTwoColumn = width >= TWO_COLUMN_THRESHOLD;
   const renderPreview =
     renderMarkdownPreview ?? ((value: string) => <MarkdownRenderer markdown={value} />);
+  const copyStatusMessage =
+    copyFeedback === "success"
+      ? "Task info copied"
+      : copyFeedback === "error"
+        ? "Could not copy task info"
+        : null;
 
   const parentTask = task.parent
     ? (() => {
@@ -245,6 +251,26 @@ export function TaskDetailPanel({
               </svg>
             )}
           </button>
+          {copyStatusMessage && (
+            <span
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              style={{
+                position: "absolute",
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: -1,
+                overflow: "hidden",
+                clip: "rect(0 0 0 0)",
+                whiteSpace: "nowrap",
+                border: 0,
+              }}
+            >
+              {copyStatusMessage}
+            </span>
+          )}
           <button
             type="button"
             onClick={onClose}

--- a/packages/ui/src/components/TaskDetailPanel.tsx
+++ b/packages/ui/src/components/TaskDetailPanel.tsx
@@ -182,7 +182,9 @@ export function TaskDetailPanel({
         </span>
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
           <button
+            type="button"
             onClick={copyTaskInfo}
+            aria-label="Copy task info as JSON"
             title="Copy task info as JSON"
             style={{
               border: "none",
@@ -244,7 +246,10 @@ export function TaskDetailPanel({
             )}
           </button>
           <button
+            type="button"
             onClick={onClose}
+            aria-label="Close task details"
+            title="Close task details"
             style={{
               border: "none",
               background: "none",


### PR DESCRIPTION
## Summary
- 詳細パネルの Copy / Close 操作ボタンへ type, aria-label, title を明示
- 操作ボタンのアクセシブルラベルを UI test で検証
- FR-VIS-022 を requirements に追加し trace を接続

## Verification
- pnpm --filter @gh-gantt/ui exec vp test run src/__tests__/detail-panel.test.tsx
- pnpm exec vp check packages/ui/src/components/TaskDetailPanel.tsx packages/ui/src/__tests__/detail-panel.test.tsx docs/requirements.yaml
- pnpm --filter @gh-gantt/ui test:json
- pnpm test:json
- pnpm build
- pnpm lint
- pnpm req:trace
- pnpm req:validate
- pnpm docs:gen
- built UI smoke: http://127.0.0.1:3000/?task=stanah%2Fgh-gantt%23237 で Copy / Close ボタンを aria-label から取得できることを headless Chromium で確認

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 詳細パネルのコピーおよびクローズボタンにアクセシビリティラベルを追加しました。これにより、スクリーンリーダーユーザーがボタン機能をより正確に認識できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->