### PR TITLE
feat(shared): Group by 軸のラベル prefix を自動検出する (#269)

### DIFF
--- a/docs/adr/ADR-015-project-map-faceted-grouping.md
+++ b/docs/adr/ADR-015-project-map-faceted-grouping.md
@@ -27,7 +27,7 @@ Project Map の分類を **「Group by 軸セレクタ（1 度に 1 軸 + 切替
 
 1. **軸セレクタ**: 利用者は 1 度に 1 つの軸を選んで切り替える（GitHub Projects と同じモデル）。組み込み軸＝`hierarchy / type / status / priority / assignee / milestone`。
 2. **親子ツリーは「分解構造」という 1 つの軸**として温存（既定 = `hierarchy`）。
-3. **名前空間ラベルを facet 軸**にする。1 タスクに `feature:project-map` と `system:ui` の両方を付与し、見る軸を切り替える（同一データ・軸切替）。`config.grouping.facets` で `{ key, label, label_prefix }` を定義し、各 facet が `label:<key>` 軸になる。
+3. **名前空間ラベルを facet 軸**にする。1 タスクに `feature:project-map` と `system:ui` の両方を付与し、見る軸を切り替える（同一データ・軸切替）。facet は **ラベルから自動検出**する（`namespace:value` 規約、既定区切り `:`）ため設定は不要。`config.grouping.facets` で `{ key, label, label_prefix }` を任意に定義すると、日本語ラベルや並び順をカスタムでき、同じ key は設定が自動検出より優先される。`label:<key>` 軸の prefix は、設定が無ければ `<key>:` にフォールバックする。
 4. **多対多の許容**: ラベル facet / 担当者は重複所属を許す（faceted）。単一値軸（type/milestone/status/priority）は 1 グループ。軸の値を持たないタスクは末尾の「(なし)」グループへ。
 5. **Board はスイムレーン**: hierarchy 以外の軸を選ぶと、Project Board は「グループ（行）× 実行状態（列）」のマトリクスで表示する（Jira 型）。
 6. **後方互換**: 既存の `grouping.label_prefix`（Gantt のラベルグルーピング）は維持する。`label_prefix` は optional 化し、`facets` を追加した。

--- a/docs/adr/ADR-015-project-map-faceted-grouping.md
+++ b/docs/adr/ADR-015-project-map-faceted-grouping.md
@@ -32,7 +32,7 @@ Project Map の分類を **「Group by 軸セレクタ（1 度に 1 軸 + 切替
 5. **Board はスイムレーン**: hierarchy 以外の軸を選ぶと、Project Board は「グループ（行）× 実行状態（列）」のマトリクスで表示する（Jira 型）。
 6. **後方互換**: 既存の `grouping.label_prefix`（Gantt のラベルグルーピング）は維持する。`label_prefix` は optional 化し、`facets` を追加した。
 
-分類ロジックは shared の `groupTasks(tasks, dimension, config)` / `getGroupDimensions(config)` に集約し、UI に分散させない。
+分類ロジックは shared の `groupTasks(tasks, dimension, config)` / `getGroupDimensions(config, tasks)` / `detectLabelFacets(tasks)` に集約し、UI に分散させない。
 
 ## ラベル名前空間規約
 

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -112,12 +112,14 @@ score =
 分類は単一の親子ツリーに固定せず、**Group by 軸セレクタ（1 度に 1 軸 + 切替）**で切り替える。設計判断は ADR-015 参照。
 
 - 組み込み軸: `階層 (hierarchy) / タイプ / ステータス / 優先度 / 担当者 / マイルストーン`
-- **名前空間ラベル facet 軸**: `config.grouping.facets` で定義した `label:<key>` 軸。機能 vs システムを両立する。
+- **名前空間ラベル facet 軸**: `label:<key>` 軸。機能 vs システムを両立する。
+  - **自動検出（設定不要）**: タスクのラベルから `namespace:value` 規約（既定区切り `:`）を走査し、`system` / `feature` / `phase` / `area` 等の namespace を Group by 軸として自動的に並べる（`detectLabelFacets`）。`config.grouping` が空でも軸が出る。
+  - **明示設定（任意）**: `config.grouping.facets` で `{ key, label, label_prefix }` を定義すると日本語ラベルや並び順をカスタムできる。同じ key は設定が自動検出より優先される。
 
 ```jsonc
 "grouping": {
   "label_prefix": "area:",        // 既存（Gantt 用）はそのまま
-  "facets": [
+  "facets": [                     // 任意。未設定でもラベルから自動検出される
     { "key": "system",  "label": "システム", "label_prefix": "system:" },
     { "key": "feature", "label": "機能",     "label_prefix": "feature:" }
   ]

--- a/packages/shared/src/__tests__/grouping.test.ts
+++ b/packages/shared/src/__tests__/grouping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Config, Task } from "../types.js";
-import { groupTasks, getGroupDimensions } from "../project-map.js";
+import { groupTasks, getGroupDimensions, detectLabelFacets } from "../project-map.js";
 
 const baseTask = (overrides: Partial<Task>): Task => ({
   id: "T",
@@ -173,5 +173,47 @@ describe("[FR-VIS-025][FR-VIS-025-AC4] getGroupDimensions", () => {
     const values = getGroupDimensions(noFacet).map((o) => o.value);
     expect(values.some((v) => v.startsWith("label:"))).toBe(false);
     expect(values).toContain("hierarchy");
+  });
+});
+
+describe("[FR-VIS-025] ラベル prefix の自動検出", () => {
+  it("detectLabelFacets が namespace:value ラベルから namespace を検出する", () => {
+    const tasks = [
+      baseTask({ id: "a", labels: ["system:ui", "phase:1"] }),
+      baseTask({ id: "b", labels: ["system:cli", "bug", "area:sync"] }),
+    ];
+    const facets = detectLabelFacets(tasks);
+    const keys = facets.map((f) => f.key);
+    // 区切りを含まない "bug" は対象外
+    expect(keys).toEqual(["area", "phase", "system"]);
+    expect(facets.find((f) => f.key === "system")?.label_prefix).toBe("system:");
+  });
+
+  it("getGroupDimensions は config 未定義の namespace も自動検出して軸に並べる", () => {
+    const noFacetConfig: Config = { ...config, grouping: undefined };
+    const tasks = [baseTask({ id: "a", labels: ["system:ui", "phase:1"] })];
+    const values = getGroupDimensions(noFacetConfig, tasks).map((o) => o.value);
+    expect(values).toContain("label:system");
+    expect(values).toContain("label:phase");
+  });
+
+  it("config 定義の facet は自動検出より優先される（カスタムラベル）", () => {
+    const tasks = [baseTask({ id: "a", labels: ["system:ui"] })];
+    const opts = getGroupDimensions(config, tasks);
+    const systemOpts = opts.filter((o) => o.value === "label:system");
+    // 重複せず 1 つ、ラベルは config の日本語
+    expect(systemOpts).toHaveLength(1);
+    expect(systemOpts[0].label).toBe("システム");
+  });
+
+  it("config に無い軸でも label:<key> で <key>: prefix にフォールバックしてグルーピングできる", () => {
+    const noFacetConfig: Config = { ...config, grouping: undefined };
+    const tasks = [
+      baseTask({ id: "a", labels: ["system:ui"] }),
+      baseTask({ id: "b", labels: ["system:cli"] }),
+    ];
+    const result = groupTasks(tasks, "label:system", noFacetConfig);
+    expect(result.groups.find((g) => g.label === "ui")?.taskIds).toEqual(["a"]);
+    expect(result.groups.find((g) => g.label === "cli")?.taskIds).toEqual(["b"]);
   });
 });

--- a/packages/shared/src/__tests__/grouping.test.ts
+++ b/packages/shared/src/__tests__/grouping.test.ts
@@ -206,6 +206,18 @@ describe("[FR-VIS-025] ラベル prefix の自動検出", () => {
     expect(systemOpts[0].label).toBe("システム");
   });
 
+  it("config facet の label_prefix と同じ prefix の namespace は自動検出で二重に出さない", () => {
+    // key=component だが prefix は system: → system:ui ラベルは config 側で扱う
+    const cfg: Config = {
+      ...config,
+      grouping: { facets: [{ key: "component", label: "部品", label_prefix: "system:" }] },
+    };
+    const tasks = [baseTask({ id: "a", labels: ["system:ui"] })];
+    const values = getGroupDimensions(cfg, tasks).map((o) => o.value);
+    expect(values).toContain("label:component");
+    expect(values).not.toContain("label:system");
+  });
+
   it("config に無い軸でも label:<key> で <key>: prefix にフォールバックしてグルーピングできる", () => {
     const noFacetConfig: Config = { ...config, grouping: undefined };
     const tasks = [

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -1,4 +1,4 @@
-import type { Task, Config, StatusValue, StatusCategory } from "./types.js";
+import type { Task, Config, StatusValue, StatusCategory, GroupingFacet } from "./types.js";
 import {
   calculateCriticalPath,
   detectCycles,
@@ -634,12 +634,46 @@ const PRIORITY_LABEL: Record<string, string> = {
   low: "Low",
 };
 
+/** ラベル facet の既定区切り文字。`namespace:value` の `:`。 */
+export const DEFAULT_FACET_SEPARATOR = ":";
+
 /**
- * 設定から Group by 軸の選択肢を組み立てる。
- * 組み込み軸（階層 / タイプ / ステータス / 優先度 / 担当者 / マイルストーン）に加え、
- * `config.grouping.facets` の各 facet を `label:<key>` 軸として追加する。
+ * タスク群のラベルから `namespace<sep>value` 規約のラベルを走査し、
+ * distinct な namespace を facet 軸候補として返す（設定不要の自動検出）。
+ *
+ * 区切りが先頭・末尾にあるラベル（`:foo` / `foo:`）は namespace とみなさない。
+ *
+ * @param tasks - 走査対象のタスク
+ * @param separator - 区切り文字（既定 `:`）
+ * @returns namespace 昇順の facet 配列（label/key は namespace、prefix は `namespace<sep>`）
  */
-export function getGroupDimensions(config: Config): GroupDimensionOption[] {
+export function detectLabelFacets(
+  tasks: Task[],
+  separator: string = DEFAULT_FACET_SEPARATOR,
+): GroupingFacet[] {
+  const namespaces = new Set<string>();
+  for (const task of tasks) {
+    for (const label of task.labels) {
+      const idx = label.indexOf(separator);
+      if (idx > 0 && idx < label.length - separator.length) {
+        namespaces.add(label.slice(0, idx));
+      }
+    }
+  }
+  return [...namespaces].sort().map((ns) => ({ key: ns, label: ns, label_prefix: ns + separator }));
+}
+
+/**
+ * Group by 軸の選択肢を組み立てる。
+ * 組み込み軸（階層 / タイプ / ステータス / 優先度 / 担当者 / マイルストーン）に加え、
+ * `config.grouping.facets`（明示定義）と、タスクのラベルから {@link detectLabelFacets} で
+ * 自動検出した namespace facet をマージして `label:<key>` 軸として並べる。
+ * 同じ key は config の定義（カスタムラベル）を優先する。
+ *
+ * @param config - gantt 設定
+ * @param tasks - 自動検出に使うタスク（省略時は config の facets のみ）
+ */
+export function getGroupDimensions(config: Config, tasks: Task[] = []): GroupDimensionOption[] {
   const options: GroupDimensionOption[] = [
     { value: "hierarchy", label: "階層" },
     { value: "type", label: "タイプ" },
@@ -648,7 +682,10 @@ export function getGroupDimensions(config: Config): GroupDimensionOption[] {
     { value: "assignee", label: "担当者" },
     { value: "milestone", label: "マイルストーン" },
   ];
-  for (const facet of config.grouping?.facets ?? []) {
+  const configFacets = config.grouping?.facets ?? [];
+  const configKeys = new Set(configFacets.map((f) => f.key));
+  const autoFacets = detectLabelFacets(tasks).filter((f) => !configKeys.has(f.key));
+  for (const facet of [...configFacets, ...autoFacets]) {
     options.push({ value: `label:${facet.key}`, label: facet.label });
   }
   return options;
@@ -683,8 +720,8 @@ function resolveGroupAssignments(
   if (dimension.startsWith("label:")) {
     const facetKey = dimension.slice("label:".length);
     const facet = config.grouping?.facets?.find((f) => f.key === facetKey);
-    if (!facet) return [];
-    const prefix = facet.label_prefix;
+    // config に明示定義が無い軸は、自動検出の規約として `<key><sep>` を prefix とする。
+    const prefix = facet?.label_prefix ?? `${facetKey}${DEFAULT_FACET_SEPARATOR}`;
     return task.labels
       .filter((l) => l.startsWith(prefix))
       .map((l) => {

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -684,7 +684,12 @@ export function getGroupDimensions(config: Config, tasks: Task[] = []): GroupDim
   ];
   const configFacets = config.grouping?.facets ?? [];
   const configKeys = new Set(configFacets.map((f) => f.key));
-  const autoFacets = detectLabelFacets(tasks).filter((f) => !configKeys.has(f.key));
+  // key だけでなく label_prefix も突き合わせ、設定済み prefix を別 namespace として
+  // 二重に自動検出しないようにする（例: key=component, prefix=system: と system:ui）。
+  const configPrefixes = new Set(configFacets.map((f) => f.label_prefix));
+  const autoFacets = detectLabelFacets(tasks).filter(
+    (f) => !configKeys.has(f.key) && !configPrefixes.has(f.label_prefix),
+  );
   for (const facet of [...configFacets, ...autoFacets]) {
     options.push({ value: `label:${facet.key}`, label: facet.label });
   }

--- a/packages/ui/src/components/project-map/ProjectMapPage.tsx
+++ b/packages/ui/src/components/project-map/ProjectMapPage.tsx
@@ -41,14 +41,6 @@ export function ProjectMapPage({
   const [filter, setFilter] = useState<ProjectMapFilterState>({ search: "", readiness: null });
   const [groupDimension, setGroupDimension] = useState<GroupDimension>("hierarchy");
   const { status: syncStatus } = useSyncStatus(syncRefreshKey);
-  const groupDimensions = useMemo(() => getGroupDimensions(config), [config]);
-
-  // config 変更で選択中の軸が候補から消えた場合（facet 削除など）は hierarchy に戻す。
-  useEffect(() => {
-    if (!groupDimensions.some((d) => d.value === groupDimension)) {
-      setGroupDimension("hierarchy");
-    }
-  }, [groupDimensions, groupDimension]);
 
   // ViewModel の hierarchy ノードから全タスクを取り出す。
   const allTasks = useMemo(() => {
@@ -62,6 +54,16 @@ export function ProjectMapPage({
     walk(viewModel.hierarchy);
     return tasks;
   }, [viewModel.hierarchy]);
+
+  // Group by 軸 = 組み込み + config facets + ラベルから自動検出した namespace facets。
+  const groupDimensions = useMemo(() => getGroupDimensions(config, allTasks), [config, allTasks]);
+
+  // 選択中の軸が候補から消えた場合（facet 削除・データ変化など）は hierarchy に戻す。
+  useEffect(() => {
+    if (!groupDimensions.some((d) => d.value === groupDimension)) {
+      setGroupDimension("hierarchy");
+    }
+  }, [groupDimensions, groupDimension]);
 
   const matchedIds = useMemo(() => {
     const ids = new Set<string>();


### PR DESCRIPTION
## Summary

Group by 軸（facet）のラベル prefix を **設定なしで自動検出**できるようにする（#269）。実データのラベルが既に `system:ui` / `feature:gantt` / `phase:1` / `area:sync` の `namespace:value` 規約で付与されているため、`config.grouping.facets` を手動定義しなくても軸が並ぶ。

- `detectLabelFacets(tasks, separator=":")` — ラベルから distinct namespace を facet として検出
- `getGroupDimensions(config, tasks)` — 組み込み軸 + config facets + 自動検出 facets をマージ（同じ key は config 優先）
- `groupTasks` の `label:<key>` 解決で config 未定義時は prefix を `<key>:` にフォールバック
- ProjectMapPage が `getGroupDimensions(config, allTasks)` にタスクを渡す
- `config.grouping.facets` は任意（日本語ラベル・並び順のカスタム用）に格下げ

Closes #269

## Test Plan

- `pnpm test` — shared 128 / ui 218 / cli 467 / smoke 15（自動検出・config 優先・fallback prefix のテストを追加）
- `pnpm build` / `pnpm lint` / `pnpm req:trace`(covered=148・差分なし) / `pnpm req:validate` / `pnpm docs:gen` — 通過
- 手動確認: `config.grouping` を空にしても Group by に system/feature/phase/area が自動で並び、グループ表示・スイムレーンが機能することをブラウザで確認

## 補足

- 設計判断は ADR-015 に追記。`docs/project-map.md` に自動検出の挙動を記載。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * プロジェクトマップのグループ化仕様とADRを更新し、自動検出される label:<key> 軸や挙動（優先順、表示ラベル・並び順の扱い、prefix フォールバック）を明記しました。

* **New Features**
  * タスクラベルの namespace:value 規約を自動検出してファセット軸を生成する機能を追加しました。
  * 明示設定が自動検出より優先される挙動と、label_prefix 未指定時のデフォルト prefix フォールバックを導入しました。

* **Tests**
  * 自動検出・優先度・重複抑制・フォールバック挙動を検証するテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->