### PR TITLE
fix(ui): 未保存 Markdown preview のリンク化を防ぐ

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1188,6 +1188,7 @@ areas:
               href として出力しない
             status: covered
             tests:
+              - packages/ui/src/__tests__/detail-panel.test.tsx
               - packages/ui/src/__tests__/markdown-renderer.test.tsx
           - id: NFR-STABILITY-011-AC2
             description: |

--- a/packages/ui/src/__tests__/detail-panel.test.tsx
+++ b/packages/ui/src/__tests__/detail-panel.test.tsx
@@ -136,6 +136,31 @@ describe("TaskDetailPanel", () => {
     expect(html).toContain("Important description text");
   });
 
+  describe("[NFR-STABILITY-011-AC1] Markdown preview の安全化", () => {
+    it("未保存の Markdown preview はリンクとして再解釈しない", () => {
+      const task = makeTask({ body: "Initial body" });
+      const { getByRole, queryByRole } = render(
+        <TaskDetailPanel
+          task={task}
+          config={config}
+          comments={[]}
+          allTasks={[task]}
+          onUpdate={() => {}}
+          onClose={() => {}}
+          onSelectTask={() => {}}
+        />,
+      );
+
+      fireEvent.click(getByRole("button", { name: "Edit" }));
+      fireEvent.change(getByRole("textbox"), {
+        target: { value: "[draft](https://example.com)" },
+      });
+      fireEvent.click(getByRole("button", { name: "Preview" }));
+
+      expect(queryByRole("link", { name: "draft" })).toBeNull();
+    });
+  });
+
   it("[FR-VIS-022-AC1] 詳細パネルの操作ボタンにアクセシブルラベルを付与する", () => {
     const task = makeTask();
     const { getByRole } = render(

--- a/packages/ui/src/components/MarkdownEditor.tsx
+++ b/packages/ui/src/components/MarkdownEditor.tsx
@@ -20,9 +20,9 @@ export function MarkdownEditor({ value, onChange, renderPreview }: MarkdownEdito
   const previewNode = useMemo(() => {
     if (!draft.trim())
       return <span style={{ color: "var(--color-text-muted)" }}>No description</span>;
-    if (renderPreview) return renderPreview(draft);
+    if (renderPreview && !dirty) return renderPreview(value);
     return <div style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{draft}</div>;
-  }, [draft, renderPreview]);
+  }, [dirty, draft, renderPreview, value]);
 
   const tabButtonStyle = (active: boolean): React.CSSProperties => ({
     padding: "4px 10px",


### PR DESCRIPTION
PR #272 merge 後に残った Code scanning alert #1 (js/xss-through-dom) の follow-up です。未保存の MarkdownEditor draft は MarkdownRenderer に渡さず plain text preview とし、保存済み value のみ Markdown preview へ渡します。検証: pnpm test:json / pnpm typecheck / pnpm lint / pnpm req:trace / pnpm req:validate / pnpm audit --audit-level low / pre-push gate.