### PR TITLE
feat(cli): loop next/complete と時間軸結線・ready 枯渇分類を実装 (#285)

### DIFF
--- a/packages/cli/src/__tests__/loop-next-complete.test.ts
+++ b/packages/cli/src/__tests__/loop-next-complete.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from "vitest";
+import type { Config, LoopState, Task } from "@gh-gantt/shared";
+import { createEmptyLoopState } from "@gh-gantt/shared";
+import {
+  completeIteration,
+  decideNextIteration,
+  formatLoopNext,
+  parseVerifySpecs,
+} from "../commands/loop.js";
+
+const baseTask = (overrides: Partial<Task>): Task => ({
+  id: "T",
+  type: "task",
+  github_issue: null,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "task",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: {},
+  start_date: null,
+  end_date: null,
+  date: null,
+  blocked_by: [],
+  ...overrides,
+});
+
+const config: Config = {
+  version: "1",
+  project: { name: "P", github: { owner: "stanah", repo: "gh-gantt", project_number: 1 } },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: {
+      start_date: "Start",
+      end_date: "End",
+      status: "Status",
+      estimate_hours: "Estimate",
+    },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    epic: { label: "Epic", display: "summary", color: "#111", github_label: null },
+  },
+  type_hierarchy: { epic: ["task"], task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false, category: "todo" },
+      Done: { color: "#2ECC71", done: true, category: "done" },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+  require_review_for_types: [],
+  require_close_evidence: false,
+};
+
+const NOW = "2026-07-04T10:00:00Z";
+
+const readyTasks = () => [
+  baseTask({ id: "plain", title: "通常", custom_fields: { Status: "Todo" } }),
+  baseTask({ id: "unblocker", title: "下流解除", custom_fields: { Status: "Todo" } }),
+  baseTask({
+    id: "down1",
+    blocked_by: [{ task: "unblocker", type: "finish-to-start", lag: 0 }],
+    custom_fields: { Status: "Todo" },
+  }),
+  baseTask({
+    id: "down2",
+    blocked_by: [{ task: "unblocker", type: "finish-to-start", lag: 0 }],
+    custom_fields: { Status: "Todo" },
+  }),
+];
+
+function decide(overrides: {
+  state?: LoopState;
+  tasks?: Task[];
+  hasConflicts?: boolean;
+  decision?: string;
+}) {
+  return decideNextIteration({
+    state: overrides.state ?? createEmptyLoopState(),
+    config,
+    tasks: overrides.tasks ?? readyTasks(),
+    hasConflicts: overrides.hasConflicts ?? false,
+    now: NOW,
+    decision: overrides.decision,
+  });
+}
+
+describe("decideNextIteration による次イテレーションの決定", () => {
+  it("最高スコアの ready タスクを選定し NextAction スナップショットを記録する", () => {
+    const result = decide({});
+    expect(result.kind).toBe("selected");
+    if (result.kind === "selected") {
+      expect(result.iteration.id).toBe(1);
+      expect(result.iteration.selectedTask).toBe("unblocker");
+      expect(result.iteration.selection?.category).toBe("unlocker");
+      expect(result.iteration.decision).toContain("unblocker");
+      expect(result.alternatives.map((a) => a.taskId)).toContain("plain");
+    }
+  });
+
+  it("--decision 指定で decision を上書きできる", () => {
+    const result = decide({ decision: "設計から着手する" });
+    if (result.kind === "selected") {
+      expect(result.iteration.decision).toBe("設計から着手する");
+    } else {
+      expect.fail("selected になるべき");
+    }
+  });
+
+  it("未完了のイテレーションがあると開始を拒否する", () => {
+    const state: LoopState = {
+      version: "1",
+      iterations: [
+        { id: 1, startedAt: "2026-07-04T09:00:00Z", selectedTask: "plain", decision: "着手" },
+      ],
+    };
+    const result = decide({ state });
+    expect(result).toEqual({ kind: "open_iteration", openIterationId: 1 });
+  });
+
+  it("コンフリクト検出中は conflicts_present で停止イテレーションを記録する", () => {
+    const result = decide({ hasConflicts: true });
+    expect(result.kind).toBe("stopped");
+    if (result.kind === "stopped") {
+      expect(result.stopReason).toBe("conflicts_present");
+      expect(result.iteration?.outcome).toBe("stopped");
+    }
+  });
+
+  it("直前と同一理由の停止はジャーナルに追記しない（重複防止）", () => {
+    const state: LoopState = {
+      version: "1",
+      iterations: [
+        {
+          id: 1,
+          startedAt: "2026-07-04T09:00:00Z",
+          selectedTask: null,
+          decision: "停止",
+          outcome: "stopped",
+          stopReason: "conflicts_present",
+        },
+      ],
+    };
+    const result = decide({ state, hasConflicts: true });
+    if (result.kind === "stopped") {
+      expect(result.iteration).toBeNull();
+    } else {
+      expect.fail("stopped になるべき");
+    }
+  });
+
+  it("選定済みイテレーション数が maxIterations に達すると budget_exhausted で停止する", () => {
+    const budgetConfig: Config = { ...config, loop: { maxIterations: 1 } };
+    const state: LoopState = {
+      version: "1",
+      iterations: [
+        {
+          id: 1,
+          startedAt: "2026-07-04T08:00:00Z",
+          completedAt: "2026-07-04T09:00:00Z",
+          selectedTask: "plain",
+          decision: "着手",
+          outcome: "completed",
+        },
+      ],
+    };
+    const result = decideNextIteration({
+      state,
+      config: budgetConfig,
+      tasks: readyTasks(),
+      hasConflicts: false,
+      now: NOW,
+    });
+    expect(result.kind).toBe("stopped");
+    if (result.kind === "stopped") expect(result.stopReason).toBe("budget_exhausted");
+  });
+
+  it("全タスク完了なら all_done で停止する", () => {
+    const result = decide({ tasks: [baseTask({ id: "d", state: "closed" })] });
+    if (result.kind === "stopped") {
+      expect(result.stopReason).toBe("all_done");
+    } else {
+      expect.fail("stopped になるべき");
+    }
+  });
+
+  it("子なし epic のみ残存なら backlog_needs_decomposition で停止し分解候補を示す", () => {
+    const tasks = [baseTask({ id: "e", type: "epic", custom_fields: { Status: "Todo" } })];
+    const result = decide({ tasks });
+    if (result.kind === "stopped") {
+      expect(result.stopReason).toBe("backlog_needs_decomposition");
+      expect(result.exhaustion?.reason).toBe("backlog_needs_decomposition");
+      expect(formatLoopNext(result)).toContain("gh-gantt-decompose");
+    } else {
+      expect.fail("stopped になるべき");
+    }
+  });
+
+  it("停止イテレーションは次回の開始をブロックしない", () => {
+    const state: LoopState = {
+      version: "1",
+      iterations: [
+        {
+          id: 1,
+          startedAt: "2026-07-04T09:00:00Z",
+          selectedTask: null,
+          decision: "停止",
+          outcome: "stopped",
+          stopReason: "all_blocked",
+        },
+      ],
+    };
+    const result = decide({ state });
+    expect(result.kind).toBe("selected");
+    if (result.kind === "selected") expect(result.iteration.id).toBe(2);
+  });
+});
+
+describe("completeIteration による実績記録", () => {
+  const openState = (): LoopState => ({
+    version: "1",
+    iterations: [
+      {
+        id: 1,
+        startedAt: "2026-07-04T08:30:00Z",
+        selectedTask: "plain",
+        decision: "着手",
+      },
+    ],
+  });
+
+  it("開いたイテレーションに completedAt / outcome / verify / review を記録し予実を返す", () => {
+    const state = openState();
+    const tasks = [baseTask({ id: "plain", custom_fields: { Status: "Todo", Estimate: 2 } })];
+    const result = completeIteration({
+      state,
+      config,
+      tasks,
+      now: NOW,
+      outcome: "completed",
+      reviewOutcome: "approve",
+      verify: parseVerifySpecs(["pnpm test=fail", "pnpm test=pass"]),
+    });
+    expect(result.kind).toBe("completed");
+    if (result.kind === "completed") {
+      expect(result.durationHours).toBe(1.5);
+      expect(result.estimateHours).toBe(2);
+    }
+    const it1 = state.iterations[0];
+    expect(it1.completedAt).toBe(NOW);
+    expect(it1.outcome).toBe("completed");
+    expect(it1.reviewOutcome).toBe("approve");
+    expect(it1.verifyResults).toEqual([
+      { command: "pnpm test", passed: false, attempt: 1 },
+      { command: "pnpm test", passed: true, attempt: 2 },
+    ]);
+  });
+
+  it("開いたイテレーションがなければ no_open_iteration", () => {
+    const state = createEmptyLoopState();
+    const result = completeIteration({
+      state,
+      config,
+      tasks: [],
+      now: NOW,
+      outcome: "completed",
+    });
+    expect(result).toEqual({ kind: "no_open_iteration" });
+  });
+});
+
+describe("parseVerifySpecs による --verify のパース", () => {
+  it("command=pass|fail をパースし同一コマンドの attempt を採番する", () => {
+    expect(parseVerifySpecs(["pnpm lint=pass", "pnpm test=fail", "pnpm test=pass"])).toEqual([
+      { command: "pnpm lint", passed: true, attempt: 1 },
+      { command: "pnpm test", passed: false, attempt: 1 },
+      { command: "pnpm test", passed: true, attempt: 2 },
+    ]);
+  });
+
+  it("形式が不正ならエラーになる", () => {
+    expect(() => parseVerifySpecs(["pnpm test"])).toThrow(/形式が不正/);
+    expect(() => parseVerifySpecs(["pnpm test=ok"])).toThrow(/形式が不正/);
+  });
+});

--- a/packages/cli/src/__tests__/loop-status.test.ts
+++ b/packages/cli/src/__tests__/loop-status.test.ts
@@ -182,6 +182,59 @@ describe("buildLoopStatusReport によるループ現在地の導出", () => {
   });
 });
 
+describe("スリップ検出と予実の表示 (ADR-017)", () => {
+  const today = "2026-07-04";
+
+  it("期日超過タスクが slips に載り、テキストに警告が出る", () => {
+    const tasks = [
+      baseTask({
+        id: "late",
+        title: "遅延中",
+        end_date: "2026-07-01",
+        custom_fields: { Status: "Todo" },
+      }),
+    ];
+    const report = buildLoopStatusReport(null, config, tasks, false, today);
+    expect(report.slips).toEqual([{ taskId: "late", title: "遅延中", kind: "overdue", days: 3 }]);
+    const text = formatLoopStatus(report);
+    expect(text).toContain("Schedule slips");
+    expect(text).toContain("期日超過 3日");
+    expect(text).toContain("gh-gantt update");
+  });
+
+  it("直近の完了イテレーションの所要と見積が表示される", () => {
+    const tasks = [baseTask({ id: "stanah/gh-gantt#279", custom_fields: { Status: "Todo" } })];
+    const report = buildLoopStatusReport(sampleState, config, tasks, false, today);
+    expect(report.lastActual).toEqual({
+      iterationId: 1,
+      taskId: "stanah/gh-gantt#279",
+      durationHours: 1,
+      estimateHours: null,
+    });
+    expect(formatLoopStatus(report)).toContain("所要 1h / 見積 未設定");
+  });
+
+  it("全ブロック時は exhaustion にブロッカー一覧が載る", () => {
+    const tasks = [
+      baseTask({ id: "dep", custom_fields: { Status: "Todo" } }),
+      baseTask({
+        id: "b",
+        blocked_by: [{ task: "外部", type: "finish-to-start", lag: 0 }],
+        custom_fields: { Status: "Todo" },
+      }),
+    ];
+    // dep 自体は ready なので枯渇にはならない
+    expect(buildLoopStatusReport(null, config, tasks, false, today).exhaustion).toBeNull();
+
+    const allBlocked = [tasks[1]];
+    const report = buildLoopStatusReport(null, config, allBlocked, false, today);
+    expect(report.exhaustion?.reason).toBe("all_blocked");
+    const text = formatLoopStatus(report);
+    expect(text).toContain("all_blocked");
+    expect(text).toContain("blocked by: 外部");
+  });
+});
+
 describe("コンフリクト検出時の HARD-GATE", () => {
   it("has_conflicts が真なら readyCandidates を提示しない", () => {
     const tasks = [baseTask({ id: "r", title: "着手可能", custom_fields: { Status: "Todo" } })];

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -69,6 +69,17 @@ function toCandidate(action: {
   };
 }
 
+/**
+ * ローカルタイムゾーンの今日 (YYYY-MM-DD)。
+ * UI の遅延判定（date-utils）とタイムゾーン基準を揃える。
+ */
+function localToday(): string {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
 /** イテレーション所要時間（時間単位・小数 1 桁）。日時が不正なら null。 */
 function durationHours(startedAt: string, completedAt: string): number | null {
   const start = Date.parse(startedAt);
@@ -115,7 +126,7 @@ export function buildLoopStatusReport(
   config: Config,
   tasks: Task[],
   hasConflicts = false,
-  today: string = new Date().toISOString().slice(0, 10),
+  today: string = localToday(),
 ): LoopStatusReport {
   const { vm, readyOnly, readyActions } = selectReadyCandidates(config, tasks);
 

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -392,7 +392,7 @@ export function parseVerifySpecs(specs: string[]): LoopVerifyResult[] {
   return specs.map((spec) => {
     const match = spec.match(/^(.+)=(pass|fail)$/);
     if (!match) {
-      throw new Error(`--verify の形式が不正です: "${spec}" ("<command>=pass|fail" で指定)`);
+      throw new UsageError(`--verify の形式が不正です: "${spec}" ("<command>=pass|fail" で指定)`);
     }
     const command = match[1];
     const attempt = (attempts.get(command) ?? 0) + 1;
@@ -457,12 +457,17 @@ export function formatLoopComplete(result: LoopCompleteResult): string {
 // commander 配線
 // ---------------------------------------------------------------------------
 
+/** ユーザー入力の誤りを示すエラー。データ破損の示唆を出さずに使い方を案内する。 */
+class UsageError extends Error {}
+
 function reportCommandError(context: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   console.error(`${context} の実行に失敗しました: ${message}`);
-  console.error(
-    "  .gantt-sync/ の設定・同期データ、または loop-state.json が破損している可能性があります。",
-  );
+  if (!(err instanceof UsageError)) {
+    console.error(
+      "  .gantt-sync/ の設定・同期データ、または loop-state.json が破損している可能性があります。",
+    );
+  }
   process.exitCode = 1;
 }
 
@@ -550,26 +555,24 @@ export const loopCommand = new Command("loop")
         async (opts: { json?: boolean; outcome: string; review?: string; verify: string[] }) => {
           try {
             if (!(COMPLETE_OUTCOMES as readonly string[]).includes(opts.outcome)) {
-              throw new Error(
+              throw new UsageError(
                 `--outcome は ${COMPLETE_OUTCOMES.join(" | ")} のいずれかで指定してください`,
               );
             }
             const { config, tasksFile, loopStore, state } = await loadStores(process.cwd());
-            if (!state) {
-              console.log(formatLoopComplete({ kind: "no_open_iteration" }));
-              process.exitCode = 1;
-              return;
-            }
-            const result = completeIteration({
-              state,
-              config,
-              tasks: tasksFile.tasks,
-              now: new Date().toISOString(),
-              outcome: opts.outcome as LoopIterationOutcome,
-              reviewOutcome: opts.review,
-              verify: parseVerifySpecs(opts.verify),
-            });
-            if (result.kind === "completed") {
+            // state 未初期化でも --json の出力形式は state ありの場合と揃える
+            const result: LoopCompleteResult = state
+              ? completeIteration({
+                  state,
+                  config,
+                  tasks: tasksFile.tasks,
+                  now: new Date().toISOString(),
+                  outcome: opts.outcome as LoopIterationOutcome,
+                  reviewOutcome: opts.review,
+                  verify: parseVerifySpecs(opts.verify),
+                })
+              : { kind: "no_open_iteration" };
+            if (result.kind === "completed" && state) {
               await loopStore.write(state);
             } else {
               process.exitCode = 1;

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -1,11 +1,25 @@
 import { Command } from "commander";
-import { buildNextActions, buildProjectMapViewModel, resolveLoopConfig } from "@gh-gantt/shared";
+import {
+  buildNextActions,
+  buildProjectMapViewModel,
+  classifyReadyExhaustion,
+  createEmptyLoopState,
+  detectScheduleSlips,
+  getEstimateHours,
+  isWorkableTask,
+  resolveLoopConfig,
+} from "@gh-gantt/shared";
 import type {
   Config,
   LoopIteration,
+  LoopIterationOutcome,
   LoopState,
+  LoopStopReason,
+  LoopVerifyResult,
   NextActionCategory,
+  ReadyExhaustion,
   ResolvedLoopConfig,
+  ScheduleSlip,
   Task,
 } from "@gh-gantt/shared";
 import { ConfigStore } from "../store/config.js";
@@ -23,17 +37,72 @@ export interface LoopReadyCandidate {
   reason: string;
 }
 
+/** decide の候補集合（ADR-017: 作業粒度 かつ ready に限定 + Next Actions スコア再利用）。 */
+function selectReadyCandidates(config: Config, tasks: Task[]) {
+  const vm = buildProjectMapViewModel(tasks, config);
+  // ADR-017: decide が再利用するのはスコアリング関数であって候補集合ではない。
+  // 作業粒度（isWorkableTask: コンテナと分解可能 type を除外）かつ ready に
+  // 限定した readiness マップを渡すことで、blocked や epic の高スコア候補を排除する。
+  const taskById = new Map(tasks.map((t) => [t.id, t]));
+  const readyOnly = Object.fromEntries(
+    Object.entries(vm.readinessById).filter(([id, r]) => {
+      const task = taskById.get(id);
+      return r.isReady && task !== undefined && isWorkableTask(task, config);
+    }),
+  );
+  const readyActions = buildNextActions(tasks, config, readyOnly, READY_CANDIDATE_LIMIT);
+  return { vm, readyOnly, readyActions };
+}
+
+function toCandidate(action: {
+  task: Task;
+  score: number;
+  category: NextActionCategory;
+  reason: string;
+}): LoopReadyCandidate {
+  return {
+    taskId: action.task.id,
+    title: action.task.title,
+    score: action.score,
+    category: action.category,
+    reason: action.reason,
+  };
+}
+
+/** イテレーション所要時間（時間単位・小数 1 桁）。日時が不正なら null。 */
+function durationHours(startedAt: string, completedAt: string): number | null {
+  const start = Date.parse(startedAt);
+  const end = Date.parse(completedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.round(((end - start) / 3_600_000) * 10) / 10;
+}
+
+// ---------------------------------------------------------------------------
+// loop status
+// ---------------------------------------------------------------------------
+
 export interface LoopStatusReport {
   /** loop-state.json が存在するか。 */
   initialized: boolean;
   iterationCount: number;
   lastIteration: LoopIteration | null;
+  /** 直近の完了イテレーションの予実（ADR-017）。 */
+  lastActual: {
+    iterationId: number;
+    taskId: string | null;
+    durationHours: number | null;
+    estimateHours: number | null;
+  } | null;
   stop: ResolvedLoopConfig;
   /** tasks.json に未解決コンフリクトがあるか（conflicts_present 相当）。 */
   hasConflicts: boolean;
+  /** スリップ検出結果（期日超過 / at-risk / 完了遅延）。 */
+  slips: ScheduleSlip[];
+  /** ready 枯渇の分類（ready 候補がある場合は null）。 */
+  exhaustion: ReadyExhaustion | null;
   readyCount: number;
   /**
-   * 次の着手候補。ADR-017 に従い、候補集合を ready に限定した上で
+   * 次の着手候補。ADR-017 に従い、候補集合を作業粒度かつ ready に限定した上で
    * Next Actions のスコアリングを適用した順で並ぶ。
    * コンフリクト検出中は HARD-GATE（解決まで他作業禁止）に従い空になる。
    */
@@ -46,39 +115,41 @@ export function buildLoopStatusReport(
   config: Config,
   tasks: Task[],
   hasConflicts = false,
+  today: string = new Date().toISOString().slice(0, 10),
 ): LoopStatusReport {
-  const vm = buildProjectMapViewModel(tasks, config);
-
-  // ADR-017: decide は候補集合を ready に限定してからスコアリング関数を再利用する。
-  // readiness マップを ready のみに絞って渡すことで blocked の高スコア候補を排除する。
-  // 子タスクを持つ親（コンテナ）は直接の着手対象ではないため、
-  // buildNextActions と同じ基準（leaf のみ）で件数・候補を揃える。
-  const taskById = new Map(tasks.map((t) => [t.id, t]));
-  const readyOnly = Object.fromEntries(
-    Object.entries(vm.readinessById).filter(
-      ([id, r]) => r.isReady && (taskById.get(id)?.sub_tasks.length ?? 0) === 0,
-    ),
-  );
-  const readyActions = buildNextActions(tasks, config, readyOnly, READY_CANDIDATE_LIMIT);
+  const { vm, readyOnly, readyActions } = selectReadyCandidates(config, tasks);
 
   const iterations = state?.iterations ?? [];
+  const lastCompleted = [...iterations]
+    .reverse()
+    .find((it) => it.completedAt !== undefined && it.selectedTask !== null);
+  const taskById = new Map(tasks.map((t) => [t.id, t]));
+  const lastActual = lastCompleted
+    ? {
+        iterationId: lastCompleted.id,
+        taskId: lastCompleted.selectedTask,
+        durationHours: durationHours(lastCompleted.startedAt, lastCompleted.completedAt!),
+        estimateHours: lastCompleted.selectedTask
+          ? (() => {
+              const task = taskById.get(lastCompleted.selectedTask);
+              return task ? getEstimateHours(task, config) : null;
+            })()
+          : null,
+      }
+    : null;
+
   return {
     initialized: state !== null,
     iterationCount: iterations.length,
     lastIteration: iterations.length > 0 ? iterations[iterations.length - 1] : null,
+    lastActual,
     stop: resolveLoopConfig(config.loop),
     hasConflicts,
+    slips: detectScheduleSlips(tasks, config, today),
+    exhaustion: classifyReadyExhaustion(tasks, config, vm.readinessById),
     readyCount: Object.keys(readyOnly).length,
     // コンフリクト解決が最優先（HARD-GATE）。解決まで次の着手候補は提示しない。
-    readyCandidates: hasConflicts
-      ? []
-      : readyActions.map((a) => ({
-          taskId: a.task.id,
-          title: a.task.title,
-          score: a.score,
-          category: a.category,
-          reason: a.reason,
-        })),
+    readyCandidates: hasConflicts ? [] : readyActions.map(toCandidate),
   };
 }
 
@@ -97,6 +168,13 @@ export function formatLoopStatus(report: LoopStatusReport): string {
     const span = it.completedAt ? `${it.startedAt} -> ${it.completedAt}` : `${it.startedAt} ->`;
     lines.push(`  outcome: ${it.outcome ?? "(未記録)"} (${span})`);
     if (it.stopReason) lines.push(`  stopReason: ${it.stopReason}`);
+    if (report.lastActual?.durationHours != null) {
+      const est =
+        report.lastActual.estimateHours != null ? `${report.lastActual.estimateHours}h` : "未設定";
+      lines.push(
+        `  actual: #${report.lastActual.iterationId} 所要 ${report.lastActual.durationHours}h / 見積 ${est}`,
+      );
+    }
   } else {
     lines.push("Iterations: 0 (ジャーナルは初期化済み)");
   }
@@ -105,6 +183,21 @@ export function formatLoopStatus(report: LoopStatusReport): string {
   const max = report.stop.maxIterations === null ? "unlimited" : String(report.stop.maxIterations);
   lines.push(`Stop conditions: ${report.stop.stopWhen.join(", ")}`);
   lines.push(`  maxIterations: ${max} / onVerifyFailure: ${report.stop.onVerifyFailure}`);
+
+  if (report.slips.length > 0) {
+    lines.push("");
+    lines.push(`Schedule slips (${report.slips.length}):`);
+    for (const slip of report.slips) {
+      const label =
+        slip.kind === "overdue"
+          ? `期日超過 ${slip.days}日`
+          : slip.kind === "done_late"
+            ? `完了遅延 ${slip.days}日`
+            : `期日まで ${slip.days}日`;
+      lines.push(`  ! [${slip.kind}] ${slip.taskId}: ${slip.title} (${label})`);
+    }
+    lines.push("  日付の変更は行いません。再計画する場合は gh-gantt update を使ってください。");
+  }
 
   lines.push("");
   if (report.hasConflicts) {
@@ -116,11 +209,21 @@ export function formatLoopStatus(report: LoopStatusReport): string {
   }
   lines.push(`Ready tasks: ${report.readyCount}`);
   if (report.readyCandidates.length > 0) {
-    lines.push("Next candidates (ready のみ, Next Actions スコア順):");
+    lines.push("Next candidates (作業粒度の ready のみ, Next Actions スコア順):");
     report.readyCandidates.forEach((c, i) => {
       lines.push(`  ${i + 1}. ${c.taskId}: ${c.title}`);
       lines.push(`     score=${c.score} [${c.category}] ${c.reason}`);
     });
+  } else if (report.exhaustion) {
+    lines.push(`Next candidates: なし (${report.exhaustion.reason})`);
+    if (report.exhaustion.reason === "all_blocked") {
+      for (const b of report.exhaustion.blocked) {
+        lines.push(`  - ${b.taskId} <- blocked by: ${b.blockingTaskIds.join(", ") || "(待ち)"}`);
+      }
+    } else if (report.exhaustion.reason === "backlog_needs_decomposition") {
+      lines.push(`  分解候補: ${report.exhaustion.decomposeCandidates.join(", ")}`);
+      lines.push("  gh-gantt-decompose で作業粒度のタスクに分解してください。");
+    }
   } else {
     lines.push("Next candidates: なし (ready なタスクがありません)");
   }
@@ -128,39 +231,353 @@ export function formatLoopStatus(report: LoopStatusReport): string {
   return lines.join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// loop next — 1 イテレーション分の observe + decide（ADR-016 案A / ADR-017）
+// ---------------------------------------------------------------------------
+
+export type LoopNextResult =
+  | { kind: "open_iteration"; openIterationId: number }
+  | {
+      kind: "stopped";
+      stopReason: LoopStopReason;
+      exhaustion: ReadyExhaustion | null;
+      /** 追記すべきイテレーション。直前と同一理由の停止なら null（重複記録を避ける）。 */
+      iteration: LoopIteration | null;
+    }
+  | { kind: "selected"; iteration: LoopIteration; alternatives: LoopReadyCandidate[] };
+
+function nextIterationId(state: LoopState): number {
+  return state.iterations.reduce((max, it) => Math.max(max, it.id), 0) + 1;
+}
+
+/**
+ * 次イテレーションを決定論的に決める（純粋関数）。
+ *
+ * 優先順位: 未完了イテレーションの拒否 → conflicts_present → budget_exhausted
+ * → ready 枯渇 3 分類 → 選定（作業粒度の ready を Next Actions スコア順）。
+ * 停止条件の検出は Config.loop.stopWhen に依らず常に行う（選定不能な状況で
+ * 選定を続けることはできないため）。stopWhen は自律ループ側の終了判断に使う。
+ */
+export function decideNextIteration(params: {
+  state: LoopState;
+  config: Config;
+  tasks: Task[];
+  hasConflicts: boolean;
+  now: string;
+  decision?: string;
+}): LoopNextResult {
+  const { state, config, tasks, hasConflicts, now, decision } = params;
+
+  const last = state.iterations.length > 0 ? state.iterations[state.iterations.length - 1] : null;
+  if (last && last.selectedTask !== null && last.completedAt === undefined && !last.outcome) {
+    return { kind: "open_iteration", openIterationId: last.id };
+  }
+
+  const stopWith = (
+    stopReason: LoopStopReason,
+    exhaustion: ReadyExhaustion | null,
+  ): LoopNextResult => {
+    // 直前も同一理由の停止なら追記しない（連続実行でジャーナルが膨らむのを防ぐ）
+    if (last?.outcome === "stopped" && last.stopReason === stopReason) {
+      return { kind: "stopped", stopReason, exhaustion, iteration: null };
+    }
+    return {
+      kind: "stopped",
+      stopReason,
+      exhaustion,
+      iteration: {
+        id: nextIterationId(state),
+        startedAt: now,
+        selectedTask: null,
+        decision: `停止条件 ${stopReason} を検出`,
+        outcome: "stopped",
+        stopReason,
+      },
+    };
+  };
+
+  if (hasConflicts) return stopWith("conflicts_present", null);
+
+  const resolved = resolveLoopConfig(config.loop);
+  if (resolved.maxIterations !== null) {
+    const consumed = state.iterations.filter((it) => it.selectedTask !== null).length;
+    if (consumed >= resolved.maxIterations) return stopWith("budget_exhausted", null);
+  }
+
+  const { vm, readyActions } = selectReadyCandidates(config, tasks);
+  const exhaustion = classifyReadyExhaustion(tasks, config, vm.readinessById);
+  if (exhaustion) return stopWith(exhaustion.reason, exhaustion);
+
+  const top = readyActions[0];
+  const iteration: LoopIteration = {
+    id: nextIterationId(state),
+    startedAt: now,
+    selectedTask: top.task.id,
+    selection: {
+      taskId: top.task.id,
+      score: top.score,
+      category: top.category,
+      reason: top.reason,
+    },
+    decision: decision ?? `${top.task.title} (${top.task.id}) に着手する`,
+  };
+  return { kind: "selected", iteration, alternatives: readyActions.slice(1).map(toCandidate) };
+}
+
+export function formatLoopNext(result: LoopNextResult): string {
+  if (result.kind === "open_iteration") {
+    return [
+      `イテレーション #${result.openIterationId} が未完了です。`,
+      "gh-gantt loop complete で閉じてから次のイテレーションを開始してください。",
+    ].join("\n");
+  }
+  if (result.kind === "stopped") {
+    const lines = [`Stopped: ${result.stopReason}`];
+    if (result.stopReason === "conflicts_present") {
+      lines.push("  gh-gantt conflicts / resolve でコンフリクトを解決してください。");
+    } else if (result.exhaustion?.reason === "all_blocked") {
+      for (const b of result.exhaustion.blocked) {
+        lines.push(`  - ${b.taskId} <- blocked by: ${b.blockingTaskIds.join(", ") || "(待ち)"}`);
+      }
+    } else if (result.exhaustion?.reason === "backlog_needs_decomposition") {
+      lines.push(`  分解候補: ${result.exhaustion.decomposeCandidates.join(", ")}`);
+      lines.push("  gh-gantt-decompose で作業粒度のタスクに分解してください。");
+    } else if (result.stopReason === "all_done") {
+      lines.push("  open タスクはありません。おつかれさまでした。");
+    } else if (result.stopReason === "budget_exhausted") {
+      lines.push(
+        "  maxIterations に達しました。継続する場合は config の loop.maxIterations を見直してください。",
+      );
+    }
+    if (result.iteration === null) {
+      lines.push("  (直前と同一理由のためジャーナルには追記していません)");
+    }
+    return lines.join("\n");
+  }
+  const it = result.iteration;
+  const lines = [
+    `Iteration #${it.id} を開始しました`,
+    `  selected: ${it.selectedTask}`,
+    `  reason: score=${it.selection?.score} [${it.selection?.category}] ${it.selection?.reason}`,
+    `  decision: ${it.decision}`,
+  ];
+  if (result.alternatives.length > 0) {
+    lines.push("  alternatives:");
+    for (const alt of result.alternatives) {
+      lines.push(`    - ${alt.taskId}: ${alt.title} (score=${alt.score})`);
+    }
+  }
+  lines.push("完了したら gh-gantt loop complete で実績を記録してください。");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// loop complete — 実績（予実）の記録（ADR-017）
+// ---------------------------------------------------------------------------
+
+const COMPLETE_OUTCOMES = ["completed", "verify_failed", "abandoned"] as const;
+
+export type LoopCompleteResult =
+  | { kind: "no_open_iteration" }
+  | {
+      kind: "completed";
+      iteration: LoopIteration;
+      durationHours: number | null;
+      estimateHours: number | null;
+    };
+
+/** `--verify "<command>=pass|fail"` の繰り返し指定をパースする。attempt は指定順で採番。 */
+export function parseVerifySpecs(specs: string[]): LoopVerifyResult[] {
+  const attempts = new Map<string, number>();
+  return specs.map((spec) => {
+    const match = spec.match(/^(.+)=(pass|fail)$/);
+    if (!match) {
+      throw new Error(`--verify の形式が不正です: "${spec}" ("<command>=pass|fail" で指定)`);
+    }
+    const command = match[1];
+    const attempt = (attempts.get(command) ?? 0) + 1;
+    attempts.set(command, attempt);
+    return { command, passed: match[2] === "pass", attempt };
+  });
+}
+
+/**
+ * 直近の開いたイテレーションに実績を記録する（state を直接更新する）。
+ */
+export function completeIteration(params: {
+  state: LoopState;
+  config: Config;
+  tasks: Task[];
+  now: string;
+  outcome: LoopIterationOutcome;
+  reviewOutcome?: string;
+  verify?: LoopVerifyResult[];
+}): LoopCompleteResult {
+  const { state, config, tasks, now, outcome, reviewOutcome, verify } = params;
+  const it = [...state.iterations]
+    .reverse()
+    .find((i) => i.selectedTask !== null && i.completedAt === undefined && !i.outcome);
+  if (!it) return { kind: "no_open_iteration" };
+
+  it.completedAt = now;
+  it.outcome = outcome;
+  if (reviewOutcome !== undefined) it.reviewOutcome = reviewOutcome;
+  if (verify && verify.length > 0) it.verifyResults = verify;
+
+  const task = tasks.find((t) => t.id === it.selectedTask);
+  return {
+    kind: "completed",
+    iteration: it,
+    durationHours: durationHours(it.startedAt, now),
+    estimateHours: task ? getEstimateHours(task, config) : null,
+  };
+}
+
+export function formatLoopComplete(result: LoopCompleteResult): string {
+  if (result.kind === "no_open_iteration") {
+    return "開いているイテレーションがありません。gh-gantt loop next で開始してください。";
+  }
+  const it = result.iteration;
+  const lines = [
+    `Iteration #${it.id} を記録しました (${it.outcome})`,
+    `  task: ${it.selectedTask}`,
+  ];
+  const est = result.estimateHours != null ? `${result.estimateHours}h` : "未設定";
+  if (result.durationHours != null) {
+    lines.push(`  actual: 所要 ${result.durationHours}h / 見積 ${est}`);
+  }
+  if (it.verifyResults && it.verifyResults.length > 0) {
+    const failed = it.verifyResults.filter((v) => !v.passed).length;
+    lines.push(`  verify: ${it.verifyResults.length} 回実行 (失敗 ${failed} 回)`);
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// commander 配線
+// ---------------------------------------------------------------------------
+
+function reportCommandError(context: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`${context} の実行に失敗しました: ${message}`);
+  console.error(
+    "  .gantt-sync/ の設定・同期データ、または loop-state.json が破損している可能性があります。",
+  );
+  process.exitCode = 1;
+}
+
+async function loadStores(projectRoot: string) {
+  const config = await new ConfigStore(projectRoot).read();
+  const tasksFile = await new TasksStore(projectRoot).read();
+  const loopStore = new LoopStateStore(projectRoot);
+  const state = await loopStore.readOrNull();
+  return { config, tasksFile, loopStore, state };
+}
+
 export const loopCommand = new Command("loop")
   .description("Outer-loop journal and status (ADR-016 / ADR-017)")
   .addCommand(
     new Command("status")
-      .description("Show outer-loop status: last iteration, stop conditions, ready candidates")
+      .description(
+        "Show outer-loop status: last iteration, stop conditions, slips, ready candidates",
+      )
       .option("--json", "Output as JSON")
       .action(async (opts: { json?: boolean }) => {
-        // エントリポイントは program.parse() のため、reject をここで処理しないと
-        // 未処理 rejection としてスタックトレースがそのまま表に出る
         try {
-          const projectRoot = process.cwd();
-          const config = await new ConfigStore(projectRoot).read();
-          const tasksFile = await new TasksStore(projectRoot).read();
-          const state = await new LoopStateStore(projectRoot).readOrNull();
-
+          const { config, tasksFile, state } = await loadStores(process.cwd());
           const report = buildLoopStatusReport(
             state,
             config,
             tasksFile.tasks,
             tasksFile.has_conflicts === true,
           );
-          if (opts.json) {
-            console.log(JSON.stringify(report, null, 2));
-          } else {
-            console.log(formatLoopStatus(report));
-          }
+          console.log(opts.json ? JSON.stringify(report, null, 2) : formatLoopStatus(report));
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error(`loop status の実行に失敗しました: ${message}`);
-          console.error(
-            "  .gantt-sync/ の設定・同期データ、または loop-state.json が破損している可能性があります。",
-          );
-          process.exitCode = 1;
+          reportCommandError("loop status", err);
         }
       }),
+  )
+  .addCommand(
+    new Command("next")
+      .description("Decide the next iteration: pick a ready task or record a stop reason")
+      .option("--json", "Output as JSON")
+      .option("--decision <text>", "このイテレーションでやることの要約を上書きする")
+      .action(async (opts: { json?: boolean; decision?: string }) => {
+        try {
+          const { config, tasksFile, loopStore, state } = await loadStores(process.cwd());
+          const current = state ?? createEmptyLoopState();
+          const result = decideNextIteration({
+            state: current,
+            config,
+            tasks: tasksFile.tasks,
+            hasConflicts: tasksFile.has_conflicts === true,
+            now: new Date().toISOString(),
+            decision: opts.decision,
+          });
+
+          if (result.kind === "selected") {
+            current.iterations.push(result.iteration);
+            await loopStore.write(current);
+          } else if (result.kind === "stopped" && result.iteration) {
+            current.iterations.push(result.iteration);
+            await loopStore.write(current);
+          }
+
+          console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopNext(result));
+          if (result.kind === "open_iteration") process.exitCode = 1;
+        } catch (err) {
+          reportCommandError("loop next", err);
+        }
+      }),
+  )
+  .addCommand(
+    new Command("complete")
+      .description("Record actuals for the open iteration (completedAt, outcome, verify results)")
+      .option("--json", "Output as JSON")
+      .option(
+        "--outcome <outcome>",
+        `イテレーションの結末 (${COMPLETE_OUTCOMES.join(" | ")})`,
+        "completed",
+      )
+      .option("--review <text>", "レビュー結果の要約")
+      .option(
+        "--verify <spec>",
+        '検証結果 "<command>=pass|fail"（繰り返し指定可、attempt は指定順で採番）',
+        (value: string, previous: string[]) => [...previous, value],
+        [] as string[],
+      )
+      .action(
+        async (opts: { json?: boolean; outcome: string; review?: string; verify: string[] }) => {
+          try {
+            if (!(COMPLETE_OUTCOMES as readonly string[]).includes(opts.outcome)) {
+              throw new Error(
+                `--outcome は ${COMPLETE_OUTCOMES.join(" | ")} のいずれかで指定してください`,
+              );
+            }
+            const { config, tasksFile, loopStore, state } = await loadStores(process.cwd());
+            if (!state) {
+              console.log(formatLoopComplete({ kind: "no_open_iteration" }));
+              process.exitCode = 1;
+              return;
+            }
+            const result = completeIteration({
+              state,
+              config,
+              tasks: tasksFile.tasks,
+              now: new Date().toISOString(),
+              outcome: opts.outcome as LoopIterationOutcome,
+              reviewOutcome: opts.review,
+              verify: parseVerifySpecs(opts.verify),
+            });
+            if (result.kind === "completed") {
+              await loopStore.write(state);
+            } else {
+              process.exitCode = 1;
+            }
+            console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopComplete(result));
+          } catch (err) {
+            reportCommandError("loop complete", err);
+          }
+        },
+      ),
   );

--- a/packages/shared/src/__tests__/loop-analysis.test.ts
+++ b/packages/shared/src/__tests__/loop-analysis.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import type { Config, Task } from "../types.js";
+import { buildProjectMapViewModel } from "../project-map.js";
+import { classifyReadyExhaustion, detectScheduleSlips } from "../loop-analysis.js";
+
+const baseTask = (overrides: Partial<Task>): Task => ({
+  id: "T",
+  type: "task",
+  github_issue: null,
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: "task",
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  closed_at: null,
+  custom_fields: {},
+  start_date: null,
+  end_date: null,
+  date: null,
+  blocked_by: [],
+  ...overrides,
+});
+
+const config: Config = {
+  version: "1",
+  project: { name: "P", github: { owner: "stanah", repo: "gh-gantt", project_number: 1 } },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    epic: { label: "Epic", display: "summary", color: "#111", github_label: null },
+  },
+  type_hierarchy: { epic: ["task"], task: [] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#3498DB", done: false, category: "todo" },
+      Done: { color: "#2ECC71", done: true, category: "done" },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    at_risk_threshold_days: 3,
+    colors: {
+      critical_path: "#E74C3C",
+      on_track: "#2ECC71",
+      at_risk: "#F39C12",
+      overdue: "#E74C3C",
+    },
+  },
+  require_review_for_types: [],
+  require_close_evidence: false,
+};
+
+function classify(tasks: Task[]) {
+  const vm = buildProjectMapViewModel(tasks, config);
+  return classifyReadyExhaustion(tasks, config, vm.readinessById);
+}
+
+describe("classifyReadyExhaustion による ready 枯渇の 3 分類 (ADR-017)", () => {
+  it("ready な leaf がある場合は枯渇ではない (null)", () => {
+    const tasks = [baseTask({ id: "r", custom_fields: { Status: "Todo" } })];
+    expect(classify(tasks)).toBeNull();
+  });
+
+  it("open タスクが 0 なら all_done", () => {
+    const tasks = [
+      baseTask({ id: "d1", state: "closed" }),
+      baseTask({ id: "d2", custom_fields: { Status: "Done" } }),
+    ];
+    expect(classify(tasks)).toEqual({ reason: "all_done" });
+  });
+
+  it("タスクが 1 件もなくても all_done（空プロジェクト）", () => {
+    expect(classify([])).toEqual({ reason: "all_done" });
+  });
+
+  it("作業粒度の open が全てブロック中なら all_blocked とブロッカーを返す", () => {
+    const tasks = [
+      baseTask({ id: "dep", state: "closed" }),
+      baseTask({
+        id: "b1",
+        blocked_by: [
+          { task: "dep2", type: "finish-to-start", lag: 0 },
+          { task: "dep", type: "finish-to-start", lag: 0 },
+        ],
+        custom_fields: { Status: "Todo" },
+      }),
+      baseTask({ id: "dep2", blocked_by: [{ task: "外部", type: "finish-to-start", lag: 0 }] }),
+    ];
+    const result = classify(tasks);
+    expect(result?.reason).toBe("all_blocked");
+    if (result?.reason === "all_blocked") {
+      const b1 = result.blocked.find((b) => b.taskId === "b1");
+      // 完了済みの dep はブロッカーに含まれない
+      expect(b1?.blockingTaskIds).toEqual(["dep2"]);
+    }
+  });
+
+  it("分解可能な type の open のみ残存なら backlog_needs_decomposition と分解候補を返す", () => {
+    const tasks = [
+      baseTask({ id: "done-task", state: "closed" }),
+      // 子を持たない epic: leaf だが type が分解可能 → 作業粒度ではない
+      baseTask({ id: "empty-epic", type: "epic", custom_fields: { Status: "Todo" } }),
+    ];
+    const result = classify(tasks);
+    expect(result?.reason).toBe("backlog_needs_decomposition");
+    if (result?.reason === "backlog_needs_decomposition") {
+      expect(result.decomposeCandidates).toEqual(["empty-epic"]);
+    }
+  });
+
+  it("子を持つ epic と完了済みの子だけなら backlog_needs_decomposition（追加の分解が必要）", () => {
+    const tasks = [
+      baseTask({
+        id: "epic",
+        type: "epic",
+        sub_tasks: ["child"],
+        custom_fields: { Status: "Todo" },
+      }),
+      baseTask({ id: "child", parent: "epic", state: "closed" }),
+    ];
+    const result = classify(tasks);
+    expect(result?.reason).toBe("backlog_needs_decomposition");
+  });
+});
+
+describe("detectScheduleSlips によるスリップ検出 (ADR-017)", () => {
+  const today = "2026-07-04";
+
+  it("期日超過の open タスクを overdue として検出する", () => {
+    const tasks = [
+      baseTask({ id: "late", end_date: "2026-07-01", custom_fields: { Status: "Todo" } }),
+    ];
+    expect(detectScheduleSlips(tasks, config, today)).toEqual([
+      { taskId: "late", title: "task", kind: "overdue", days: 3 },
+    ]);
+  });
+
+  it("期日が at_risk_threshold_days 以内の open タスクを at_risk として検出する", () => {
+    const tasks = [
+      baseTask({ id: "soon", end_date: "2026-07-06", custom_fields: { Status: "Todo" } }),
+      baseTask({ id: "far", end_date: "2026-07-20", custom_fields: { Status: "Todo" } }),
+    ];
+    const slips = detectScheduleSlips(tasks, config, today);
+    expect(slips).toEqual([{ taskId: "soon", title: "task", kind: "at_risk", days: 2 }]);
+  });
+
+  it("期日後に完了したタスクを done_late として検出する", () => {
+    const tasks = [
+      baseTask({
+        id: "slipped",
+        state: "closed",
+        end_date: "2026-06-30",
+        closed_at: "2026-07-02T10:00:00Z",
+      }),
+      baseTask({
+        id: "on-time",
+        state: "closed",
+        end_date: "2026-06-30",
+        closed_at: "2026-06-30T23:00:00Z",
+      }),
+    ];
+    expect(detectScheduleSlips(tasks, config, today)).toEqual([
+      { taskId: "slipped", title: "task", kind: "done_late", days: 2 },
+    ]);
+  });
+
+  it("end_date がないタスクは対象外", () => {
+    const tasks = [baseTask({ id: "no-date", custom_fields: { Status: "Todo" } })];
+    expect(detectScheduleSlips(tasks, config, today)).toEqual([]);
+  });
+
+  it("深刻な順（overdue → done_late → at_risk）に並ぶ", () => {
+    const tasks = [
+      baseTask({ id: "risk", end_date: "2026-07-05", custom_fields: { Status: "Todo" } }),
+      baseTask({ id: "over", end_date: "2026-07-01", custom_fields: { Status: "Todo" } }),
+      baseTask({
+        id: "late-done",
+        state: "closed",
+        end_date: "2026-06-01",
+        closed_at: "2026-06-10T00:00:00Z",
+      }),
+    ];
+    const kinds = detectScheduleSlips(tasks, config, today).map((s) => s.kind);
+    expect(kinds).toEqual(["overdue", "done_late", "at_risk"]);
+  });
+});

--- a/packages/shared/src/__tests__/loop-analysis.test.ts
+++ b/packages/shared/src/__tests__/loop-analysis.test.ts
@@ -121,6 +121,19 @@ describe("classifyReadyExhaustion による ready 枯渇の 3 分類 (ADR-017)",
     }
   });
 
+  it("分解不可 type なのに子を持つ不整合タスクも分解候補に含まれる（出力から消えない）", () => {
+    const tasks = [
+      // type task (分解不可) だが sub_tasks を持つデータ不整合
+      baseTask({ id: "odd-parent", sub_tasks: ["child"], custom_fields: { Status: "Todo" } }),
+      baseTask({ id: "child", parent: "odd-parent", state: "closed" }),
+    ];
+    const result = classify(tasks);
+    expect(result?.reason).toBe("backlog_needs_decomposition");
+    if (result?.reason === "backlog_needs_decomposition") {
+      expect(result.decomposeCandidates).toContain("odd-parent");
+    }
+  });
+
   it("子を持つ epic と完了済みの子だけなら backlog_needs_decomposition（追加の分解が必要）", () => {
     const tasks = [
       baseTask({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,5 +11,6 @@ export * from "./status-dates.js";
 export * from "./dependency-graph.js";
 export * from "./project-map.js";
 export * from "./loop-state.js";
+export * from "./loop-analysis.js";
 export * from "./adr-schema.js";
 export * from "./export-renderer.js";

--- a/packages/shared/src/loop-analysis.ts
+++ b/packages/shared/src/loop-analysis.ts
@@ -1,0 +1,142 @@
+import type { Config, Task } from "./types.js";
+import type { TaskReadiness } from "./project-map.js";
+import { isTaskDone } from "./project-map.js";
+
+// ---------------------------------------------------------------------------
+// 外側ループの decide を支える決定論的分析 — ADR-017
+//   1. ready 枯渇の 3 分類（no_ready_tasks の置き換え）
+//   2. スリップ検出（期日超過 / at-risk / 完了遅延）
+// ---------------------------------------------------------------------------
+
+/** ready 枯渇の分類結果。ready 候補が存在する場合は null。 */
+export type ReadyExhaustion =
+  | { reason: "all_done" }
+  | {
+      reason: "all_blocked";
+      /** ブロックまたは待ち状態の open タスクと、そのブロッカー。 */
+      blocked: Array<{ taskId: string; blockingTaskIds: string[] }>;
+    }
+  | {
+      reason: "backlog_needs_decomposition";
+      /** gh-gantt-decompose による分解候補（分解可能な type の open タスク）。 */
+      decomposeCandidates: string[];
+    };
+
+/** type_hierarchy 上で子を持てる（分解可能な）type か。 */
+function isDecomposableType(task: Task, config: Config): boolean {
+  return (config.type_hierarchy[task.type] ?? []).length > 0;
+}
+
+/**
+ * 外側ループの decide が直接着手できる「作業粒度」のタスクか。
+ * 子を持つコンテナ、および子がなくても分解可能な type（epic / feature 等）は
+ * 実装対象ではなく分解対象なので除外する（ADR-017）。
+ */
+export function isWorkableTask(task: Task, config: Config): boolean {
+  return task.sub_tasks.length === 0 && !isDecomposableType(task, config);
+}
+
+/**
+ * ready 枯渇を 3 状態に分類する（ADR-017 Decision 3）。
+ *
+ * - `all_done`: open タスクが 0 → 正常終了
+ * - `backlog_needs_decomposition`: 分解可能な type の open のみ残存 → decompose へ
+ * - `all_blocked`: open はあるが ready 0 で全て依存・レビュー等の待ち → ブロッカー提示
+ *
+ * ready な作業粒度の候補（decide の候補集合と同一基準）が存在する場合は null を返す。
+ */
+export function classifyReadyExhaustion(
+  tasks: Task[],
+  config: Config,
+  readinessById: Record<string, TaskReadiness>,
+): ReadyExhaustion | null {
+  const open = tasks.filter((t) => !(readinessById[t.id]?.isDone ?? isTaskDone(t, config)));
+  if (open.length === 0) return { reason: "all_done" };
+
+  // decide の候補集合と同じ基準（isWorkableTask）で ready を判定する
+  const workable = open.filter((t) => isWorkableTask(t, config));
+  if (workable.some((t) => readinessById[t.id]?.isReady === true)) return null;
+
+  // 作業粒度の open が一つもない → バックログが粗い
+  if (workable.length === 0) {
+    return {
+      reason: "backlog_needs_decomposition",
+      decomposeCandidates: open.filter((t) => isDecomposableType(t, config)).map((t) => t.id),
+    };
+  }
+
+  return {
+    reason: "all_blocked",
+    blocked: workable.map((t) => ({
+      taskId: t.id,
+      blockingTaskIds: readinessById[t.id]?.blockingTaskIds ?? [],
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// スリップ検出（ADR-017 Decision 2）
+// ---------------------------------------------------------------------------
+
+/** at_risk_threshold_days 未指定時のデフォルト（UI の遅延ハイライトと同値）。 */
+export const DEFAULT_AT_RISK_THRESHOLD_DAYS = 3;
+
+export interface ScheduleSlip {
+  taskId: string;
+  title: string;
+  /** overdue: 期日超過の open / at_risk: 期日が閾値以内の open / done_late: 期日後に完了 */
+  kind: "overdue" | "at_risk" | "done_late";
+  /** overdue・done_late は超過日数、at_risk は期日までの残日数。 */
+  days: number;
+}
+
+/** YYYY-MM-DD 同士の日数差（a - b）。不正な日付は null。 */
+function diffDays(a: string, b: string): number | null {
+  const ta = Date.parse(`${a.slice(0, 10)}T00:00:00Z`);
+  const tb = Date.parse(`${b.slice(0, 10)}T00:00:00Z`);
+  if (!Number.isFinite(ta) || !Number.isFinite(tb)) return null;
+  return Math.round((ta - tb) / 86_400_000);
+}
+
+/**
+ * 予定日に対するスリップを検出する（日付の自動更新はしない — 検出と提示のみ）。
+ *
+ * 閾値は既存の `gantt.at_risk_threshold_days`（FR-VIS-018）を再利用する。
+ * `today` は YYYY-MM-DD。呼び出し側が与えることで純粋関数に保つ。
+ */
+export function detectScheduleSlips(tasks: Task[], config: Config, today: string): ScheduleSlip[] {
+  const threshold = config.gantt.at_risk_threshold_days ?? DEFAULT_AT_RISK_THRESHOLD_DAYS;
+  const slips: ScheduleSlip[] = [];
+
+  for (const task of tasks) {
+    if (!task.end_date) continue;
+    const done = isTaskDone(task, config);
+
+    if (done) {
+      // 完了済みの期日超過: 実完了日（closed_at）が end_date より後
+      if (task.closed_at) {
+        const late = diffDays(task.closed_at, task.end_date);
+        if (late != null && late > 0) {
+          slips.push({ taskId: task.id, title: task.title, kind: "done_late", days: late });
+        }
+      }
+      continue;
+    }
+
+    const untilDue = diffDays(task.end_date, today);
+    if (untilDue == null) continue;
+    if (untilDue < 0) {
+      slips.push({ taskId: task.id, title: task.title, kind: "overdue", days: -untilDue });
+    } else if (untilDue <= threshold) {
+      slips.push({ taskId: task.id, title: task.title, kind: "at_risk", days: untilDue });
+    }
+  }
+
+  // 深刻な順: 期日超過（超過日数の大きい順）→ 完了遅延 → at-risk（残日数の少ない順）
+  const kindOrder = { overdue: 0, done_late: 1, at_risk: 2 } as const;
+  slips.sort((a, b) => {
+    if (kindOrder[a.kind] !== kindOrder[b.kind]) return kindOrder[a.kind] - kindOrder[b.kind];
+    return a.kind === "at_risk" ? a.days - b.days : b.days - a.days;
+  });
+  return slips;
+}

--- a/packages/shared/src/loop-analysis.ts
+++ b/packages/shared/src/loop-analysis.ts
@@ -61,7 +61,11 @@ export function classifyReadyExhaustion(
   if (workable.length === 0) {
     return {
       reason: "backlog_needs_decomposition",
-      decomposeCandidates: open.filter((t) => isDecomposableType(t, config)).map((t) => t.id),
+      // 分解可能 type に加え、分解不可 type なのに子を持つ不整合タスクも
+      // 直接着手できないため整理対象として提示する（出力から消さない）
+      decomposeCandidates: open
+        .filter((t) => isDecomposableType(t, config) || t.sub_tasks.length > 0)
+        .map((t) => t.id),
     };
   }
 

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -151,7 +151,8 @@ export function getNormalizedPriority(task: Task, config: Config): string | null
   return level in PRIORITY_WEIGHT ? level : null;
 }
 
-function getEstimateHours(task: Task, config: Config): number | null {
+/** field_mapping.estimate_hours で指定されたカスタムフィールドから見積り時間を取得する。 */
+export function getEstimateHours(task: Task, config: Config): number | null {
   const field = config.sync?.field_mapping?.estimate_hours;
   if (!field) return null;
   const raw = task.custom_fields[field];


### PR DESCRIPTION
## Summary

[ADR-017](docs/adr/ADR-017-loop-time-axis-and-exhaustion-taxonomy.md) の 3 決定（decide の Next Actions 再利用 / 予実記録とスリップ検出 / ready 枯渇の 3 分類）を実装する。#276 の MVP（PR #287）で用意したスキーマの `selection` / `completedAt` / `verifyResults` フィールドが、本 PR で実際に書き込まれるようになる。

### shared

- **`loop-analysis.ts` 新設**
  - `classifyReadyExhaustion`: ready 枯渇を `all_done` / `all_blocked`（ブロッカー一覧付き）/ `backlog_needs_decomposition`（分解候補付き）に決定論的に分類
  - `detectScheduleSlips`: 期日超過（overdue）/ 期日接近（at_risk）/ 完了遅延（done_late）を検出。閾値は既存の `gantt.at_risk_threshold_days`（FR-VIS-018）を再利用し新設定は増やさない
  - `isWorkableTask`: decide の候補基準を「コンテナと分解可能 type（子なし epic 含む）を除外した作業粒度」として共通化。分類と decide が同一基準を共有する
- `getEstimateHours` を export 化（予実算出で再利用）

### cli

- **`gh-gantt loop next`**（`--json` / `--decision <text>`）
  - 未完了イテレーションがあれば開始を拒否（ループ規律の強制）
  - 停止判定: `conflicts_present` → `budget_exhausted`（maxIterations、停止エントリは予算を消費しない）→ 枯渇 3 分類。停止はジャーナルに記録するが、**直前と同一理由なら追記しない**（連続実行でのジャーナル肥大防止）
  - 選定: 作業粒度の ready を Next Actions スコア順で選び、`selection`（NextAction スナップショット）付きでジャーナル追記。代替候補も提示
  - 停止時は導線を提示（`backlog_needs_decomposition` → gh-gantt-decompose、`all_blocked` → ブロッカー一覧、`conflicts_present` → resolve）
- **`gh-gantt loop complete`**（`--outcome` / `--review` / `--verify "cmd=pass|fail"` 繰り返し可）
  - 開いたイテレーションに `completedAt` / `outcome` / `reviewOutcome` / `verifyResults`（attempt 自動採番）を記録し、所要 vs 見積の予実を表示
- **`loop status` 拡張**: スリップ警告（**日付は自動更新せず提示のみ** — 再計画は `gh-gantt update` へ誘導）、直近完了イテレーションの予実、枯渇分類の詳細

## 関連 Issue

Closes #285

Epic: #275 / 設計正本: ADR-017（decide contract・枯渇分類・予実の各決定に準拠）

## Test Plan

- 新規テスト 25 件（shared 11 + cli 14、既存 loop テストは 45 件に増加）:
  - 枯渇分類: null（ready あり）/ all_done（空含む）/ all_blocked（完了済みブロッカー除外）/ backlog_needs_decomposition（子なし epic・完了済み子のみの epic）
  - スリップ: overdue / at_risk（閾値内外）/ done_late（期日内完了は除外）/ 並び順
  - next: 最高スコア選定 + selection 記録 / decision 上書き / 未完了拒否 / conflicts・budget・枯渇停止 / 同一理由停止の重複防止 / 停止エントリが次回をブロックしないこと
  - complete: 実績記録と予実（1.5h vs 見積 2h）/ verify の attempt 採番 / 不正 spec 拒否 / 開いたイテレーションなし
- `pnpm typecheck` / `pnpm test`（全パッケージ）/ `pnpm lint` / `pnpm build` 成功
- `pnpm test:json && pnpm req:trace`（requirements.yaml 差分なし）`&& pnpm req:validate && pnpm docs:gen` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKoC5PYTkdwxeA7XTsD2Ax


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKoC5PYTkdwxeA7XTsD2Ax)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ループ状態の表示に、期限超過や期限リスク、直近完了分の実績/見積を含めるようになりました。
  * 次に実行する候補の表示が、実行可能な作業のみを優先順で示す形式になりました。

* **バグ修正**
  * 完了条件、ブロック中、分解不足などの状態判定がより正確になりました。
  * ループ完了時や停止条件の扱いを改善し、次回実行への影響を抑えました。

* **その他**
  * ループ関連の挙動を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->