### PR TITLE
feat(cli): 自律ループの同期鮮度チェックと status 更新、スキル手順を追加 (#277)

### DIFF
--- a/packages/cli/src/__tests__/loop-next-complete.test.ts
+++ b/packages/cli/src/__tests__/loop-next-complete.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import type { Config, LoopState, Task } from "@gh-gantt/shared";
 import { createEmptyLoopState } from "@gh-gantt/shared";
 import {
+  applyTaskStatus,
+  assessSyncFreshness,
   completeIteration,
   decideNextIteration,
   formatLoopNext,
@@ -301,5 +303,74 @@ describe("parseVerifySpecs による --verify のパース", () => {
   it("形式が不正ならエラーになる", () => {
     expect(() => parseVerifySpecs(["pnpm test"])).toThrow(/形式が不正/);
     expect(() => parseVerifySpecs(["pnpm test=ok"])).toThrow(/形式が不正/);
+  });
+});
+
+describe("assessSyncFreshness による同期鮮度の判定 (observe)", () => {
+  it("last_synced_at が空なら never（初回同期がまだ）", () => {
+    expect(assessSyncFreshness("", NOW)).toBe("never");
+  });
+
+  it("閾値内なら fresh、超過なら stale", () => {
+    expect(assessSyncFreshness("2026-07-04T09:00:00Z", NOW)).toBe("fresh");
+    expect(assessSyncFreshness("2026-07-01T00:00:00Z", NOW)).toBe("stale");
+  });
+
+  it("閾値は時間単位で指定できる", () => {
+    expect(assessSyncFreshness("2026-07-04T07:00:00Z", NOW, 2)).toBe("stale");
+    expect(assessSyncFreshness("2026-07-04T09:00:00Z", NOW, 2)).toBe("fresh");
+  });
+});
+
+describe("未同期時の loop next", () => {
+  it("lastSyncedAt が空なら選定せず sync_required を返す（空状態の all_done 誤判定を防ぐ）", () => {
+    const result = decideNextIteration({
+      state: createEmptyLoopState(),
+      config,
+      tasks: [],
+      hasConflicts: false,
+      now: NOW,
+      lastSyncedAt: "",
+    });
+    expect(result).toEqual({ kind: "sync_required" });
+    expect(formatLoopNext(result)).toContain("gh-gantt pull");
+  });
+
+  it("同期済みなら通常どおり選定する", () => {
+    const result = decideNextIteration({
+      state: createEmptyLoopState(),
+      config,
+      tasks: readyTasks(),
+      hasConflicts: false,
+      now: NOW,
+      lastSyncedAt: "2026-07-04T09:00:00Z",
+    });
+    expect(result.kind).toBe("selected");
+  });
+});
+
+describe("applyTaskStatus によるローカル status 更新", () => {
+  const makeTasksFile = () => ({
+    tasks: [baseTask({ id: "t1", custom_fields: { Status: "Todo" } })],
+    cache: { comments: {}, reactions: {} },
+  });
+
+  it("status を更新し、done への遷移で end_date が自動設定される", () => {
+    const tasksFile = makeTasksFile();
+    const task = applyTaskStatus(tasksFile, "t1", "Done", config);
+    expect(task.custom_fields.Status).toBe("Done");
+    expect(task.end_date).not.toBeNull();
+  });
+
+  it("config に存在しない status はエラーになる", () => {
+    expect(() => applyTaskStatus(makeTasksFile(), "t1", "Unknown", config)).toThrow(
+      /不明な status/,
+    );
+  });
+
+  it("存在しないタスク ID はエラーになる", () => {
+    expect(() => applyTaskStatus(makeTasksFile(), "missing", "Done", config)).toThrow(
+      /見つかりません/,
+    );
   });
 });

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -554,7 +554,9 @@ function reportCommandError(context: string, err: unknown): void {
 async function loadStores(projectRoot: string) {
   const config = await new ConfigStore(projectRoot).read();
   const tasksStore = new TasksStore(projectRoot);
-  const tasksFile = await tasksStore.read();
+  // 新品クローン等で tasks.json 不在でも例外にせず空状態で開始する。
+  // last_synced_at が空のままなので loop next は sync_required で pull を要求する
+  const tasksFile = await tasksStore.readOrDefault();
   const syncState = await new SyncStateStore(projectRoot).readOrDefault();
   const loopStore = new LoopStateStore(projectRoot);
   const state = await loopStore.readOrNull();
@@ -598,7 +600,7 @@ export const loopCommand = new Command("loop")
           // observe: 同期の鮮度確認（stale なら警告して続行、never は選定を拒否）
           if (assessSyncFreshness(syncState.last_synced_at, now) === "stale") {
             console.warn(
-              `⚠ 最終同期から ${SYNC_STALE_THRESHOLD_HOURS} 時間以上経過しています。gh-gantt pull の実行を推奨します。`,
+              `⚠ 最終同期から ${SYNC_STALE_THRESHOLD_HOURS} 時間を超えて経過しています。gh-gantt pull の実行を推奨します。`,
             );
           }
           const current = state ?? createEmptyLoopState();
@@ -680,7 +682,9 @@ export const loopCommand = new Command("loop")
               : { kind: "no_open_iteration" };
             if (result.kind === "completed" && state) {
               await loopStore.write(state);
-              // journal 記録と status 更新を 1 コマンドで原子的に行う（ADR-016 案A）
+              // journal 記録と status 更新を 1 コマンドにまとめる（ADR-016 案A）。
+              // 各ファイルは個別に atomic write されるが 2 ファイル間はトランザクションではなく、
+              // 万一 tasks.json 側が失敗しても journal は残る（再実行で status のみ再適用可能）
               if (opts.taskStatus && result.iteration.selectedTask) {
                 applyTaskStatus(tasksFile, result.iteration.selectedTask, opts.taskStatus, config);
                 await tasksStore.write(tasksFile);

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -3,6 +3,7 @@ import {
   buildNextActions,
   buildProjectMapViewModel,
   classifyReadyExhaustion,
+  computeStatusDateUpdates,
   createEmptyLoopState,
   detectScheduleSlips,
   getEstimateHours,
@@ -21,9 +22,11 @@ import type {
   ResolvedLoopConfig,
   ScheduleSlip,
   Task,
+  TasksFile,
 } from "@gh-gantt/shared";
 import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
+import { SyncStateStore } from "../store/state.js";
 import { LoopStateStore } from "../store/loop-state.js";
 
 /** ready 候補として表示する件数。 */
@@ -67,6 +70,26 @@ function toCandidate(action: {
     category: action.category,
     reason: action.reason,
   };
+}
+
+/** stale とみなす同期経過時間（時間）。 */
+const SYNC_STALE_THRESHOLD_HOURS = 24;
+
+/**
+ * 同期の鮮度を判定する（observe の一部）。
+ * never（初回同期がまだ）の場合、ローカルの空状態を all_done と誤判定し得るため
+ * loop next は選定に進まず pull を要求する。
+ */
+export function assessSyncFreshness(
+  lastSyncedAt: string,
+  now: string,
+  thresholdHours: number = SYNC_STALE_THRESHOLD_HOURS,
+): "never" | "stale" | "fresh" {
+  if (!lastSyncedAt) return "never";
+  const synced = Date.parse(lastSyncedAt);
+  const current = Date.parse(now);
+  if (!Number.isFinite(synced) || !Number.isFinite(current)) return "stale";
+  return current - synced > thresholdHours * 3_600_000 ? "stale" : "fresh";
 }
 
 /**
@@ -247,6 +270,7 @@ export function formatLoopStatus(report: LoopStatusReport): string {
 // ---------------------------------------------------------------------------
 
 export type LoopNextResult =
+  | { kind: "sync_required" }
   | { kind: "open_iteration"; openIterationId: number }
   | {
       kind: "stopped";
@@ -275,9 +299,16 @@ export function decideNextIteration(params: {
   tasks: Task[];
   hasConflicts: boolean;
   now: string;
+  /** sync-state の last_synced_at。空（未同期）なら選定せず pull を要求する。 */
+  lastSyncedAt?: string;
   decision?: string;
 }): LoopNextResult {
-  const { state, config, tasks, hasConflicts, now, decision } = params;
+  const { state, config, tasks, hasConflicts, now, lastSyncedAt, decision } = params;
+
+  // 一度も同期していないローカル状態は空であり、all_done と誤判定し得る
+  if (lastSyncedAt !== undefined && assessSyncFreshness(lastSyncedAt, now) === "never") {
+    return { kind: "sync_required" };
+  }
 
   const last = state.iterations.length > 0 ? state.iterations[state.iterations.length - 1] : null;
   if (last && last.selectedTask !== null && last.completedAt === undefined && !last.outcome) {
@@ -336,6 +367,12 @@ export function decideNextIteration(params: {
 }
 
 export function formatLoopNext(result: LoopNextResult): string {
+  if (result.kind === "sync_required") {
+    return [
+      "初回同期がまだです（sync-state が空）。",
+      "gh-gantt pull を実行してから loop next を再実行してください。",
+    ].join("\n");
+  }
   if (result.kind === "open_iteration") {
     return [
       `イテレーション #${result.openIterationId} が未完了です。`,
@@ -413,6 +450,38 @@ export function parseVerifySpecs(specs: string[]): LoopVerifyResult[] {
 }
 
 /**
+ * タスクの status をローカルで更新する（tasksFile を直接更新する）。
+ * status 遷移に伴う start/end date の自動更新（computeStatusDateUpdates）も適用する。
+ * GitHub への反映は gh-gantt push が担う（sync 規律に従う）。
+ */
+export function applyTaskStatus(
+  tasksFile: TasksFile,
+  taskId: string,
+  status: string,
+  config: Config,
+): Task {
+  if (!config.statuses.values[status]) {
+    throw new UsageError(
+      `不明な status です: "${status}"。利用可能: ${Object.keys(config.statuses.values).join(", ")}`,
+    );
+  }
+  const task = tasksFile.tasks.find((t) => t.id === taskId);
+  if (!task) {
+    throw new UsageError(`タスク ${taskId} が tasks.json に見つかりません`);
+  }
+  const statusField = config.statuses.field_name;
+  const oldStatus = task.custom_fields[statusField] as string | undefined;
+  task.custom_fields = { ...task.custom_fields, [statusField]: status };
+  const dateUpdates = computeStatusDateUpdates(oldStatus, status, config.statuses.values, {
+    start_date: task.start_date,
+    end_date: task.end_date,
+  });
+  if (dateUpdates.start_date) task.start_date = dateUpdates.start_date;
+  if (dateUpdates.end_date) task.end_date = dateUpdates.end_date;
+  return task;
+}
+
+/**
  * 直近の開いたイテレーションに実績を記録する（state を直接更新する）。
  */
 export function completeIteration(params: {
@@ -484,10 +553,12 @@ function reportCommandError(context: string, err: unknown): void {
 
 async function loadStores(projectRoot: string) {
   const config = await new ConfigStore(projectRoot).read();
-  const tasksFile = await new TasksStore(projectRoot).read();
+  const tasksStore = new TasksStore(projectRoot);
+  const tasksFile = await tasksStore.read();
+  const syncState = await new SyncStateStore(projectRoot).readOrDefault();
   const loopStore = new LoopStateStore(projectRoot);
   const state = await loopStore.readOrNull();
-  return { config, tasksFile, loopStore, state };
+  return { config, tasksStore, tasksFile, syncState, loopStore, state };
 }
 
 export const loopCommand = new Command("loop")
@@ -520,14 +591,24 @@ export const loopCommand = new Command("loop")
       .option("--decision <text>", "このイテレーションでやることの要約を上書きする")
       .action(async (opts: { json?: boolean; decision?: string }) => {
         try {
-          const { config, tasksFile, loopStore, state } = await loadStores(process.cwd());
+          const { config, tasksFile, syncState, loopStore, state } = await loadStores(
+            process.cwd(),
+          );
+          const now = new Date().toISOString();
+          // observe: 同期の鮮度確認（stale なら警告して続行、never は選定を拒否）
+          if (assessSyncFreshness(syncState.last_synced_at, now) === "stale") {
+            console.warn(
+              `⚠ 最終同期から ${SYNC_STALE_THRESHOLD_HOURS} 時間以上経過しています。gh-gantt pull の実行を推奨します。`,
+            );
+          }
           const current = state ?? createEmptyLoopState();
           const result = decideNextIteration({
             state: current,
             config,
             tasks: tasksFile.tasks,
             hasConflicts: tasksFile.has_conflicts === true,
-            now: new Date().toISOString(),
+            now,
+            lastSyncedAt: syncState.last_synced_at,
             decision: opts.decision,
           });
 
@@ -540,7 +621,9 @@ export const loopCommand = new Command("loop")
           }
 
           console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopNext(result));
-          if (result.kind === "open_iteration") process.exitCode = 1;
+          if (result.kind === "open_iteration" || result.kind === "sync_required") {
+            process.exitCode = 1;
+          }
         } catch (err) {
           reportCommandError("loop next", err);
         }
@@ -557,20 +640,32 @@ export const loopCommand = new Command("loop")
       )
       .option("--review <text>", "レビュー結果の要約")
       .option(
+        "--task-status <status>",
+        "選定タスクの status をローカル更新する（GitHub への反映は gh-gantt push）",
+      )
+      .option(
         "--verify <spec>",
         '検証結果 "<command>=pass|fail"（繰り返し指定可、attempt は指定順で採番）',
         (value: string, previous: string[]) => [...previous, value],
         [] as string[],
       )
       .action(
-        async (opts: { json?: boolean; outcome: string; review?: string; verify: string[] }) => {
+        async (opts: {
+          json?: boolean;
+          outcome: string;
+          review?: string;
+          taskStatus?: string;
+          verify: string[];
+        }) => {
           try {
             if (!(COMPLETE_OUTCOMES as readonly string[]).includes(opts.outcome)) {
               throw new UsageError(
                 `--outcome は ${COMPLETE_OUTCOMES.join(" | ")} のいずれかで指定してください`,
               );
             }
-            const { config, tasksFile, loopStore, state } = await loadStores(process.cwd());
+            const { config, tasksStore, tasksFile, loopStore, state } = await loadStores(
+              process.cwd(),
+            );
             // state 未初期化でも --json の出力形式は state ありの場合と揃える
             const result: LoopCompleteResult = state
               ? completeIteration({
@@ -585,10 +680,20 @@ export const loopCommand = new Command("loop")
               : { kind: "no_open_iteration" };
             if (result.kind === "completed" && state) {
               await loopStore.write(state);
+              // journal 記録と status 更新を 1 コマンドで原子的に行う（ADR-016 案A）
+              if (opts.taskStatus && result.iteration.selectedTask) {
+                applyTaskStatus(tasksFile, result.iteration.selectedTask, opts.taskStatus, config);
+                await tasksStore.write(tasksFile);
+              }
             } else {
               process.exitCode = 1;
             }
             console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopComplete(result));
+            if (result.kind === "completed" && opts.taskStatus) {
+              console.log(
+                `task status を "${opts.taskStatus}" に更新しました。gh-gantt push で GitHub に反映してください。`,
+              );
+            }
           } catch (err) {
             reportCommandError("loop complete", err);
           }

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -681,14 +681,14 @@ export const loopCommand = new Command("loop")
                 })
               : { kind: "no_open_iteration" };
             if (result.kind === "completed" && state) {
-              await loopStore.write(state);
-              // journal 記録と status 更新を 1 コマンドにまとめる（ADR-016 案A）。
-              // 各ファイルは個別に atomic write されるが 2 ファイル間はトランザクションではなく、
-              // 万一 tasks.json 側が失敗しても journal は残る（再実行で status のみ再適用可能）
+              // journal 記録と status 更新は別ファイルへの書き込みでありトランザクションではない。
+              // 先に tasks.json を書き込むことで、途中失敗時は「イテレーション未完了」のまま残り、
+              // loop complete の再実行で復旧できる（逆順だと journal だけ完了して status が失われる）
               if (opts.taskStatus && result.iteration.selectedTask) {
                 applyTaskStatus(tasksFile, result.iteration.selectedTask, opts.taskStatus, config);
                 await tasksStore.write(tasksFile);
               }
+              await loopStore.write(state);
             } else {
               process.exitCode = 1;
             }

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -90,6 +90,17 @@ Evidence: コマンド出力をそのまま提示する。
 17. **★`on_session_end`** — workflow.md の該当セクションを実行
 18. **REQUIRED:** `gh-gantt-sync`（push）を invoke。タスクの close は PR マージ時に GitHub が自動で行う
 
+## 自律ループモード
+
+人間との対話なしで複数タスクを連続処理する場合（Claude Code の /loop 等）は、
+タスク選定・停止判定・実績記録を `gh-gantt loop` コマンドに委ねる。
+1 イテレーションの手順と停止条件は [references/autonomous-loop.md](references/autonomous-loop.md) を参照。
+
+- 選定は `gh-gantt loop next` — デフォルトフローのステップ 3〜5（一覧表示 → ユーザー選択 →
+  status 更新）を置き換え、作業粒度の ready を Next Actions スコア順で決定論的に選定する
+- 実績記録と status 更新は `gh-gantt loop complete --task-status <status>`
+- 現在地の確認は `gh-gantt loop status`（直近イテレーション・停止条件・スリップ・次候補）
+
 ## Red Flags
 
 | やりがちなこと                                                 | 問題                                                             |

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -96,7 +96,7 @@ Evidence: コマンド出力をそのまま提示する。
 タスク選定・停止判定・実績記録を `gh-gantt loop` コマンドに委ねる。
 1 イテレーションの手順と停止条件は [references/autonomous-loop.md](references/autonomous-loop.md) を参照。
 
-- 選定は `gh-gantt loop next` — デフォルトフローのステップ 3〜5（一覧表示 → ユーザー選択 →
+- 選定は `gh-gantt loop next` — デフォルトフローのステップ 3〜4（一覧表示 → ユーザー選択 →
   status 更新）を置き換え、作業粒度の ready を Next Actions スコア順で決定論的に選定する
 - 実績記録と status 更新は `gh-gantt loop complete --task-status <status>`
 - 現在地の確認は `gh-gantt loop status`（直近イテレーション・停止条件・スリップ・次候補）

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -96,9 +96,10 @@ Evidence: コマンド出力をそのまま提示する。
 タスク選定・停止判定・実績記録を `gh-gantt loop` コマンドに委ねる。
 1 イテレーションの手順と停止条件は [references/autonomous-loop.md](references/autonomous-loop.md) を参照。
 
-- 選定は `gh-gantt loop next` — デフォルトフローのステップ 3〜4（一覧表示 → ユーザー選択 →
-  status 更新）を置き換え、作業粒度の ready を Next Actions スコア順で決定論的に選定する
-- 実績記録と status 更新は `gh-gantt loop complete --task-status <status>`
+- 選定は `gh-gantt loop next` — デフォルトフローのステップ 3（一覧表示 → ユーザー選択）を
+  置き換え、作業粒度の ready を Next Actions スコア順で決定論的に選定する。
+  作業中ステータスへの更新（ステップ 4）は従来どおり `gh-gantt update <number> --status <作業中ステータス>` で行う
+- 実績記録と完了時の status 更新は `gh-gantt loop complete --task-status <status>`
 - 現在地の確認は `gh-gantt loop status`（直近イテレーション・停止条件・スリップ・次候補）
 
 ## Red Flags

--- a/skills/gh-gantt-workflow/references/autonomous-loop.md
+++ b/skills/gh-gantt-workflow/references/autonomous-loop.md
@@ -1,0 +1,57 @@
+# 自律ループ（gh-gantt loop × Claude Code /loop）
+
+外側ループ（タスクを選ぶ → 完了させる → 次を選ぶ）をコード駆動で回す手順。
+決定論的な部分（選定・停止判定・実績記録）は gh-gantt CLI が行い、
+エージェントは設計・実装だけを担う（ADR-016 / ADR-017）。
+
+## 1 イテレーションの手順
+
+1. **observe** — `gh-gantt pull` で最新化する。コンフリクト検出時は
+   `gh-gantt-conflict-resolution` を invoke して解決するまで先に進まない
+2. **decide** — `gh-gantt loop next --json` を実行する
+   - `selected`: iteration plan（選定タスク・選定理由・代替候補）が返り、ジャーナルに記録済み
+   - `stopped`: stopReason に従う（下表）
+   - `sync_required` / `open_iteration`: 出力の案内に従って前提を整え、再実行する
+3. **act** — 選定タスクを実装する。`.gantt-sync/workflow.md` に `## Dev-Role Config` があれば
+   `gh-gantt-dev-role role=orchestrator` に引き継ぐ（設計 → 実装 → executor 検証 → レビュー）
+4. **record** — 実績を記録する
+
+   ```bash
+   gh-gantt loop complete --outcome completed \
+     --verify "pnpm test=pass" --verify "pnpm lint=pass" \
+     --task-status <done 系ステータス名>
+   ```
+
+   検証失敗のまま断念する場合は `--outcome verify_failed`
+   （リトライ予算は dev-role の `maxExecutorRetries` に従う）
+
+5. **sync** — `gh-gantt push` で GitHub に反映し、PR を作成する
+   （`gh-gantt-pr` と [PR レビューサイクル](pr-review-cycle.md) に従う）
+6. 手順 1 に戻る
+
+## 停止条件（stopReason）と対応
+
+| stopReason                    | 意味                              | 次の一手                                |
+| ----------------------------- | --------------------------------- | --------------------------------------- |
+| `all_done`                    | open タスクなし                   | ループ終了（正常）                      |
+| `all_blocked`                 | 全て依存・レビュー等の待ち        | ブロッカー一覧を人間に報告して終了      |
+| `backlog_needs_decomposition` | 分解可能な type の open のみ残存  | `gh-gantt-decompose` で分解してから再開 |
+| `conflicts_present`           | 未解決コンフリクト                | `gh-gantt-conflict-resolution` で解決   |
+| `budget_exhausted`            | `loop.maxIterations` 到達         | 人間に報告して終了                      |
+| `human_gate_required`         | config 宣言用（自動検出は未実装） | 人間に委譲                              |
+
+## Claude Code の /loop での駆動
+
+/loop（自律モード）で回す場合、1 反復 = 上記手順 1〜5 とする。
+`gh-gantt loop next` が `stopped` を返したら stopReason と詳細を報告してループを終了する。
+イテレーション上限や停止条件は `gantt.config.json` の `loop` セクション
+（`maxIterations` / `stopWhen` / `onVerifyFailure`）で調整できる。
+
+## Red Flags
+
+| やりがちなこと                       | 問題                                                       |
+| ------------------------------------ | ---------------------------------------------------------- |
+| loop next を使わずタスクを自分で選ぶ | 選定根拠がジャーナルに残らず、スコアリングもバイパスされる |
+| complete せずに次の next を叩く      | open_iteration で拒否される。実績（予実）が記録されない    |
+| stopped を無視して作業を続ける       | 停止条件はハーネスの判断。無視はループの暴走               |
+| pull せずに next を叩く              | 古い状態で選定する。sync_required / stale 警告に従うこと   |

--- a/skills/gh-gantt-workflow/references/commands.md
+++ b/skills/gh-gantt-workflow/references/commands.md
@@ -232,6 +232,26 @@ gh-gantt link <id> [--blocked-by <id>] [--unblock <id>] \
 
 ---
 
+## loop
+
+外側ループ（ADR-016 / ADR-017）の観測・選定・実績記録。ジャーナルは `.gantt-sync/loop-state.json`（直接編集禁止）。
+
+```bash
+gh-gantt loop status [--json]     # 直近イテレーション・停止条件・スリップ・ready 候補
+gh-gantt loop next [--json] [--decision <text>]
+gh-gantt loop complete [--json] [--outcome completed|verify_failed|abandoned] \
+  [--review <text>] [--verify "<command>=pass|fail"]... [--task-status <status>]
+```
+
+- `next` は作業粒度（コンテナ・分解可能 type を除く）の ready を Next Actions スコア順で選定し、
+  ジャーナルに追記する。選定できない場合は停止理由（all_done / all_blocked /
+  backlog_needs_decomposition / conflicts_present / budget_exhausted）を記録する。
+  未同期（sync-state が空）の場合は選定せず pull を要求する
+- `complete` は開いているイテレーションに completedAt / outcome / verifyResults を記録し、
+  所要 vs 見積の予実を表示する。`--task-status` で選定タスクの status をローカル更新
+  （GitHub への反映は `gh-gantt push`）
+- 自律実行の手順は [autonomous-loop.md](autonomous-loop.md) を参照
+
 ## タスクタイプ（task_types）
 
 gh-gantt はタスクの種類（epic, task, feature 等）を `gantt.config.json` の `task_types` で管理する。


### PR DESCRIPTION
## 概要

Closes #277（Epic #275、ADR-016 案A / ADR-017 準拠）

外側ループドライバを自律運用するための最後の結線を追加します。observe（pull）→ decide（loop next）→ act → record（loop complete）→ sync（push）の 1 イテレーションを、エージェントが明示的な CLI チェーンとして安全に回せるようにします。

## 変更内容

### CLI: 同期鮮度チェック（loop next）

- `assessSyncFreshness(lastSyncedAt, now)` を追加: `never` / `stale`（24h 超） / `fresh` の 3 値
- sync-state が未同期（`last_synced_at` 空 = 新品クローン等）の場合、`loop next` は `sync_required` を返して選定を**拒否**します。空のローカル状態を見て `all_done` と誤判定するのを防ぐガードです
- 24h を超えて古い場合は選定は行いつつ stale 警告を表示します
- `sync_required` / `open_iteration` は exit code 1（ハーネス側で前提未達を機械判定できる）

### CLI: status 更新（loop complete）

- `--task-status <status>` オプションを追加。`config.statuses.values` に対して検証し（不明な値は UsageError）、`computeStatusDateUpdates` で日付実績（Done 系なら end_date 等）を反映して tasks.json に書き込みます
- 反映後は「gh-gantt push で GitHub に反映してください」と案内し、push は明示操作のまま残します

### 設計判断: observe / sync を loop コマンドに埋め込まない

pull / push のネットワーク操作を `loop next` / `loop complete` に内蔵せず、明示的な CLI チェーンとして分離しました。コマンドが純粋関数ベースでテスト可能なまま保たれ、鮮度チェック（sync_required / stale 警告）がチェーンの安全性を担保します。

### スキル文書

- `skills/gh-gantt-workflow/references/autonomous-loop.md` を新規追加: 1 イテレーションの手順、stopReason 対応表、Claude Code /loop での駆動方法、Red Flags
- `SKILL.md` に「自律ループモード」セクションを追加（loop next がデフォルトフローの選定ステップを置き換える）
- `references/commands.md` に `loop` コマンド群（status / next / complete）を追記

## テスト

- `assessSyncFreshness` の never / stale / fresh / 閾値境界
- `lastSyncedAt` 空 → `sync_required`、`formatLoopNext` が pull 案内を含むこと
- `applyTaskStatus`: Done 遷移で end_date 反映 / 不明 status で UsageError / 存在しないタスクで UsageError
- 全テスト・build・req:trace・req:validate・docs:gen をローカルで通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKoC5PYTkdwxeA7XTsD2Ax

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKoC5PYTkdwxeA7XTsD2Ax)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `loop next / complete / status` を使った自律ループ操作の案内と手順を追加しました。
  * `loop complete` で完了記録に加えてタスクの状態を更新できるようになりました。
  * `loop next` で同期状況を確認し、未同期時は続行せず案内を表示します。

* **ドキュメント**
  * 自律ループの流れ、停止条件、各コマンドの使い方を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->