### PR TITLE
fix(sync): start_date / end_date のクリアを ProjectV2 に反映する

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -58,6 +58,11 @@ areas:
             description: 未解決コンフリクトがある場合は push を拒否する
             status: uncovered
             tests: []
+          - id: FR-SYNC-003-AC4
+            description: start_date / end_date の null 化を push で ProjectV2 の日付フィールドクリアとして反映できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/push-executor.test.ts
       - id: FR-SYNC-004
         summary: リモートデータからローカルタスクへのマッピング
         acceptance_criteria:
@@ -1058,6 +1063,14 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-233-relation-node-id.test.ts
+          - id: NFR-STABILITY-002-AC3
+            description: |
+              ローカルで null 化された日付フィールド (start_date / end_date) が
+              push で無言のまま GitHub に残置されず、ProjectV2 フィールドクリア
+              として反映される (regression #306)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-306-date-clear-push.test.ts
       - id: NFR-STABILITY-003
         summary: Org 環境と個人環境の両方で主要 CLI コマンドが動作する
         acceptance_criteria:

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -1423,6 +1423,59 @@ describe("executePush", () => {
       expect(updatedFields).not.toContainEqual(expect.objectContaining({ fieldId: "FIELD_END" }));
     });
 
+    it("[FR-SYNC-003-AC4] 空文字の日付はクリア意図として扱い、GraphQL に日付として送らない", async () => {
+      const clearedFields: any[] = [];
+      const updatedFields: any[] = [];
+      // 空文字は Zod 検証を通らない不正値だが、防御的にクリア意図へ正規化する契約を固定する
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        start_date: "" as unknown as string,
+        end_date: null,
+      });
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        start_date: "2026-07-01",
+        end_date: null,
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: { "Start Date": "FIELD_START", "End Date": "FIELD_END" },
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(previousTask),
+            synced_at: "",
+            syncFields: extractSyncFields(previousTask),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+
+      const mockGql = makeMockGql({
+        updateProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          updatedFields.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+        clearProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          clearedFields.push(vars);
+          return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+      });
+
+      await executePush(mockGql as any, makeConfig(), tasksFile, syncState);
+
+      // 空文字はクリアとして送信され、update で "" が日付として送られることはない
+      expect(clearedFields).toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+      expect(updatedFields).not.toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+    });
+
     it("[FR-SYNC-003-AC4] 以前から null の日付フィールドには clear を呼ばない", async () => {
       const clearedFields: any[] = [];
       // タイトルだけ変更し、日付は以前も現在も null のまま

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -1366,6 +1366,150 @@ describe("executePush", () => {
       );
     });
 
+    it("[FR-SYNC-003-AC4] start_date / end_date が null 化された場合は date フィールドを clear する", async () => {
+      const clearedFields: any[] = [];
+      const updatedFields: any[] = [];
+      // ローカルでは両方の日付が none 指定で null 化されている
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        start_date: null,
+        end_date: null,
+      });
+      // snapshot (前回同期時) には日付が設定されていた
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        start_date: "2026-07-01",
+        end_date: "2026-07-31",
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: { "Start Date": "FIELD_START", "End Date": "FIELD_END" },
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(previousTask),
+            synced_at: "",
+            syncFields: extractSyncFields(previousTask),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+
+      const mockGql = makeMockGql({
+        updateProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          updatedFields.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+        clearProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          clearedFields.push(vars);
+          return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+      });
+
+      await executePush(mockGql as any, makeConfig(), tasksFile, syncState);
+
+      // 両方の日付フィールドがクリアされる
+      expect(clearedFields).toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+      expect(clearedFields).toContainEqual(expect.objectContaining({ fieldId: "FIELD_END" }));
+      // updateProjectV2ItemFieldValue で日付が送信されることはない
+      expect(updatedFields).not.toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+      expect(updatedFields).not.toContainEqual(expect.objectContaining({ fieldId: "FIELD_END" }));
+    });
+
+    it("[FR-SYNC-003-AC4] 以前から null の日付フィールドには clear を呼ばない", async () => {
+      const clearedFields: any[] = [];
+      // タイトルだけ変更し、日付は以前も現在も null のまま
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        title: "更新後のタイトル",
+      });
+      const previousTask = makeTask("o/r#1", { github_issue: 1 });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: { "Start Date": "FIELD_START", "End Date": "FIELD_END" },
+        snapshots: {
+          "o/r#1": {
+            hash: "stale-hash",
+            synced_at: "",
+            syncFields: extractSyncFields(previousTask),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+
+      const mockGql = makeMockGql({
+        clearProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          clearedFields.push(vars);
+          return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+      });
+
+      await executePush(mockGql as any, makeConfig(), tasksFile, syncState);
+
+      // 以前から null → クリアは不要 (無駄な API コールを増やさない)
+      expect(clearedFields).toEqual([]);
+    });
+
+    it("[FR-SYNC-003-AC4] 日付に値がある場合は従来どおり update で送信する", async () => {
+      const fieldUpdates: any[] = [];
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        start_date: "2026-07-01",
+        end_date: "2026-07-31",
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: { "Start Date": "FIELD_START", "End Date": "FIELD_END" },
+        snapshots: {
+          "o/r#1": {
+            hash: "stale-hash",
+            synced_at: "",
+            syncFields: extractSyncFields(makeTask("o/r#1", { github_issue: 1 })),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+
+      const mockGql = makeMockGql({
+        updateProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          fieldUpdates.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+      });
+
+      await executePush(mockGql as any, makeConfig(), tasksFile, syncState);
+
+      expect(fieldUpdates).toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_START", value: { date: "2026-07-01" } }),
+      );
+      expect(fieldUpdates).toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_END", value: { date: "2026-07-31" } }),
+      );
+    });
+
     it("blocker mutations run in parallel", async () => {
       const concurrency: string[] = [];
       const blocker1 = makeTask("o/r#5", { github_issue: 5 });

--- a/packages/cli/src/__tests__/regressions/issue-306-date-clear-push.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-306-date-clear-push.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Issue #306: push が start_date / end_date のクリア (none 指定) を ProjectV2 に反映しない
+ *
+ * push-executor の日付フィールド送信は `if (task.start_date && ...)` の truthy 判定で
+ * ガードされており、`gh-gantt update <id> --start-date none` でローカルの日付を null に
+ * しても ProjectV2 側のフィールドをクリアする経路が存在しなかった。
+ * その結果、ローカルで消した日付が GitHub に残り続け、次の pull で復活していた。
+ *
+ * 修正: estimate_hours の既存クリアパターンに従い、「ローカルが null かつ
+ * snapshot (syncFields) に以前の値がある」場合のみ clearProjectV2ItemFieldValue を呼ぶ。
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Config, Task, TasksFile, SyncState } from "@gh-gantt/shared";
+import { computeLocalDiff } from "../../sync/diff.js";
+import { extractSyncFields, hashTask } from "../../sync/hash.js";
+import { executePush } from "../../sync/push-executor.js";
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "o/r",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${id}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "",
+    updated_at: "",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(): Config {
+  return {
+    version: "1",
+    project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+    sync: {
+      auto_create_issues: true,
+      field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+    },
+    task_types: {},
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "", on_track: "", at_risk: "", overdue: "" },
+    },
+  } as Config;
+}
+
+function makeBatchIssueResponse(query: string): any {
+  const matches = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)];
+  const repository: Record<string, any> = {};
+  matches.forEach((match, index) => {
+    repository[`i${index}`] = {
+      number: Number(match[1]),
+      updatedAt: "2026-01-01T00:00:00Z",
+      stateReason: null,
+      closedAt: null,
+    };
+  });
+  return { repository };
+}
+
+/** clearProjectV2ItemFieldValue / updateProjectV2ItemFieldValue の呼び出しを記録する mock gql */
+function makeMockGql(recorded: { cleared: any[]; updated: any[] }) {
+  return vi.fn().mockImplementation(async (query: string, vars?: any) => {
+    if (query.includes("issue(number:") && !query.includes("mutation")) {
+      return makeBatchIssueResponse(query);
+    }
+    if (query.includes("updateIssue")) {
+      return { updateIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("closeIssue")) {
+      return { closeIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("reopenIssue")) {
+      return { reopenIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("updateProjectV2ItemFieldValue")) {
+      recorded.updated.push(vars);
+      return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+    }
+    if (query.includes("clearProjectV2ItemFieldValue")) {
+      recorded.cleared.push(vars);
+      return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+    }
+    return {};
+  });
+}
+
+function makeSyncState(previousTask: Task): SyncState {
+  return {
+    last_synced_at: "",
+    project_node_id: "PVT_1",
+    id_map: {
+      "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+    },
+    field_ids: { "Start Date": "FIELD_START", "End Date": "FIELD_END" },
+    snapshots: {
+      "o/r#1": {
+        hash: hashTask(previousTask),
+        synced_at: "",
+        syncFields: extractSyncFields(previousTask),
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    },
+  };
+}
+
+describe("[NFR-STABILITY-002-AC3] [Issue #306] 日付クリアが push で ProjectV2 に反映されないリグレッション", () => {
+  it("日付の null 化が diff で modified として検出される", () => {
+    // 前回同期時は日付あり、ローカルで none 指定により null 化
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-31",
+    });
+    const task = makeTask("o/r#1", { github_issue: 1 });
+
+    const diffs = computeLocalDiff([task], makeSyncState(previousTask));
+
+    expect(diffs).toContainEqual(expect.objectContaining({ id: "o/r#1", type: "modified" }));
+  });
+
+  it("start_date / end_date の null 化が push で ProjectV2 フィールドクリアとして反映される", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-31",
+    });
+    // `gh-gantt update <id> --start-date none --end-date none` 相当の状態
+    const task = makeTask("o/r#1", { github_issue: 1 });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    // 期待: 両方の日付フィールドが clearProjectV2ItemFieldValue でクリアされる
+    expect(recorded.cleared).toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+    expect(recorded.cleared).toContainEqual(expect.objectContaining({ fieldId: "FIELD_END" }));
+  });
+
+  it("片方の日付だけ null 化した場合、null 化した側だけ clear し残りは update する", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      start_date: "2026-07-01",
+      end_date: "2026-07-31",
+    });
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      start_date: null,
+      end_date: "2026-07-31",
+    });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    expect(recorded.cleared).toContainEqual(expect.objectContaining({ fieldId: "FIELD_START" }));
+    expect(recorded.cleared).not.toContainEqual(expect.objectContaining({ fieldId: "FIELD_END" }));
+    expect(recorded.updated).toContainEqual(
+      expect.objectContaining({ fieldId: "FIELD_END", value: { date: "2026-07-31" } }),
+    );
+  });
+
+  it("以前から null の日付には clear を呼ばない (不要な API コールを避ける)", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    // 日付は以前も現在も null。タイトル変更のみで modified になる
+    const previousTask = makeTask("o/r#1", { github_issue: 1 });
+    const task = makeTask("o/r#1", { github_issue: 1, title: "更新後のタイトル" });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    expect(recorded.cleared).toEqual([]);
+  });
+});

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -586,28 +586,24 @@ export async function executePush(
       if (idEntry.project_item_id) {
         const fieldUpdates: Promise<unknown>[] = [];
 
-        if (task.start_date && syncState.field_ids[fm.start_date]) {
-          fieldUpdates.push(
-            updateProjectItemField(
-              gql,
-              syncState.project_node_id,
-              idEntry.project_item_id,
-              syncState.field_ids[fm.start_date],
-              { date: task.start_date },
-            ),
-          );
-        }
-        if (task.end_date && syncState.field_ids[fm.end_date]) {
-          fieldUpdates.push(
-            updateProjectItemField(
-              gql,
-              syncState.project_node_id,
-              idEntry.project_item_id,
-              syncState.field_ids[fm.end_date],
-              { date: task.end_date },
-            ),
-          );
-        }
+        const startDateUpdate = buildDateFieldUpdate(
+          gql,
+          syncState,
+          fm.start_date,
+          idEntry.project_item_id,
+          task,
+          "start_date",
+        );
+        if (startDateUpdate) fieldUpdates.push(startDateUpdate);
+        const endDateUpdate = buildDateFieldUpdate(
+          gql,
+          syncState,
+          fm.end_date,
+          idEntry.project_item_id,
+          task,
+          "end_date",
+        );
+        if (endDateUpdate) fieldUpdates.push(endDateUpdate);
         if (fm.type && syncState.field_ids[fm.type]) {
           const typeOptionId = resolveTypeOptionId(
             task.type,
@@ -984,6 +980,35 @@ function buildPriorityFieldUpdate(
       singleSelectOptionId: optionId,
     },
   );
+}
+
+/**
+ * 日付フィールド (start_date / end_date) の ProjectV2 更新 mutation を組み立てる。
+ *
+ * ローカルの日付が null の場合、snapshot (syncFields) に以前の値が残っているときだけ
+ * clearProjectV2ItemFieldValue でリモート側のフィールドをクリアする (#306)。
+ * 以前から null の場合は不要な API コールを避けるため何もしない。
+ * buildEstimateHoursFieldUpdate と同じクリア判定パターンに従う。
+ */
+function buildDateFieldUpdate(
+  gql: typeof graphql,
+  syncState: SyncState,
+  fieldName: string,
+  projectItemId: string,
+  task: Task,
+  dateKey: "start_date" | "end_date",
+): Promise<unknown> | null {
+  const fieldId = syncState.field_ids[fieldName];
+  if (!fieldId) return null;
+  const localDate = task[dateKey];
+  if (!localDate) {
+    const previousDate = syncState.snapshots[task.id]?.syncFields?.[dateKey];
+    if (!previousDate) return null;
+    return clearProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId);
+  }
+  return updateProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId, {
+    date: localDate,
+  });
 }
 
 function buildEstimateHoursFieldUpdate(

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -1000,15 +1000,24 @@ function buildDateFieldUpdate(
 ): Promise<unknown> | null {
   const fieldId = syncState.field_ids[fieldName];
   if (!fieldId) return null;
-  const localDate = task[dateKey];
-  if (!localDate) {
-    const previousDate = syncState.snapshots[task.id]?.syncFields?.[dateKey];
-    if (!previousDate) return null;
+  const localDate = normalizeDateValue(task[dateKey]);
+  if (localDate === null) {
+    const previousDate = normalizeDateValue(syncState.snapshots[task.id]?.syncFields?.[dateKey]);
+    if (previousDate === null) return null;
     return clearProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId);
   }
   return updateProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId, {
     date: localDate,
   });
+}
+
+/**
+ * 日付値を「クリア意図 (null)」か「設定する値」に正規化する。
+ * 空文字は不正値であり GraphQL に日付として送ってはならないため、null と同じ
+ * クリア意図として扱う。
+ */
+function normalizeDateValue(value: string | null | undefined): string | null {
+  return value === null || value === undefined || value === "" ? null : value;
 }
 
 function buildEstimateHoursFieldUpdate(


### PR DESCRIPTION
## Summary

- `gh-gantt update <id> --start-date none` 等でローカルの日付を null にしても、push が ProjectV2 のフィールドをクリアせず「push 成功と報告しつつリモートに古い値が無言残置 → 次の pull で復活」していたバグ(#306、ADR-018 の pull-only ギャップの一つ)を修正
- `buildDateFieldUpdate` ヘルパーを追加(estimate_hours の既存クリアパターンに忠実)。クリア条件は「ローカル null かつ snapshot.syncFields に以前の値あり」— 以前から null なら API コールなし、push 成功後の snapshot 再構築により 2 回目 push で clear が再発しない冪等性も担保
- 既存の `clearProjectItemField` mutation を再利用(mutations.ts 変更なし)
- requirements.yaml に FR-SYNC-003-AC4(日付クリアの反映)と NFR-STABILITY-002-AC3(silent no-op の禁止)を追加

## レビュー経緯(dev-role)

- executor: 9/9 passed(1015 tests green、req:trace 冪等)
- reviewer: **approve (10/8、nit 1 件のみ)**。クリア条件の全経路(modified/added/draft)・冪等性・ADR-018 との整合・テストのスパイ実効性まで実コードで裏取り済み

Closes #306

## Test plan

- [x] push-executor.test.ts に [FR-SYNC-003-AC4] ユニットテスト 3 件(クリア送信・API コール抑制・片側のみクリア)
- [x] regressions/issue-306-date-clear-push.test.ts に [NFR-STABILITY-002-AC3] [Issue #306] リグレッション 4 件
- [x] pnpm typecheck / test:json(1015 tests) / build / req:trace(冪等) / req:validate / docs:gen green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ローカルで未設定にした日付が、同期時にリモート側へ正しく反映されるようになりました。
  * 片方の日時だけを消した場合でも、消した項目のみがクリアされ、残りはそのまま更新されます。
  * 以前から未設定だった日付には不要な変更を送らないよう改善しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->