### PR TITLE
fix(sync): 既存 Issue の assignees / labels / milestone の変更を push で反映する

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -63,6 +63,11 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/push-executor.test.ts
+          - id: FR-SYNC-003-AC5
+            description: 既存 Issue の assignees / labels / milestone の変更 (milestone の解除を含む) を push で GitHub に反映できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/push-executor.test.ts
       - id: FR-SYNC-004
         summary: リモートデータからローカルタスクへのマッピング
         acceptance_criteria:
@@ -1071,6 +1076,15 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-306-date-clear-push.test.ts
+          - id: NFR-STABILITY-002-AC4
+            description: |
+              push の既存 Issue 更新で assignees / labels / milestone に
+              未解決名が含まれる場合、silent drop でリモート値を剥がさず、
+              該当フィールドだけ送信をスキップして警告を出し、snapshot を
+              旧値に留めて次回 push で再試行できる (regression #305)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-305-metadata-push.test.ts
       - id: NFR-STABILITY-003
         summary: Org 環境と個人環境の両方で主要 CLI コマンドが動作する
         acceptance_criteria:

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -140,6 +140,16 @@ function makeMockGql(handlers?: Partial<Record<string, (query: string, vars?: an
       if (handlers?.["removeBlockedBy"]) return handlers["removeBlockedBy"](query, vars);
       return { removeIssueRelation: { issue: { id: "ISSUE_1" } } };
     }
+    // repository metadata クエリ (labelMap / milestoneMap)
+    if (query.includes("labels(first")) {
+      if (handlers?.["repositoryMetadata"]) return handlers["repositoryMetadata"](query, vars);
+      return { repository: { labels: { nodes: [] }, milestones: { nodes: [] } } };
+    }
+    // fetchUserIds クエリ (u0: user(login: "x") { id login })
+    if (query.includes("user(login:")) {
+      if (handlers?.["userIds"]) return handlers["userIds"](query, vars);
+      return {};
+    }
     return {};
   });
 }
@@ -1624,6 +1634,309 @@ describe("executePush", () => {
       const end5 = concurrency.indexOf("addBlockedBy:ISSUE_5:end");
       const end6 = concurrency.indexOf("addBlockedBy:ISSUE_6:end");
       expect(Math.max(start5, start6)).toBeLessThan(Math.min(end5, end6));
+    });
+  });
+
+  describe("[FR-SYNC-003-AC5] 既存 Issue の assignees / labels / milestone の変更を push で反映できる", () => {
+    /** 既存 Issue 1 件 (o/r#1) の snapshot を previousTask の状態で構築する */
+    function makeUpdateSyncState(previousTask: Task): SyncState {
+      return {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: {},
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(previousTask),
+            synced_at: "",
+            syncFields: extractSyncFields(previousTask),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+    }
+
+    function makeTasksFile(task: Task): TasksFile {
+      return { tasks: [task], cache: { comments: {}, reactions: {} } };
+    }
+
+    /** labelMap: bug/feature, milestoneMap: v1.0 を返す repository metadata handler */
+    const repositoryMetadataHandler = async () => ({
+      repository: {
+        labels: {
+          nodes: [
+            { id: "LABEL_BUG", name: "bug" },
+            { id: "LABEL_FEATURE", name: "feature" },
+          ],
+        },
+        milestones: { nodes: [{ id: "MS_1", title: "v1.0", number: 1 }] },
+      },
+    });
+
+    it("labels の変更は labelIds に解決して updateIssue で送信する", async () => {
+      const updateIssueVars: any[] = [];
+      const previousTask = makeTask("o/r#1", { github_issue: 1, labels: ["bug"] });
+      const task = makeTask("o/r#1", { github_issue: 1, labels: ["bug", "feature"] });
+
+      const mockGql = makeMockGql({
+        repositoryMetadata: repositoryMetadataHandler,
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      // 置換セマンティクス: ローカルの labels 全体が labelIds として送信される
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0].labelIds).toEqual(["LABEL_BUG", "LABEL_FEATURE"]);
+    });
+
+    it("assignees の変更は assigneeIds に解決して updateIssue で送信する", async () => {
+      const updateIssueVars: any[] = [];
+      const previousTask = makeTask("o/r#1", { github_issue: 1, assignees: [] });
+      const task = makeTask("o/r#1", { github_issue: 1, assignees: ["alice"] });
+
+      const mockGql = makeMockGql({
+        userIds: async () => ({ u0: { id: "USER_ALICE", login: "alice" } }),
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0].assigneeIds).toEqual(["USER_ALICE"]);
+    });
+
+    it("milestone の変更は milestoneId に解決して updateIssue で送信する", async () => {
+      const updateIssueVars: any[] = [];
+      const previousTask = makeTask("o/r#1", { github_issue: 1, milestone: null });
+      const task = makeTask("o/r#1", { github_issue: 1, milestone: "v1.0" });
+
+      const mockGql = makeMockGql({
+        repositoryMetadata: repositoryMetadataHandler,
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0].milestoneId).toBe("MS_1");
+    });
+
+    it("milestone のローカル null 化は milestoneId: null で解除として送信する", async () => {
+      const updateIssueVars: any[] = [];
+      const previousTask = makeTask("o/r#1", { github_issue: 1, milestone: "v1.0" });
+      const task = makeTask("o/r#1", { github_issue: 1, milestone: null });
+
+      const mockGql = makeMockGql({
+        repositoryMetadata: repositoryMetadataHandler,
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      // null は「未指定」ではなく「解除」として明示的に送信される
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0]).toHaveProperty("milestoneId", null);
+    });
+
+    it("metadata に差分がない場合はフィールドを送信せず metadata の fetch も行わない", async () => {
+      const updateIssueVars: any[] = [];
+      let metadataFetchCount = 0;
+      let userIdsFetchCount = 0;
+      // assignees / labels / milestone は同一のままタイトルだけ変更する
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        assignees: ["alice"],
+        labels: ["bug"],
+        milestone: "v1.0",
+      });
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        title: "更新後のタイトル",
+        assignees: ["alice"],
+        labels: ["bug"],
+        milestone: "v1.0",
+      });
+
+      const mockGql = makeMockGql({
+        repositoryMetadata: async () => {
+          metadataFetchCount++;
+          return repositoryMetadataHandler();
+        },
+        userIds: async () => {
+          userIdsFetchCount++;
+          return {};
+        },
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      // 差分がないフィールドは UpdateIssueInput に含めない (不要な置換を避ける)
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0]).not.toHaveProperty("assigneeIds");
+      expect(updateIssueVars[0]).not.toHaveProperty("labelIds");
+      expect(updateIssueVars[0]).not.toHaveProperty("milestoneId");
+      // metadata 変更がない push では fetch 自体を行わない (NFR-SYNC-002)
+      expect(metadataFetchCount).toBe(0);
+      expect(userIdsFetchCount).toBe(0);
+    });
+
+    it("未解決の label 名があるフィールドは送信をスキップして警告し、snapshot を旧値に留めて再試行できる", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const updateIssueVars: any[] = [];
+        const previousTask = makeTask("o/r#1", { github_issue: 1, labels: ["bug"] });
+        const task = makeTask("o/r#1", {
+          github_issue: 1,
+          labels: ["bug", "unknown-label"],
+        });
+        const tasksFile = makeTasksFile(task);
+
+        const mockGql = makeMockGql({
+          repositoryMetadata: repositoryMetadataHandler,
+          updateIssue: async (_q: string, vars: any) => {
+            updateIssueVars.push(vars);
+            return { updateIssue: { issue: { id: "ISSUE_1" } } };
+          },
+        });
+
+        const { syncState: newSyncState } = await executePush(
+          mockGql as any,
+          makeConfig(),
+          tasksFile,
+          makeUpdateSyncState(previousTask),
+        );
+
+        // labelIds は送信されない (silent drop で unknown-label 以外まで剥がさない)
+        expect(updateIssueVars).toHaveLength(1);
+        expect(updateIssueVars[0]).not.toHaveProperty("labelIds");
+        // 警告が出る
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("label が解決できない"));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown-label"));
+        // snapshot は旧値に留まり、次回 push で再試行される
+        expect(newSyncState.snapshots["o/r#1"].syncFields?.labels).toEqual(["bug"]);
+        const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+        expect(retryDiffs).toContainEqual(
+          expect.objectContaining({ id: "o/r#1", type: "modified" }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("未解決の assignee があっても labels など解決できたフィールドは送信される", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const updateIssueVars: any[] = [];
+        const previousTask = makeTask("o/r#1", { github_issue: 1 });
+        const task = makeTask("o/r#1", {
+          github_issue: 1,
+          assignees: ["ghost"],
+          labels: ["bug"],
+        });
+
+        const mockGql = makeMockGql({
+          repositoryMetadata: repositoryMetadataHandler,
+          userIds: async () => ({}),
+          updateIssue: async (_q: string, vars: any) => {
+            updateIssueVars.push(vars);
+            return { updateIssue: { issue: { id: "ISSUE_1" } } };
+          },
+        });
+
+        const { syncState: newSyncState } = await executePush(
+          mockGql as any,
+          makeConfig(),
+          makeTasksFile(task),
+          makeUpdateSyncState(previousTask),
+        );
+
+        expect(updateIssueVars).toHaveLength(1);
+        // 未解決の assignees だけスキップされ、labels は送信される
+        expect(updateIssueVars[0]).not.toHaveProperty("assigneeIds");
+        expect(updateIssueVars[0].labelIds).toEqual(["LABEL_BUG"]);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("assignee が解決できない"));
+        // snapshot は assignees だけ旧値に留まり、labels は新値へ進む
+        expect(newSyncState.snapshots["o/r#1"].syncFields?.assignees).toEqual([]);
+        expect(newSyncState.snapshots["o/r#1"].syncFields?.labels).toEqual(["bug"]);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("未解決の milestone 名は milestone の更新をスキップして警告する", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const updateIssueVars: any[] = [];
+        const previousTask = makeTask("o/r#1", { github_issue: 1, milestone: null });
+        const task = makeTask("o/r#1", { github_issue: 1, milestone: "no-such-milestone" });
+
+        const mockGql = makeMockGql({
+          repositoryMetadata: repositoryMetadataHandler,
+          updateIssue: async (_q: string, vars: any) => {
+            updateIssueVars.push(vars);
+            return { updateIssue: { issue: { id: "ISSUE_1" } } };
+          },
+        });
+
+        const { syncState: newSyncState } = await executePush(
+          mockGql as any,
+          makeConfig(),
+          makeTasksFile(task),
+          makeUpdateSyncState(previousTask),
+        );
+
+        expect(updateIssueVars).toHaveLength(1);
+        expect(updateIssueVars[0]).not.toHaveProperty("milestoneId");
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("milestone が解決できない"));
+        // snapshot の milestone は旧値 (null) に留まる
+        expect(newSyncState.snapshots["o/r#1"].syncFields?.milestone).toBeNull();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -1724,6 +1724,38 @@ describe("executePush", () => {
       expect(updateIssueVars[0].assigneeIds).toEqual(["USER_ALICE"]);
     });
 
+    it("labels / assignees の空配列化は全削除として空の ID 配列を送信する", async () => {
+      const updateIssueVars: any[] = [];
+      // 以前は labels / assignees が設定されていた
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        labels: ["bug"],
+        assignees: ["alice"],
+      });
+      // ローカルで両方とも空にした = 全削除の意図
+      const task = makeTask("o/r#1", { github_issue: 1, labels: [], assignees: [] });
+
+      const mockGql = makeMockGql({
+        repositoryMetadata: repositoryMetadataHandler,
+        updateIssue: async (_q: string, vars: any) => {
+          updateIssueVars.push(vars);
+          return { updateIssue: { issue: { id: "ISSUE_1" } } };
+        },
+      });
+
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeTasksFile(task),
+        makeUpdateSyncState(previousTask),
+      );
+
+      // 空配列が silent no-op に退行せず、全削除として明示送信されることを固定する
+      expect(updateIssueVars).toHaveLength(1);
+      expect(updateIssueVars[0].labelIds).toEqual([]);
+      expect(updateIssueVars[0].assigneeIds).toEqual([]);
+    });
+
     it("milestone の変更は milestoneId に解決して updateIssue で送信する", async () => {
       const updateIssueVars: any[] = [];
       const previousTask = makeTask("o/r#1", { github_issue: 1, milestone: null });

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -1726,6 +1726,7 @@ describe("executePush", () => {
 
     it("labels / assignees の空配列化は全削除として空の ID 配列を送信する", async () => {
       const updateIssueVars: any[] = [];
+      let metadataFetchCount = 0;
       // 以前は labels / assignees が設定されていた
       const previousTask = makeTask("o/r#1", {
         github_issue: 1,
@@ -1736,7 +1737,10 @@ describe("executePush", () => {
       const task = makeTask("o/r#1", { github_issue: 1, labels: [], assignees: [] });
 
       const mockGql = makeMockGql({
-        repositoryMetadata: repositoryMetadataHandler,
+        repositoryMetadata: async () => {
+          metadataFetchCount++;
+          return repositoryMetadataHandler();
+        },
         updateIssue: async (_q: string, vars: any) => {
           updateIssueVars.push(vars);
           return { updateIssue: { issue: { id: "ISSUE_1" } } };
@@ -1754,6 +1758,8 @@ describe("executePush", () => {
       expect(updateIssueVars).toHaveLength(1);
       expect(updateIssueVars[0].labelIds).toEqual([]);
       expect(updateIssueVars[0].assigneeIds).toEqual([]);
+      // 全削除は ID 解決が不要であり、metadata fetch の失敗に巻き込まれない
+      expect(metadataFetchCount).toBe(0);
     });
 
     it("milestone の変更は milestoneId に解決して updateIssue で送信する", async () => {

--- a/packages/cli/src/__tests__/regressions/issue-305-metadata-push.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-305-metadata-push.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Issue #305: push が既存 Issue の assignees / labels / milestone の変更を GitHub に反映しない
+ *
+ * updateIssue (packages/cli/src/github/mutations.ts) は title / body しか送信せず、
+ * labelIds / milestoneId / assigneeIds は draft → Issue 作成経路 (createIssue) でのみ
+ * 使用されていた。そのため `gh-gantt update <id> --label / --assignee / --milestone` による
+ * ローカル変更が push で GitHub に反映されず、次の pull でリモート値に巻き戻されていた。
+ *
+ * 修正: UpdateIssueInput の assigneeIds / labelIds / milestoneId (置換セマンティクス) を
+ * updateIssue mutation に追加し、snapshot (syncFields) と差分があるフィールドだけを送信する。
+ * 未解決名 (labelMap / milestoneMap / userIdMap で解決できない名前) を含むフィールドは
+ * silent drop せず、そのフィールドだけ送信をスキップして警告を出し、snapshot を旧値に
+ * 留めて次回 push で再試行可能にする。
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Config, Task, TasksFile, SyncState } from "@gh-gantt/shared";
+import { computeLocalDiff } from "../../sync/diff.js";
+import { extractSyncFields, hashTask } from "../../sync/hash.js";
+import { executePush } from "../../sync/push-executor.js";
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "o/r",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${id}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "",
+    updated_at: "",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(): Config {
+  return {
+    version: "1",
+    project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+    sync: {
+      auto_create_issues: true,
+      field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+    },
+    task_types: {},
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "", on_track: "", at_risk: "", overdue: "" },
+    },
+  } as Config;
+}
+
+function makeBatchIssueResponse(query: string): any {
+  const matches = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)];
+  const repository: Record<string, any> = {};
+  matches.forEach((match, index) => {
+    repository[`i${index}`] = {
+      number: Number(match[1]),
+      updatedAt: "2026-01-01T00:00:00Z",
+      stateReason: null,
+      closedAt: null,
+    };
+  });
+  return { repository };
+}
+
+/** updateIssue mutation の変数を記録し、metadata / user ID クエリを解決する mock gql */
+function makeMockGql(recorded: { updateIssueVars: any[] }) {
+  return vi.fn().mockImplementation(async (query: string, vars?: any) => {
+    if (query.includes("issue(number:") && !query.includes("mutation")) {
+      return makeBatchIssueResponse(query);
+    }
+    if (query.includes("updateIssue")) {
+      recorded.updateIssueVars.push(vars);
+      return { updateIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("closeIssue")) {
+      return { closeIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("reopenIssue")) {
+      return { reopenIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    // repository metadata (labelMap / milestoneMap)
+    if (query.includes("labels(first")) {
+      return {
+        repository: {
+          labels: {
+            nodes: [
+              { id: "LABEL_BUG", name: "bug" },
+              { id: "LABEL_FEATURE", name: "feature" },
+            ],
+          },
+          milestones: { nodes: [{ id: "MS_1", title: "v1.0", number: 1 }] },
+        },
+      };
+    }
+    // fetchUserIds (u0: user(login: "alice") { id login })
+    if (query.includes("user(login:")) {
+      const logins = [...query.matchAll(/user\(login:\s*"([^"]+)"\)/g)].map((m) => m[1]);
+      const result: Record<string, any> = {};
+      logins.forEach((login, index) => {
+        if (login === "alice") {
+          result[`u${index}`] = { id: "USER_ALICE", login: "alice" };
+        }
+      });
+      return result;
+    }
+    return {};
+  });
+}
+
+function makeSyncState(previousTask: Task): SyncState {
+  return {
+    last_synced_at: "",
+    project_node_id: "PVT_1",
+    id_map: {
+      "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+    },
+    field_ids: {},
+    snapshots: {
+      "o/r#1": {
+        hash: hashTask(previousTask),
+        synced_at: "",
+        syncFields: extractSyncFields(previousTask),
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    },
+  };
+}
+
+function makeTasksFile(task: Task): TasksFile {
+  return { tasks: [task], cache: { comments: {}, reactions: {} } };
+}
+
+describe("[NFR-STABILITY-002-AC4] [Issue #305] assignees / labels / milestone の変更が push で反映されないリグレッション", () => {
+  it("assignees / labels / milestone の変更が diff で modified として検出される", () => {
+    const previousTask = makeTask("o/r#1", { github_issue: 1, labels: ["bug"] });
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      assignees: ["alice"],
+      labels: ["bug", "feature"],
+      milestone: "v1.0",
+    });
+
+    const diffs = computeLocalDiff([task], makeSyncState(previousTask));
+
+    expect(diffs).toContainEqual(expect.objectContaining({ id: "o/r#1", type: "modified" }));
+  });
+
+  it("assignees / labels / milestone の変更が updateIssue mutation の変数として送信される", async () => {
+    const recorded = { updateIssueVars: [] as any[] };
+    const previousTask = makeTask("o/r#1", { github_issue: 1, labels: ["bug"] });
+    // `gh-gantt update o/r#1 --assignee alice --label feature --milestone v1.0` 相当の状態
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      assignees: ["alice"],
+      labels: ["bug", "feature"],
+      milestone: "v1.0",
+    });
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(
+      mockGql as any,
+      makeConfig(),
+      makeTasksFile(task),
+      makeSyncState(previousTask),
+    );
+
+    // 修正前は title / body のみ送信され、metadata は一切 GitHub に反映されなかった
+    expect(recorded.updateIssueVars).toHaveLength(1);
+    expect(recorded.updateIssueVars[0].assigneeIds).toEqual(["USER_ALICE"]);
+    expect(recorded.updateIssueVars[0].labelIds).toEqual(["LABEL_BUG", "LABEL_FEATURE"]);
+    expect(recorded.updateIssueVars[0].milestoneId).toBe("MS_1");
+  });
+
+  it("milestone のローカル解除が milestoneId: null として送信される", async () => {
+    const recorded = { updateIssueVars: [] as any[] };
+    const previousTask = makeTask("o/r#1", { github_issue: 1, milestone: "v1.0" });
+    const task = makeTask("o/r#1", { github_issue: 1, milestone: null });
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(
+      mockGql as any,
+      makeConfig(),
+      makeTasksFile(task),
+      makeSyncState(previousTask),
+    );
+
+    expect(recorded.updateIssueVars).toHaveLength(1);
+    expect(recorded.updateIssueVars[0]).toHaveProperty("milestoneId", null);
+  });
+
+  it("未解決の label 名を含むフィールドは silent drop せず警告付きでスキップし、次回 push で再試行される", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const recorded = { updateIssueVars: [] as any[] };
+      const previousTask = makeTask("o/r#1", { github_issue: 1, labels: ["bug"] });
+      // labelMap に存在しない名前を含む → そのまま送るとリモートから label が剥がれる
+      const task = makeTask("o/r#1", { github_issue: 1, labels: ["bug", "unknown-label"] });
+      const tasksFile = makeTasksFile(task);
+
+      const mockGql = makeMockGql(recorded);
+      const { syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        makeSyncState(previousTask),
+      );
+
+      // labels フィールドは送信されない (bug まで剥がす置換をしない)
+      expect(recorded.updateIssueVars).toHaveLength(1);
+      expect(recorded.updateIssueVars[0]).not.toHaveProperty("labelIds");
+      // 警告として顕在化する (silent drop の禁止)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown-label"));
+      // snapshot は旧値に留まり、次回 push で同じ変更が再試行される
+      expect(newSyncState.snapshots["o/r#1"].syncFields?.labels).toEqual(["bug"]);
+      const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+      expect(retryDiffs).toContainEqual(expect.objectContaining({ id: "o/r#1", type: "modified" }));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/github/mutations.ts
+++ b/packages/cli/src/github/mutations.ts
@@ -22,8 +22,8 @@ const ADD_PROJECT_V2_ITEM_MUTATION = `
 `;
 
 const UPDATE_ISSUE_MUTATION = `
-  mutation($issueId: ID!, $title: String, $body: String) {
-    updateIssue(input: { id: $issueId, title: $title, body: $body }) {
+  mutation($issueId: ID!, $title: String, $body: String, $assigneeIds: [ID!], $labelIds: [ID!], $milestoneId: ID) {
+    updateIssue(input: { id: $issueId, title: $title, body: $body, assigneeIds: $assigneeIds, labelIds: $labelIds, milestoneId: $milestoneId }) {
       issue { id }
     }
   }
@@ -73,10 +73,28 @@ const CLEAR_PROJECT_ITEM_FIELD = `
   }
 `;
 
+/**
+ * updateIssue mutation に渡すフィールド。
+ *
+ * assigneeIds / labelIds は GitHub 側で **全置換** されるため、
+ * 未指定 (undefined) のフィールドは JSON シリアライズ時に落ちて「変更なし」となる。
+ * milestoneId は null を明示的に渡すと milestone が解除される。
+ */
+export interface UpdateIssueFields {
+  title?: string;
+  body?: string;
+  /** 置換セマンティクス: 指定すると Issue の assignees がこの配列で全置換される */
+  assigneeIds?: string[];
+  /** 置換セマンティクス: 指定すると Issue の labels がこの配列で全置換される */
+  labelIds?: string[];
+  /** null で milestone を解除する。undefined は変更しない */
+  milestoneId?: string | null;
+}
+
 export async function updateIssue(
   gql: typeof graphql,
   issueNodeId: string,
-  fields: { title?: string; body?: string },
+  fields: UpdateIssueFields,
 ): Promise<void> {
   await gql(UPDATE_ISSUE_MUTATION, {
     issueId: issueNodeId,

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -1168,23 +1168,32 @@ async function resolveIssueMetadataUpdate(
   const fields: IssueMetadataUpdateResult["fields"] = {};
   const failedFields: IssueMetadataFieldName[] = [];
 
+  // 解除・全削除は ID 解決が不要なため metadata / user の fetch を伴わずに送信する。
+  // fetch が必要なのは非空の名前を ID に解決する場合だけであり、クリア操作が
+  // 無関係な fetch の失敗に巻き込まれてブロックされることも防ぐ (NFR-SYNC-002)
+
   if (changes.assignees) {
-    const userIdMap = await deps.getUserIdMap();
-    const unresolved = task.assignees.filter((login) => !userIdMap.has(login));
-    if (unresolved.length > 0) {
-      console.warn(
-        `  ⚠ assignee が解決できないため assignees の更新をスキップ (${task.id}): ${unresolved.join(", ")}`,
-      );
-      failedFields.push("assignees");
+    if (task.assignees.length === 0) {
+      fields.assigneeIds = [];
     } else {
-      fields.assigneeIds = task.assignees.map((login) => userIdMap.get(login)!);
+      const userIdMap = await deps.getUserIdMap();
+      const unresolved = task.assignees.filter((login) => !userIdMap.has(login));
+      if (unresolved.length > 0) {
+        console.warn(
+          `  ⚠ assignee が解決できないため assignees の更新をスキップ (${task.id}): ${unresolved.join(", ")}`,
+        );
+        failedFields.push("assignees");
+      } else {
+        fields.assigneeIds = task.assignees.map((login) => userIdMap.get(login)!);
+      }
     }
   }
 
-  if (changes.labels || changes.milestone) {
-    const metadata = await deps.getRepositoryMetadata();
-
-    if (changes.labels) {
+  if (changes.labels) {
+    if (task.labels.length === 0) {
+      fields.labelIds = [];
+    } else {
+      const metadata = await deps.getRepositoryMetadata();
       const unresolved = task.labels.filter((name) => !metadata.labelMap.has(name));
       if (unresolved.length > 0) {
         console.warn(
@@ -1195,21 +1204,22 @@ async function resolveIssueMetadataUpdate(
         fields.labelIds = task.labels.map((name) => metadata.labelMap.get(name)!);
       }
     }
+  }
 
-    if (changes.milestone) {
-      if (task.milestone === null) {
-        // ローカルで milestone が解除された場合は null を明示的に送信して解除する
-        fields.milestoneId = null;
+  if (changes.milestone) {
+    if (task.milestone === null) {
+      // ローカルで milestone が解除された場合は null を明示的に送信して解除する
+      fields.milestoneId = null;
+    } else {
+      const metadata = await deps.getRepositoryMetadata();
+      const milestoneId = metadata.milestoneMap.get(task.milestone);
+      if (milestoneId === undefined) {
+        console.warn(
+          `  ⚠ milestone が解決できないため milestone の更新をスキップ (${task.id}): ${task.milestone}`,
+        );
+        failedFields.push("milestone");
       } else {
-        const milestoneId = metadata.milestoneMap.get(task.milestone);
-        if (milestoneId === undefined) {
-          console.warn(
-            `  ⚠ milestone が解決できないため milestone の更新をスキップ (${task.id}): ${task.milestone}`,
-          );
-          failedFields.push("milestone");
-        } else {
-          fields.milestoneId = milestoneId;
-        }
+        fields.milestoneId = milestoneId;
       }
     }
   }

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -21,6 +21,7 @@ import {
   fetchRepositoryMetadata,
   fetchUserIds,
   fetchOrgIssueTypes,
+  type RepositoryMetadata,
 } from "../github/projects.js";
 import { buildIssueUpdatedAtQuery } from "../github/queries.js";
 import { getToken } from "../github/auth.js";
@@ -37,6 +38,7 @@ import {
   createGithubMilestone,
   addBlockedByIssue,
   removeBlockedByIssue,
+  type UpdateIssueFields,
 } from "../github/mutations.js";
 import { formatError } from "../util/format.js";
 
@@ -168,6 +170,16 @@ export async function executePush(
 
   const fm = config.sync.field_mapping;
   const { owner, repo } = config.project.github;
+
+  // repository metadata (labelMap / milestoneMap) の遅延 fetch キャッシュ。
+  // draft 作成経路と既存 Issue の metadata 更新経路 (#305) で共有し、
+  // metadata 変更がない push では fetch しない (NFR-SYNC-002)
+  let repositoryMetadataPromise: Promise<RepositoryMetadata> | null = null;
+  const getRepositoryMetadata = (): Promise<RepositoryMetadata> => {
+    repositoryMetadataPromise ??= fetchRepositoryMetadata(gql, owner, repo);
+    return repositoryMetadataPromise;
+  };
+
   let issueTypeIdByName: Map<string, string> | undefined;
   const usesGithubIssueTypes = Object.values(config.task_types).some((t) => t.github_issue_type);
 
@@ -201,8 +213,15 @@ export async function executePush(
   interface IssueTypeFailure {
     previousSyncFields: SyncFields | undefined;
   }
+  interface MetadataFailure {
+    fields: IssueMetadataFieldName[];
+    previousSyncFields: SyncFields | undefined;
+  }
   const failedRelations = new Map<string, RelationFailure>();
   const failedIssueTypes = new Map<string, IssueTypeFailure>();
+  // 未解決名 (label / assignee / milestone) により送信をスキップしたフィールドの記録 (#305)。
+  // snapshot 更新時に該当フィールドだけ旧値へロールバックし、次回 push で再試行可能にする
+  const failedMetadata = new Map<string, MetadataFailure>();
   // Pre-relation baseline: remote state before relation mutations were attempted
   const preRelationBaseline = new Map<
     string,
@@ -278,7 +297,7 @@ export async function executePush(
 
     const [repositoryId, metadata, userIdMap] = await Promise.all([
       fetchRepositoryId(gql, owner, repo),
-      fetchRepositoryMetadata(gql, owner, repo),
+      getRepositoryMetadata(),
       fetchUserIds(gql, [...allAssignees]),
     ]);
     const createdTaskIds: string[] = [];
@@ -544,6 +563,23 @@ export async function executePush(
     result.skipped += draftDiffs.length;
   }
 
+  // 既存 Issue の assignees 変更に必要な login を事前収集し、
+  // 1 回の fetchUserIds でまとめて解決する (NFR-SYNC-002)。
+  // 変更がない場合は fetch 自体を行わない
+  const assigneeLoginsToResolve = new Set<string>();
+  for (const diff of existingDiffs) {
+    if (diff.type === "deleted") continue;
+    const previous = syncState.snapshots[diff.id]?.syncFields;
+    if (detectIssueMetadataChanges(diff.task, previous).assignees) {
+      for (const login of diff.task.assignees) assigneeLoginsToResolve.add(login);
+    }
+  }
+  let updateUserIdMapPromise: Promise<Map<string, string>> | null = null;
+  const getUpdateUserIdMap = (): Promise<Map<string, string>> => {
+    updateUserIdMapPromise ??= fetchUserIds(gql, [...assigneeLoginsToResolve]);
+    return updateUserIdMapPromise;
+  };
+
   // Process existing task updates
   for (const diff of existingDiffs) {
     if (diff.type === "deleted") {
@@ -559,16 +595,30 @@ export async function executePush(
     }
 
     if (diff.type === "modified" || diff.type === "added") {
+      const snapshot = syncState.snapshots[task.id];
       if (idEntry.issue_node_id) {
+        // assignees / labels / milestone は置換セマンティクスのため、
+        // snapshot と差分があるフィールドだけを updateIssue に含める (#305)
+        const metadataUpdate = await resolveIssueMetadataUpdate(task, snapshot?.syncFields, {
+          getRepositoryMetadata,
+          getUserIdMap: getUpdateUserIdMap,
+        });
+        if (metadataUpdate.failedFields.length > 0) {
+          failedMetadata.set(task.id, {
+            fields: metadataUpdate.failedFields,
+            previousSyncFields: snapshot?.syncFields,
+          });
+        }
+
         const issueMutations: Promise<unknown>[] = [
           updateIssue(gql, idEntry.issue_node_id, {
             title: task.title,
             body: serializeTaskBodyForGithub(task),
+            ...metadataUpdate.fields,
           }),
           setIssueState(gql, idEntry.issue_node_id, task.state),
         ];
 
-        const snapshot = syncState.snapshots[task.id];
         if (usesGithubIssueTypes && snapshot?.syncFields?.type !== task.type) {
           const issueTypeId = await resolveGithubIssueTypeId(task.type);
           if (issueTypeId !== undefined) {
@@ -645,7 +695,6 @@ export async function executePush(
         }
       }
 
-      const snapshot = syncState.snapshots[task.id];
       if (idEntry.issue_node_id) {
         // Capture pre-mutation baseline for rollback on failure
         preRelationBaseline.set(task.id, {
@@ -809,6 +858,35 @@ export async function executePush(
         }
       }
 
+      // 未解決名により送信をスキップした metadata フィールドは snapshot を旧値に
+      // 留めることで computeLocalDiff が次回 push でも差分として検出できるようにする (#305)
+      const metadataFailure = failedMetadata.get(id);
+      if (metadataFailure) {
+        if (metadataFailure.previousSyncFields) {
+          if (metadataFailure.fields.includes("assignees")) {
+            syncFields = { ...syncFields, assignees: metadataFailure.previousSyncFields.assignees };
+          }
+          if (metadataFailure.fields.includes("labels")) {
+            syncFields = { ...syncFields, labels: metadataFailure.previousSyncFields.labels };
+          }
+          if (metadataFailure.fields.includes("milestone")) {
+            syncFields = { ...syncFields, milestone: metadataFailure.previousSyncFields.milestone };
+          }
+        } else {
+          // 旧値が不明 (snapshot なし) の場合は snapshot を進めず次回 push で再試行する
+          if (existing) {
+            newSnapshots[id] = {
+              ...existing,
+              synced_at: new Date().toISOString(),
+              updated_at: freshMetadata?.updatedAt ?? existing.updated_at,
+            };
+          } else {
+            delete newSnapshots[id];
+          }
+          continue;
+        }
+      }
+
       // If relationship mutations partially failed, roll back only the failed fields
       // to the pre-mutation baseline so computeLocalDiff detects the diff on next push
       const relationFailure = failedRelations.get(id);
@@ -825,7 +903,7 @@ export async function executePush(
       }
 
       // Hash must match syncFields so diff detection works correctly
-      const hasRetryableFailure = Boolean(issueTypeFailure || relationFailure);
+      const hasRetryableFailure = Boolean(issueTypeFailure || relationFailure || metadataFailure);
       const snapshotHash = hasRetryableFailure ? hashSyncFields(syncFields) : hashTask(task);
 
       newSnapshots[id] = {
@@ -1018,6 +1096,125 @@ function buildDateFieldUpdate(
  */
 function normalizeDateValue(value: string | null | undefined): string | null {
   return value === null || value === undefined || value === "" ? null : value;
+}
+
+/** updateIssue で送信する Issue metadata フィールドの名前 (#305) */
+type IssueMetadataFieldName = "assignees" | "labels" | "milestone";
+
+/** 2 つの文字列配列をソート済み集合として比較する (assignees / labels 用) */
+function stringArraysEqualSorted(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+interface IssueMetadataChanges {
+  assignees: boolean;
+  labels: boolean;
+  milestone: boolean;
+}
+
+/**
+ * snapshot (syncFields) と比較して assignees / labels / milestone に変更があるか判定する (#305)。
+ *
+ * snapshot が無い場合 (非 draft の added 経路) はリモートの既存値が不明なため、
+ * ローカルに値があるフィールドだけを変更ありとして扱う。
+ * 空のフィールドを置換セマンティクスで送るとリモート値を意図せず剥がすため送らない。
+ */
+function detectIssueMetadataChanges(
+  task: Task,
+  previous: SyncFields | undefined,
+): IssueMetadataChanges {
+  if (!previous) {
+    return {
+      assignees: task.assignees.length > 0,
+      labels: task.labels.length > 0,
+      milestone: task.milestone !== null,
+    };
+  }
+  return {
+    assignees: !stringArraysEqualSorted(task.assignees, previous.assignees),
+    labels: !stringArraysEqualSorted(task.labels, previous.labels),
+    milestone: task.milestone !== previous.milestone,
+  };
+}
+
+interface IssueMetadataUpdateResult {
+  /** updateIssue に渡す解決済みフィールド (変更がないフィールドはキー自体を含めない) */
+  fields: Pick<UpdateIssueFields, "assigneeIds" | "labelIds" | "milestoneId">;
+  /** 未解決名により送信をスキップしたフィールド */
+  failedFields: IssueMetadataFieldName[];
+}
+
+/**
+ * 既存 Issue の assignees / labels / milestone の変更を updateIssue 用に解決する (#305)。
+ *
+ * - snapshot と差分があるフィールドだけを対象にする (不要な API 負荷と意図しない置換を避ける)
+ * - assigneeIds / labelIds は全置換のため、1 つでも未解決名があるフィールドは
+ *   送信をスキップして警告を出す (silent drop するとリモートの値が剥がれる)
+ * - milestone のローカル null 化は milestoneId: null で解除として送信する
+ * - metadata の fetch は変更があるフィールドの解決に必要な場合だけ行う (NFR-SYNC-002)
+ */
+async function resolveIssueMetadataUpdate(
+  task: Task,
+  previous: SyncFields | undefined,
+  deps: {
+    getRepositoryMetadata: () => Promise<RepositoryMetadata>;
+    getUserIdMap: () => Promise<Map<string, string>>;
+  },
+): Promise<IssueMetadataUpdateResult> {
+  const changes = detectIssueMetadataChanges(task, previous);
+  const fields: IssueMetadataUpdateResult["fields"] = {};
+  const failedFields: IssueMetadataFieldName[] = [];
+
+  if (changes.assignees) {
+    const userIdMap = await deps.getUserIdMap();
+    const unresolved = task.assignees.filter((login) => !userIdMap.has(login));
+    if (unresolved.length > 0) {
+      console.warn(
+        `  ⚠ assignee が解決できないため assignees の更新をスキップ (${task.id}): ${unresolved.join(", ")}`,
+      );
+      failedFields.push("assignees");
+    } else {
+      fields.assigneeIds = task.assignees.map((login) => userIdMap.get(login)!);
+    }
+  }
+
+  if (changes.labels || changes.milestone) {
+    const metadata = await deps.getRepositoryMetadata();
+
+    if (changes.labels) {
+      const unresolved = task.labels.filter((name) => !metadata.labelMap.has(name));
+      if (unresolved.length > 0) {
+        console.warn(
+          `  ⚠ label が解決できないため labels の更新をスキップ (${task.id}): ${unresolved.join(", ")}`,
+        );
+        failedFields.push("labels");
+      } else {
+        fields.labelIds = task.labels.map((name) => metadata.labelMap.get(name)!);
+      }
+    }
+
+    if (changes.milestone) {
+      if (task.milestone === null) {
+        // ローカルで milestone が解除された場合は null を明示的に送信して解除する
+        fields.milestoneId = null;
+      } else {
+        const milestoneId = metadata.milestoneMap.get(task.milestone);
+        if (milestoneId === undefined) {
+          console.warn(
+            `  ⚠ milestone が解決できないため milestone の更新をスキップ (${task.id}): ${task.milestone}`,
+          );
+          failedFields.push("milestone");
+        } else {
+          fields.milestoneId = milestoneId;
+        }
+      }
+    }
+  }
+
+  return { fields, failedFields };
 }
 
 function buildEstimateHoursFieldUpdate(


### PR DESCRIPTION
## Summary

- `updateIssue` が title/body しか送信せず、既存 Issue への assignees / labels / milestone のローカル変更が push されず pull で巻き戻されていたバグ(#305、ADR-018 の pull-only ギャップ)を修正
- `UPDATE_ISSUE_MUTATION` を assigneeIds / labelIds / milestoneId 対応に拡張(未指定 = 変更なし、`milestoneId: null` = 解除)
- **置換セマンティクス対策**: snapshot(syncFields)と差分があるフィールドのみ送信(順序非依存比較)。未解決名を含むフィールドはフィールド単位でスキップ + 警告し、snapshot を旧値に留めて次回 push で再試行(failedRelations/failedIssueTypes と同型の retryable 設計)
- 空配列 = 全削除の契約をテストで固定。metadata fetch は draft 経路と共有の遅延キャッシュ + assignee 事前スキャンで API 効率を維持(NFR-SYNC-002)
- requirements.yaml に FR-SYNC-003-AC5 と NFR-STABILITY-002-AC4 を追加

## レビュー経緯(dev-role)

- executor: 9/9 passed(1028 tests green、req:trace 冪等)
- reviewer: **approve (10/8)**。剥がし事故の全経路(部分解決・大小文字・混在・キー不在)と null/undefined 区別、rollback の NFR-SYNC-001 整合、fetch 集約を実コードで裏取り。minor(空配列契約テスト)は 41096f3 で対応済み

Closes #305

## Test plan

- [x] push-executor.test.ts [FR-SYNC-003-AC5] 9 tests(送信・スキップ・置換内容・未解決名警告・空配列全削除)
- [x] regressions/issue-305-metadata-push.test.ts [NFR-STABILITY-002-AC4] [Issue #305] 4 tests
- [x] pnpm typecheck / test:json(1028+ tests) / build / req:trace(冪等) / req:validate / docs:gen green