### PR TITLE
fix(sync): Status フィールドの変更を push で ProjectV2 に反映する

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -68,6 +68,11 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/push-executor.test.ts
+          - id: FR-SYNC-003-AC6
+            description: Status (custom_fields[statuses.field_name]) の変更 (null 化によるクリアを含む) を push で ProjectV2 の Status フィールドに反映できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/push-executor.test.ts
       - id: FR-SYNC-004
         summary: リモートデータからローカルタスクへのマッピング
         acceptance_criteria:
@@ -1085,6 +1090,16 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-305-metadata-push.test.ts
+          - id: NFR-STABILITY-002-AC5
+            description: |
+              ローカルで変更された Status (custom_fields[statuses.field_name]) が
+              push で無言のまま巻き戻されず ProjectV2 の Status フィールドに
+              反映される。option として解決できない Status 値は silent drop せず
+              警告を出してスキップし、snapshot を旧値に留めて次回 push で
+              再試行できる (regression #303)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
       - id: NFR-STABILITY-003
         summary: Org 環境と個人環境の両方で主要 CLI コマンドが動作する
         acceptance_criteria:

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -1978,6 +1978,220 @@ describe("executePush", () => {
     });
   });
 
+  describe("[FR-SYNC-003-AC6] Status フィールドの変更を push で ProjectV2 に反映できる", () => {
+    /** Status フィールドの field_ids / option_ids を持つ既存 Issue 1 件の syncState を構築する */
+    function makeStatusSyncState(previousTask: Task): SyncState {
+      return {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+        },
+        field_ids: { Status: "FIELD_STATUS" },
+        option_ids: {
+          Status: { Todo: "OPT_TODO", "In Progress": "OPT_IN_PROGRESS", Done: "OPT_DONE" },
+        },
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(previousTask),
+            synced_at: "",
+            syncFields: extractSyncFields(previousTask),
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        },
+      };
+    }
+
+    function makeStatusTasksFile(task: Task): TasksFile {
+      return { tasks: [task], cache: { comments: {}, reactions: {} } };
+    }
+
+    /** updateProjectV2ItemFieldValue / clearProjectV2ItemFieldValue の呼び出し変数を記録する handlers */
+    function makeFieldRecorder(recorded: { updated: any[]; cleared: any[] }) {
+      return {
+        updateProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          recorded.updated.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+        clearProjectV2ItemFieldValue: async (_q: string, vars: any) => {
+          recorded.cleared.push(vars);
+          return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+        },
+      };
+    }
+
+    it("Status の変更は singleSelectOptionId に解決して updateProjectV2ItemFieldValue で送信する", async () => {
+      const recorded = { updated: [] as any[], cleared: [] as any[] };
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "Todo" },
+      });
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "In Progress" },
+      });
+
+      const mockGql = makeMockGql(makeFieldRecorder(recorded));
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeStatusTasksFile(task),
+        makeStatusSyncState(previousTask),
+      );
+
+      expect(recorded.updated).toContainEqual(
+        expect.objectContaining({
+          fieldId: "FIELD_STATUS",
+          value: { singleSelectOptionId: "OPT_IN_PROGRESS" },
+        }),
+      );
+    });
+
+    it("Status に差分がなければ Status フィールドの update を送信しない (偽 push の回避)", async () => {
+      const recorded = { updated: [] as any[], cleared: [] as any[] };
+      // Status は同一のままタイトルだけ変更する
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "Todo" },
+      });
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        title: "更新後のタイトル",
+        custom_fields: { Status: "Todo" },
+      });
+
+      const mockGql = makeMockGql(makeFieldRecorder(recorded));
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeStatusTasksFile(task),
+        makeStatusSyncState(previousTask),
+      );
+
+      expect(recorded.updated).not.toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+      );
+      expect(recorded.cleared).not.toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+      );
+    });
+
+    it("Status の null 化 (以前の値あり) は clearProjectV2ItemFieldValue でクリアする", async () => {
+      const recorded = { updated: [] as any[], cleared: [] as any[] };
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "Todo" },
+      });
+      // 3-way merge 等でローカルの Status キーが失われた状態
+      const task = makeTask("o/r#1", { github_issue: 1, custom_fields: {} });
+
+      const mockGql = makeMockGql(makeFieldRecorder(recorded));
+      await executePush(
+        mockGql as any,
+        makeConfig(),
+        makeStatusTasksFile(task),
+        makeStatusSyncState(previousTask),
+      );
+
+      expect(recorded.cleared).toContainEqual(expect.objectContaining({ fieldId: "FIELD_STATUS" }));
+    });
+
+    it("未解決の Status 値は送信をスキップして警告し、snapshot の Status を旧値に留める", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const recorded = { updated: [] as any[], cleared: [] as any[] };
+        const previousTask = makeTask("o/r#1", {
+          github_issue: 1,
+          custom_fields: { Status: "Todo" },
+        });
+        const task = makeTask("o/r#1", {
+          github_issue: 1,
+          custom_fields: { Status: "no-such-status" },
+        });
+
+        const mockGql = makeMockGql(makeFieldRecorder(recorded));
+        const { syncState: newSyncState } = await executePush(
+          mockGql as any,
+          makeConfig(),
+          makeStatusTasksFile(task),
+          makeStatusSyncState(previousTask),
+        );
+
+        // Status の update / clear は送信されない
+        expect(recorded.updated).not.toContainEqual(
+          expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+        );
+        expect(recorded.cleared).not.toContainEqual(
+          expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+        );
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("option として解決できない"));
+        // snapshot の Status は旧値に留まり、次回 push で差分として再検出される
+        expect(newSyncState.snapshots["o/r#1"].syncFields?.custom_fields).toEqual({
+          Status: "Todo",
+        });
+        const retryDiffs = computeLocalDiff([task], newSyncState);
+        expect(retryDiffs).toContainEqual(
+          expect.objectContaining({ id: "o/r#1", type: "modified" }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("draft 新規作成経路でも Status が設定されていれば作成直後に送信する", async () => {
+      const recorded: any[] = [];
+      const draft = makeTask("o/r#draft-1", {
+        custom_fields: { Status: "In Progress" },
+      });
+      const tasksFile: TasksFile = {
+        tasks: [draft],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {},
+        field_ids: { Status: "FIELD_STATUS" },
+        option_ids: { Status: { "In Progress": "OPT_IN_PROGRESS" } },
+        snapshots: {},
+      };
+
+      const mockGql = vi.fn().mockImplementation(async (query: string, vars?: any) => {
+        if (query.includes("createIssue")) {
+          return { createIssue: { issue: { id: "ISSUE_99", number: 99 } } };
+        }
+        if (query.includes("addProjectV2ItemById")) {
+          return { addProjectV2ItemById: { item: { id: "ITEM_99" } } };
+        }
+        if (query.includes("updateProjectV2ItemFieldValue")) {
+          recorded.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_99" } } };
+        }
+        if (query.includes("labels") || query.includes("milestones")) {
+          return { repository: { labels: { nodes: [] }, milestones: { nodes: [] } } };
+        }
+        if (query.includes("repository(")) {
+          return { repository: { id: "REPO_1" } };
+        }
+        if (query.includes("issue(number:")) {
+          return makeBatchIssueResponse(extractBatchIssueNumbers(query));
+        }
+        return {};
+      });
+
+      const { result } = await executePush(mockGql as any, makeConfig(), tasksFile, syncState);
+
+      expect(result.created).toBe(1);
+      expect(recorded).toContainEqual(
+        expect.objectContaining({
+          itemId: "ITEM_99",
+          fieldId: "FIELD_STATUS",
+          value: { singleSelectOptionId: "OPT_IN_PROGRESS" },
+        }),
+      );
+    });
+  });
+
   describe("[NFR-SYNC-001-AC1] push 中に API エラーが発生しても snapshot が不整合にならない", () => {
     it("relation failure preserves old syncFields and enables retry via computeLocalDiff", async () => {
       const parentTask = makeTask("o/r#10", { github_issue: 10 });

--- a/packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
@@ -236,6 +236,81 @@ describe("[NFR-STABILITY-002-AC5] [Issue #303] Status 変更が push で Project
     }
   });
 
+  it("draft 作成時に未解決の Status は snapshot をキーなしで確定し、次回 push で再試行される", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const recorded = { cleared: [] as any[], updated: [] as any[] };
+      // draft タスクに ProjectV2 の option として存在しない Status が設定されている
+      const task = makeTask("o/r#draft-1", {
+        custom_fields: { Status: "no-such-status" },
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "",
+        project_node_id: "PVT_1",
+        id_map: {},
+        field_ids: { Status: "FIELD_STATUS" },
+        option_ids: { Status: { Todo: "OPT_TODO" } },
+        snapshots: {},
+      };
+
+      const mockGql = vi.fn().mockImplementation(async (query: string, vars?: any) => {
+        if (query.includes("createIssue(input")) {
+          return { createIssue: { issue: { id: "ISSUE_NEW", number: 99 } } };
+        }
+        if (query.includes("addProjectV2ItemById")) {
+          return { addProjectV2ItemById: { item: { id: "ITEM_NEW" } } };
+        }
+        if (query.includes("updateProjectV2ItemFieldValue")) {
+          recorded.updated.push(vars);
+          return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_NEW" } } };
+        }
+        if (query.includes("clearProjectV2ItemFieldValue")) {
+          recorded.cleared.push(vars);
+          return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_NEW" } } };
+        }
+        if (query.includes("labels(")) {
+          return {
+            repository: { labels: { nodes: [] }, milestones: { nodes: [] } },
+          };
+        }
+        if (query.includes("repository(owner")) {
+          return { repository: { id: "REPO_1" } };
+        }
+        return {};
+      });
+
+      const { syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        syncState,
+      );
+
+      // Status は送信されず警告が出る
+      expect(recorded.updated).not.toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("option として解決できない"));
+
+      // snapshot は「リモートに Status がない」実態に合わせてキーなしで確定する
+      // (ローカル値のまま確定すると差分が消えて再試行不能になるリグレッション)
+      const snapshot = newSyncState.snapshots["o/r#99"];
+      expect(snapshot.syncFields?.custom_fields).not.toHaveProperty("Status");
+
+      // 次回 push でローカルの Status が差分として再検出される
+      const retryDiffs = computeLocalDiff(tasksFile.tasks, newSyncState);
+      expect(retryDiffs).toContainEqual(
+        expect.objectContaining({ id: "o/r#99", type: "modified" }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("Status に差分がなければ Status フィールドの API コールを行わない", async () => {
     const recorded = { cleared: [] as any[], updated: [] as any[] };
     // Status は同一のままタイトルだけ変更する

--- a/packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Issue #303: push が ProjectV2 の Status フィールドを更新せず一方向 (pull-only) になっている
+ *
+ * push-executor の updateProjectItemField 呼び出しは start_date / end_date / type /
+ * priority / estimate_hours のみを対象としており、ProjectV2 の Status フィールド
+ * (task.custom_fields[config.statuses.field_name] に保持) を書き込む経路が存在しなかった。
+ * その結果 `gh-gantt update <id> --status "In Progress"` でローカルの Status を変更しても
+ * push で GitHub に反映されず、pull でリモート値に巻き戻されていた。
+ *
+ * 修正: config.statuses.field_name のフィールドについて、snapshot (syncFields) の
+ * custom_fields と差分がある場合のみ updateProjectV2ItemFieldValue を
+ * singleSelectOptionId で送信する。option 名 → ID の解決には pull 時に保存済みの
+ * syncState.option_ids を使い、未解決名は #305 のパターン (警告 + フィールド単位スキップ +
+ * snapshot 旧値維持) に従う。null 化は #306 のパターンでフィールドクリアとして送信する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Config, Task, TasksFile, SyncState } from "@gh-gantt/shared";
+import { computeLocalDiff } from "../../sync/diff.js";
+import { extractSyncFields, hashTask } from "../../sync/hash.js";
+import { executePush } from "../../sync/push-executor.js";
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "o/r",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${id}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "",
+    updated_at: "",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(): Config {
+  return {
+    version: "1",
+    project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+    sync: {
+      auto_create_issues: true,
+      field_mapping: { start_date: "Start Date", end_date: "End Date", status: "Status" },
+    },
+    task_types: {},
+    type_hierarchy: {},
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "", on_track: "", at_risk: "", overdue: "" },
+    },
+  } as Config;
+}
+
+function makeBatchIssueResponse(query: string): any {
+  const matches = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)];
+  const repository: Record<string, any> = {};
+  matches.forEach((match, index) => {
+    repository[`i${index}`] = {
+      number: Number(match[1]),
+      updatedAt: "2026-01-01T00:00:00Z",
+      stateReason: null,
+      closedAt: null,
+    };
+  });
+  return { repository };
+}
+
+/** updateProjectV2ItemFieldValue / clearProjectV2ItemFieldValue の呼び出しを記録する mock gql */
+function makeMockGql(recorded: { cleared: any[]; updated: any[] }) {
+  return vi.fn().mockImplementation(async (query: string, vars?: any) => {
+    if (query.includes("issue(number:") && !query.includes("mutation")) {
+      return makeBatchIssueResponse(query);
+    }
+    if (query.includes("updateIssue")) {
+      return { updateIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("closeIssue")) {
+      return { closeIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("reopenIssue")) {
+      return { reopenIssue: { issue: { id: "ISSUE_1" } } };
+    }
+    if (query.includes("updateProjectV2ItemFieldValue")) {
+      recorded.updated.push(vars);
+      return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+    }
+    if (query.includes("clearProjectV2ItemFieldValue")) {
+      recorded.cleared.push(vars);
+      return { clearProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_1" } } };
+    }
+    return {};
+  });
+}
+
+function makeSyncState(previousTask: Task): SyncState {
+  return {
+    last_synced_at: "",
+    project_node_id: "PVT_1",
+    id_map: {
+      "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+    },
+    field_ids: { Status: "FIELD_STATUS" },
+    option_ids: {
+      Status: { Todo: "OPT_TODO", "In Progress": "OPT_IN_PROGRESS", Done: "OPT_DONE" },
+    },
+    snapshots: {
+      "o/r#1": {
+        hash: hashTask(previousTask),
+        synced_at: "",
+        syncFields: extractSyncFields(previousTask),
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    },
+  };
+}
+
+describe("[NFR-STABILITY-002-AC5] [Issue #303] Status 変更が push で ProjectV2 に反映されないリグレッション", () => {
+  it("Status の変更が diff で modified として検出される", () => {
+    // 前回同期時は Todo、ローカルで In Progress に変更
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "Todo" },
+    });
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "In Progress" },
+    });
+
+    const diffs = computeLocalDiff([task], makeSyncState(previousTask));
+
+    expect(diffs).toContainEqual(expect.objectContaining({ id: "o/r#1", type: "modified" }));
+  });
+
+  it("Status の変更が push で ProjectV2 の Status フィールド更新として反映される", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "Todo" },
+    });
+    // `gh-gantt update <id> --status "In Progress"` 相当の状態
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "In Progress" },
+    });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    // 期待: Status フィールドが singleSelectOptionId で更新される
+    expect(recorded.updated).toContainEqual(
+      expect.objectContaining({
+        fieldId: "FIELD_STATUS",
+        value: { singleSelectOptionId: "OPT_IN_PROGRESS" },
+      }),
+    );
+  });
+
+  it("Status の null 化が push で ProjectV2 フィールドクリアとして反映される", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "Todo" },
+    });
+    // 3-way merge 等でローカルの Status キーが失われた状態
+    const task = makeTask("o/r#1", { github_issue: 1, custom_fields: {} });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    expect(recorded.cleared).toContainEqual(expect.objectContaining({ fieldId: "FIELD_STATUS" }));
+  });
+
+  it("未解決の Status 値は silent drop せず警告付きでスキップし、次回 push で再試行される", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const recorded = { cleared: [] as any[], updated: [] as any[] };
+      const previousTask = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "Todo" },
+      });
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        custom_fields: { Status: "no-such-status" },
+      });
+      const tasksFile: TasksFile = {
+        tasks: [task],
+        cache: { comments: {}, reactions: {} },
+      };
+
+      const mockGql = makeMockGql(recorded);
+      const { syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        makeSyncState(previousTask),
+      );
+
+      // Status の update / clear は送信されず、警告が出る
+      expect(recorded.updated).not.toContainEqual(
+        expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+      );
+      expect(recorded.cleared).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("option として解決できない"));
+
+      // snapshot の Status は旧値に留まり、次回 push で差分として再検出される
+      expect(newSyncState.snapshots["o/r#1"].syncFields?.custom_fields).toEqual({
+        Status: "Todo",
+      });
+      const retryDiffs = computeLocalDiff([task], newSyncState);
+      expect(retryDiffs).toContainEqual(expect.objectContaining({ id: "o/r#1", type: "modified" }));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("Status に差分がなければ Status フィールドの API コールを行わない", async () => {
+    const recorded = { cleared: [] as any[], updated: [] as any[] };
+    // Status は同一のままタイトルだけ変更する
+    const previousTask = makeTask("o/r#1", {
+      github_issue: 1,
+      custom_fields: { Status: "Todo" },
+    });
+    const task = makeTask("o/r#1", {
+      github_issue: 1,
+      title: "更新後のタイトル",
+      custom_fields: { Status: "Todo" },
+    });
+    const tasksFile: TasksFile = {
+      tasks: [task],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    const mockGql = makeMockGql(recorded);
+    await executePush(mockGql as any, makeConfig(), tasksFile, makeSyncState(previousTask));
+
+    expect(recorded.updated).not.toContainEqual(
+      expect.objectContaining({ fieldId: "FIELD_STATUS" }),
+    );
+    expect(recorded.cleared).toEqual([]);
+  });
+});

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -398,9 +398,7 @@ export async function executePush(
       );
       if (estimateHoursUpdate) draftFieldUpdates.push(estimateHoursUpdate);
 
-      // Status フィールド (single-select) の設定 (#303)。
-      // 新規作成 Issue にはリモート値が存在しないため、未解決名は警告のみで
-      // snapshot ロールバックは行わない (draft の labels / assignees と同一挙動)
+      // Status フィールド (single-select) の設定 (#303)
       const draftStatusUpdate = resolveStatusFieldUpdate(
         gql,
         config,
@@ -419,6 +417,23 @@ export async function executePush(
       task.id = newId;
       task.github_issue = issueNumber;
       task.github_repo = `${owner}/${repo}`;
+
+      // 未解決の Status を送信しないまま snapshot をローカル値で確定すると
+      // 次回 push が差分を検出できず再試行不能になるため、snapshot 側は
+      // 「リモートに Status がない」実態 (キーなし) に合わせて確定させる
+      if (draftStatusUpdate.unresolved) {
+        const fieldsNow = extractSyncFields(task);
+        failedStatus.set(newId, {
+          previousSyncFields: {
+            ...fieldsNow,
+            custom_fields: rollbackCustomFieldValue(
+              fieldsNow.custom_fields,
+              config.statuses.field_name,
+              undefined,
+            ),
+          },
+        });
+      }
 
       // Update references in all tasks
       replaceTaskIdReferences(tasksFile.tasks, oldId, newId);

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -217,11 +217,17 @@ export async function executePush(
     fields: IssueMetadataFieldName[];
     previousSyncFields: SyncFields | undefined;
   }
+  interface StatusFailure {
+    previousSyncFields: SyncFields | undefined;
+  }
   const failedRelations = new Map<string, RelationFailure>();
   const failedIssueTypes = new Map<string, IssueTypeFailure>();
   // 未解決名 (label / assignee / milestone) により送信をスキップしたフィールドの記録 (#305)。
   // snapshot 更新時に該当フィールドだけ旧値へロールバックし、次回 push で再試行可能にする
   const failedMetadata = new Map<string, MetadataFailure>();
+  // 未解決の Status 値により送信をスキップしたタスクの記録 (#303)。
+  // failedMetadata と同じく snapshot の Status だけ旧値へロールバックして次回 push で再試行する
+  const failedStatus = new Map<string, StatusFailure>();
   // Pre-relation baseline: remote state before relation mutations were attempted
   const preRelationBaseline = new Map<
     string,
@@ -391,6 +397,19 @@ export async function executePush(
         task,
       );
       if (estimateHoursUpdate) draftFieldUpdates.push(estimateHoursUpdate);
+
+      // Status フィールド (single-select) の設定 (#303)。
+      // 新規作成 Issue にはリモート値が存在しないため、未解決名は警告のみで
+      // snapshot ロールバックは行わない (draft の labels / assignees と同一挙動)
+      const draftStatusUpdate = resolveStatusFieldUpdate(
+        gql,
+        config,
+        syncState,
+        projectItemId,
+        task,
+        syncState.snapshots[task.id]?.syncFields,
+      );
+      if (draftStatusUpdate.promise) draftFieldUpdates.push(draftStatusUpdate.promise);
       if (draftFieldUpdates.length > 0) {
         await Promise.all(draftFieldUpdates);
       }
@@ -690,6 +709,21 @@ export async function executePush(
         );
         if (estimateHoursUpdate) fieldUpdates.push(estimateHoursUpdate);
 
+        // Status フィールド (single-select) の更新 (#303)。
+        // 未解決名は送信をスキップし、snapshot の Status を旧値に留めて次回 push で再試行する
+        const statusUpdate = resolveStatusFieldUpdate(
+          gql,
+          config,
+          syncState,
+          idEntry.project_item_id,
+          task,
+          snapshot?.syncFields,
+        );
+        if (statusUpdate.promise) fieldUpdates.push(statusUpdate.promise);
+        if (statusUpdate.unresolved) {
+          failedStatus.set(task.id, { previousSyncFields: snapshot?.syncFields });
+        }
+
         if (fieldUpdates.length > 0) {
           await Promise.all(fieldUpdates);
         }
@@ -887,6 +921,35 @@ export async function executePush(
         }
       }
 
+      // 未解決の Status 値により送信をスキップした場合は snapshot の Status を旧値に
+      // 留めることで computeLocalDiff が次回 push でも差分として検出できるようにする (#303)
+      const statusFailure = failedStatus.get(id);
+      if (statusFailure) {
+        if (statusFailure.previousSyncFields) {
+          const statusFieldName = config.statuses.field_name;
+          syncFields = {
+            ...syncFields,
+            custom_fields: rollbackCustomFieldValue(
+              syncFields.custom_fields,
+              statusFieldName,
+              statusFailure.previousSyncFields.custom_fields[statusFieldName],
+            ),
+          };
+        } else {
+          // 旧値が不明 (snapshot なし) の場合は snapshot を進めず次回 push で再試行する
+          if (existing) {
+            newSnapshots[id] = {
+              ...existing,
+              synced_at: new Date().toISOString(),
+              updated_at: freshMetadata?.updatedAt ?? existing.updated_at,
+            };
+          } else {
+            delete newSnapshots[id];
+          }
+          continue;
+        }
+      }
+
       // If relationship mutations partially failed, roll back only the failed fields
       // to the pre-mutation baseline so computeLocalDiff detects the diff on next push
       const relationFailure = failedRelations.get(id);
@@ -903,7 +966,9 @@ export async function executePush(
       }
 
       // Hash must match syncFields so diff detection works correctly
-      const hasRetryableFailure = Boolean(issueTypeFailure || relationFailure || metadataFailure);
+      const hasRetryableFailure = Boolean(
+        issueTypeFailure || relationFailure || metadataFailure || statusFailure,
+      );
       const snapshotHash = hasRetryableFailure ? hashSyncFields(syncFields) : hashTask(task);
 
       newSnapshots[id] = {
@@ -1225,6 +1290,90 @@ async function resolveIssueMetadataUpdate(
   }
 
   return { fields, failedFields };
+}
+
+interface StatusFieldUpdateResult {
+  /** 送信する mutation (差分なし・フィールド不在・未解決の場合は null) */
+  promise: Promise<unknown> | null;
+  /** ローカルの Status 値が option 名として解決できず送信をスキップしたか */
+  unresolved: boolean;
+}
+
+/**
+ * Status フィールド (single-select) の ProjectV2 更新 mutation を組み立てる (#303)。
+ *
+ * - 対象フィールド名は config.statuses.field_name (update コマンドの書き込み先と同一)
+ * - 偽 push を避けるため snapshot (syncFields) の custom_fields と差分がある場合のみ送信する
+ * - option 名 → ID の解決には pull 時に保存済みの syncState.option_ids を使う
+ * - ローカルの null 化は snapshot に以前の値があるときだけ clearProjectV2ItemFieldValue で
+ *   クリアする (#306 の日付クリアと同じ判定パターン)
+ * - option 名が解決できない場合は警告を出しフィールド単位でスキップする (#305 の未解決名パターン)
+ */
+function resolveStatusFieldUpdate(
+  gql: typeof graphql,
+  config: Config,
+  syncState: SyncState,
+  projectItemId: string,
+  task: Task,
+  previous: SyncFields | undefined,
+): StatusFieldUpdateResult {
+  const fieldName = config.statuses.field_name;
+  const fieldId = syncState.field_ids[fieldName];
+  if (!fieldId) return { promise: null, unresolved: false };
+
+  const localStatus = normalizeStatusValue(task.custom_fields[fieldName]);
+  const previousStatus = normalizeStatusValue(previous?.custom_fields[fieldName]);
+  if (localStatus === previousStatus) return { promise: null, unresolved: false };
+
+  if (localStatus === null) {
+    // previousStatus は非 null (差分なしの場合は上で除外済み) のためリモート値をクリアする
+    return {
+      promise: clearProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId),
+      unresolved: false,
+    };
+  }
+
+  const optionId = syncState.option_ids?.[fieldName]?.[localStatus];
+  if (!optionId) {
+    console.warn(
+      `  ⚠ Status "${localStatus}" が ProjectV2 の option として解決できないため Status の更新をスキップ (${task.id})`,
+    );
+    return { promise: null, unresolved: true };
+  }
+
+  return {
+    promise: updateProjectItemField(gql, syncState.project_node_id, projectItemId, fieldId, {
+      singleSelectOptionId: optionId,
+    }),
+    unresolved: false,
+  };
+}
+
+/**
+ * Status 値を「クリア意図 (null)」か「設定する option 名」に正規化する。
+ * custom_fields は unknown を許容するため、文字列以外・空文字はクリア意図として扱う。
+ */
+function normalizeStatusValue(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * custom_fields の特定キーだけ旧値へロールバックする (#303)。
+ *
+ * hashSyncFields は JSON.stringify ベースでキーの挿入順序に依存するため、
+ * 既存キーの置換はスプレッドで元の位置を保存し、旧値が存在しない場合はキーを
+ * 削除して extractSyncFields のソート済み出力と順序を一致させる。
+ */
+function rollbackCustomFieldValue(
+  customFields: Record<string, unknown>,
+  key: string,
+  previousValue: unknown,
+): Record<string, unknown> {
+  if (previousValue === undefined) {
+    const { [key]: _removed, ...rest } = customFields;
+    return rest;
+  }
+  return { ...customFields, [key]: previousValue };
 }
 
 function buildEstimateHoursFieldUpdate(


### PR DESCRIPTION
## Summary

- ProjectV2 の Status フィールドが pull 専用の一方向で、`gh-gantt update --status` が push されず pull で巻き戻されていたバグ(#303、ADR-018 レビューで発見された元祖の pull-only ギャップ)を修正
- `resolveStatusFieldUpdate` を追加: snapshot(syncFields)差分がある場合のみ `singleSelectOptionId` で送信(#305/#306 で確立したパターンの合成)。未解決 option 名は警告 + スキップ + snapshot ロールバックで次回 push 再試行。null 化は 3-way merge でキーが失われるケースを考慮しクリアとして送信
- option 名 → ID は pull が保存済みの `syncState.option_ids` を利用(取得経路の追加なし)。既存 Issue 更新と draft 作成の両経路に対応
- フィールド名は `statuses.field_name` を採用(update コマンド・pull と同一)。`sync.field_mapping.status` との二重定義の整理は #315 で追跡
- requirements.yaml に FR-SYNC-003-AC6 / NFR-STABILITY-002-AC5 を追加

これで push 反映 3 部作(#306 日付クリア → #305 metadata → #303 Status)が完結し、ADR-018 キャッシュファースト移行の前提バグがすべて解消されます。

## レビュー経緯(dev-role)

- executor: 9/9 passed(1039 tests green、req:trace 冪等)
- reviewer: **approve (10/8)**。option_ids の pull 側保存の裏取り、snapshot ロールバックの順序依存実装の安全性(到達不能分岐と自己修復性)、draft 経路の二重送信なしを実コードで検証。minor(追跡 Issue 未起票)は #315 起票で対応済み

Closes #303

## Test plan

- [x] push-executor.test.ts [FR-SYNC-003-AC6] 5 tests(送信・差分なしスキップ・未解決名・クリア・draft 経路)
- [x] regressions/issue-303-status-push.test.ts [NFR-STABILITY-002-AC5] [Issue #303] 5 tests
- [x] pnpm typecheck / test:json(1039 tests) / build / req:trace(冪等) / req:validate / docs:gen green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProjectV2 の `Status` が push 時に同期されるようになりました。
  * 値のクリア（null 化）にも対応しました。
* **Bug Fixes**
  * push 後に `Status` が巻き戻る問題を改善しました。
  * 解決できない `Status` は警告を出してスキップし、次回の push で再試行できるようになりました。
* **Tests**
  * `Status` 同期と回帰ケースを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->