### PR TITLE
fix(cli): create --parent の参照を正規化し draft→実Issue 変換での親子関係スキップを解消

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -235,6 +235,14 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/draft-tasks.test.ts
+          - id: FR-CLI-004-AC3
+            description: |
+              create --parent は draft 短縮形・番号・#付きの入力を正規形
+              (owner/repo#N / owner/repo#draft-N) に解決して保存し、
+              存在しない親を指す場合はエラーになる (regression #302)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/create-parent.test.ts
       - id: FR-CLI-005
         summary: マイルストーン管理
         acceptance_criteria:
@@ -1106,6 +1114,15 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-303-status-push.test.ts
+          - id: NFR-STABILITY-002-AC6
+            description: |
+              同一 push 内で draft の親子を一括作成した場合、子の parent 参照が
+              親の新 Issue ID に置換され sub-issue 関係が GitHub に設定される。
+              create --parent の参照は正規形で保存されるため
+              replaceTaskIdReferences / id_map 照合が確実に機能する (regression #302)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-302-draft-parent-ref.test.ts
       - id: NFR-STABILITY-003
         summary: Org 環境と個人環境の両方で主要 CLI コマンドが動作する
         acceptance_criteria:

--- a/packages/cli/src/__tests__/create-parent.test.ts
+++ b/packages/cli/src/__tests__/create-parent.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createCreateCommand } from "../commands/create.js";
+import type { Config, Task, TasksFile } from "@gh-gantt/shared";
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const mockConfig: Config = {
+  version: "1",
+  project: { name: "test", github: { owner: "owner", repo: "repo", project_number: 1 } },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    epic: { label: "Epic", display: "bar", color: "#00f", github_label: "epic" },
+  },
+  type_hierarchy: {},
+  statuses: { field_name: "Status", values: {} },
+  gantt: {
+    default_view: "week",
+    working_days: [1, 2, 3, 4, 5],
+    colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+  },
+};
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    type: "task",
+    github_issue: null,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${id}`,
+    body: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeTasksFile(tasks: Task[] = []): TasksFile {
+  return { tasks, cache: { comments: {}, reactions: {} } };
+}
+
+let currentTasksFile = makeTasksFile();
+let writtenTasksFile: TasksFile | null = null;
+
+vi.mock("../store/config.js", () => ({
+  ConfigStore: class {
+    async read() {
+      return mockConfig;
+    }
+  },
+}));
+
+vi.mock("../store/tasks.js", () => ({
+  TasksStore: class {
+    async read() {
+      return clone(currentTasksFile);
+    }
+
+    async write(data: TasksFile) {
+      writtenTasksFile = clone(data);
+      currentTasksFile = clone(data);
+    }
+  },
+}));
+
+async function runCreate(args: string[]): Promise<void> {
+  await createCreateCommand().parseAsync(args, { from: "user" });
+}
+
+describe("[FR-CLI-004-AC3] create --parent は参照を正規形へ解決して保存する", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    // 親候補: draft と実 Issue の両方を用意する
+    currentTasksFile = makeTasksFile([
+      makeTask("owner/repo#draft-1", { type: "epic" }),
+      makeTask("owner/repo#293", { github_issue: 293 }),
+    ]);
+    writtenTasksFile = null;
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("draft 短縮形 (draft-1) を正規形 owner/repo#draft-1 に解決して保存する", async () => {
+    await runCreate(["--title", "子タスク", "--type", "task", "--parent", "draft-1", "--json"]);
+
+    const created = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-2");
+    expect(created?.parent).toBe("owner/repo#draft-1");
+    // 親の sub_tasks にも正規形の子 ID が追加される
+    const parent = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-1");
+    expect(parent?.sub_tasks).toContain("owner/repo#draft-2");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("番号形式 (293) を正規形 owner/repo#293 に解決して保存する", async () => {
+    await runCreate(["--title", "子タスク", "--type", "task", "--parent", "293", "--json"]);
+
+    const created = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-2");
+    expect(created?.parent).toBe("owner/repo#293");
+    const parent = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#293");
+    expect(parent?.sub_tasks).toContain("owner/repo#draft-2");
+  });
+
+  it("#付き番号形式 (#293) を正規形 owner/repo#293 に解決して保存する", async () => {
+    await runCreate(["--title", "子タスク", "--type", "task", "--parent", "#293", "--json"]);
+
+    const created = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-2");
+    expect(created?.parent).toBe("owner/repo#293");
+  });
+
+  it("完全形 (owner/repo#293) はそのまま保存する", async () => {
+    await runCreate([
+      "--title",
+      "子タスク",
+      "--type",
+      "task",
+      "--parent",
+      "owner/repo#293",
+      "--json",
+    ]);
+
+    const created = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-2");
+    expect(created?.parent).toBe("owner/repo#293");
+  });
+
+  it("存在しないタスクを指す --parent はエラーになりタスクを作成しない", async () => {
+    await runCreate(["--title", "子タスク", "--type", "task", "--parent", "draft-99", "--json"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(writtenTasksFile).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith("Parent task not found: owner/repo#draft-99");
+  });
+
+  it("不正な入力 (foo-bar) は fallback 解決後に存在しない親としてエラーになる", async () => {
+    await runCreate(["--title", "子タスク", "--type", "task", "--parent", "foo-bar", "--json"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(writtenTasksFile).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith("Parent task not found: owner/repo#foo-bar");
+  });
+
+  it("--parent 未指定なら parent は null のまま作成される", async () => {
+    await runCreate(["--title", "単独タスク", "--type", "task", "--json"]);
+
+    const created = writtenTasksFile?.tasks.find((t) => t.id === "owner/repo#draft-2");
+    expect(created?.parent).toBeNull();
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -621,6 +621,60 @@ describe("[NFR-STABILITY-001] doctor コマンド", () => {
     });
   });
 
+  describe("[Issue #302] 宙ぶらりん参照の検出", () => {
+    it("非正規形の parent 参照 (旧 create --parent の残骸) を WARN として検出する", async () => {
+      // 過去の create --parent が生の "draft-1" / "293" を保存していたケースを再現
+      const parent = makeTask("o/r#draft-1");
+      const child1 = makeTask("o/r#draft-2", { parent: "draft-1" });
+      const child2 = makeTask("o/r#draft-3", { parent: "293" });
+
+      testDir = await setupProjectDir({
+        tasksFile: makeTasksFile([parent, child1, child2]),
+      });
+
+      const output = await runDoctorJson(testDir);
+      const check = output.checks.find((c) => c.name === "project-dangling-references");
+
+      expect(check?.status).toBe("WARN");
+      expect(check?.details).toHaveLength(2);
+      expect(check?.details?.[0]).toContain('parent "draft-1" がタスク一覧に存在しません');
+      expect(check?.details?.[1]).toContain('parent "293" がタスク一覧に存在しません');
+    });
+
+    it("存在しない blocked_by / sub_tasks 参照を WARN として検出する", async () => {
+      const task = makeTask("o/r#1", {
+        github_issue: 1,
+        blocked_by: [{ task: "o/r#999", type: "finish-to-start", lag: 0 }],
+        sub_tasks: ["o/r#draft-9"],
+      });
+
+      testDir = await setupProjectDir({ tasksFile: makeTasksFile([task]) });
+
+      const output = await runDoctorJson(testDir);
+      const check = output.checks.find((c) => c.name === "project-dangling-references");
+
+      expect(check?.status).toBe("WARN");
+      expect(check?.details).toHaveLength(2);
+      expect(check?.details?.[0]).toContain('blocked_by "o/r#999" がタスク一覧に存在しません');
+      expect(check?.details?.[1]).toContain('sub_tasks "o/r#draft-9" がタスク一覧に存在しません');
+    });
+
+    it("すべての参照が正規形で解決できる場合は PASS", async () => {
+      const parent = makeTask("o/r#draft-1", { sub_tasks: ["o/r#draft-2"] });
+      const child = makeTask("o/r#draft-2", {
+        parent: "o/r#draft-1",
+        blocked_by: [{ task: "o/r#draft-1", type: "finish-to-start", lag: 0 }],
+      });
+
+      testDir = await setupProjectDir({ tasksFile: makeTasksFile([parent, child]) });
+
+      const output = await runDoctorJson(testDir);
+      const check = output.checks.find((c) => c.name === "project-dangling-references");
+
+      expect(check?.status).toBe("PASS");
+    });
+  });
+
   describe("[FR-CLI-015-AC3] doctor のタスクサイズ閾値チェック", () => {
     it("見積もりが max_task_size_hours を超えた open task を WARN として返す", async () => {
       const config = makeConfig();

--- a/packages/cli/src/__tests__/regressions/issue-302-draft-parent-ref.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-302-draft-parent-ref.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createCreateCommand } from "../../commands/create.js";
+import { createTaskLinkCommand } from "../../commands/task/link.js";
+import { executePush } from "../../sync/push-executor.js";
+import type { Config, SyncState, TasksFile } from "@gh-gantt/shared";
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const mockConfig: Config = {
+  version: "1",
+  project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+  sync: {
+    auto_create_issues: true,
+    field_mapping: { start_date: "Start", end_date: "End", status: "Status" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    epic: { label: "Epic", display: "bar", color: "#00f", github_label: null },
+  },
+  type_hierarchy: {},
+  statuses: { field_name: "Status", values: {} },
+  gantt: {
+    default_view: "week",
+    working_days: [1, 2, 3, 4, 5],
+    colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+  },
+} as Config;
+
+let currentTasksFile: TasksFile = { tasks: [], cache: { comments: {}, reactions: {} } };
+
+vi.mock("../../store/config.js", () => ({
+  ConfigStore: class {
+    async read() {
+      return mockConfig;
+    }
+  },
+}));
+
+vi.mock("../../store/tasks.js", () => ({
+  TasksStore: class {
+    async read() {
+      return clone(currentTasksFile);
+    }
+
+    async write(data: TasksFile) {
+      currentTasksFile = clone(data);
+    }
+  },
+}));
+
+/** create --parent 由来のタイトル → Issue 番号の対応で push 順序に依存しないモックを作る */
+function makeMockGql(recorded: {
+  addSubIssueCalls: Array<{ issueId: string; subIssueId: string }>;
+  addBlockedByCalls: Array<{ issueId: string; blockingIssueId: string }>;
+}) {
+  const titleToNumber: Record<string, number> = {
+    "親 Epic": 294,
+    "子タスク A": 295,
+    "子タスク B": 296,
+  };
+  return vi.fn().mockImplementation(async (query: string, vars?: any) => {
+    if (query.includes("createIssue")) {
+      const n = titleToNumber[vars?.title];
+      if (!n) throw new Error(`予期しない createIssue title: ${vars?.title}`);
+      return { createIssue: { issue: { id: `ISSUE_${n}`, number: n } } };
+    }
+    if (query.includes("addProjectV2ItemById")) {
+      return { addProjectV2ItemById: { item: { id: `ITEM_${vars?.contentId}` } } };
+    }
+    if (query.includes("addSubIssue")) {
+      recorded.addSubIssueCalls.push({ issueId: vars.issueId, subIssueId: vars.subIssueId });
+      return { addSubIssue: { issue: { id: vars.issueId } } };
+    }
+    if (query.includes("addBlockedBy")) {
+      recorded.addBlockedByCalls.push({
+        issueId: vars.issueId,
+        blockingIssueId: vars.blockingIssueId,
+      });
+      return { addBlockedBy: { issue: { id: vars.issueId } } };
+    }
+    if (query.includes("updateProjectV2ItemFieldValue")) {
+      return { updateProjectV2ItemFieldValue: { projectV2Item: { id: "ITEM_X" } } };
+    }
+    // fetchRepositoryMetadata (labels / milestones)
+    if (query.includes("labels") || query.includes("milestones")) {
+      return { repository: { id: "REPO_1", labels: { nodes: [] }, milestones: { nodes: [] } } };
+    }
+    // fetchBatchUpdatedAt (issue(number: N) の alias バッチ)
+    if (query.includes("issue(number:")) {
+      const matches = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)];
+      const repository: Record<string, unknown> = {};
+      matches.forEach((match, index) => {
+        repository[`i${index}`] = {
+          number: Number(match[1]),
+          updatedAt: "2026-01-01T00:00:00Z",
+          stateReason: null,
+          closedAt: null,
+        };
+      });
+      return { repository };
+    }
+    // fetchRepositoryId
+    if (query.includes("repository(")) {
+      return { repository: { id: "REPO_1" } };
+    }
+    return {};
+  });
+}
+
+describe("[NFR-STABILITY-002-AC6] [Issue #302] draft 親子一括 push の parent 参照置換リグレッション", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    currentTasksFile = { tasks: [], cache: { comments: {}, reactions: {} } };
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("create --parent draft-1 で一括作成した親子 draft を push すると parent が新 Issue ID に置換され sub-issue 関係が設定される", async () => {
+    // 再現形 1 (Issue #302): 親 epic + 子タスクを draft 短縮形の --parent で一括作成し、
+    // 子同士の依存を link で設定してから push する
+    await createCreateCommand().parseAsync(["--title", "親 Epic", "--type", "epic", "--json"], {
+      from: "user",
+    });
+    await createCreateCommand().parseAsync(
+      ["--title", "子タスク A", "--type", "task", "--parent", "draft-1", "--json"],
+      { from: "user" },
+    );
+    await createCreateCommand().parseAsync(
+      ["--title", "子タスク B", "--type", "task", "--parent", "draft-1", "--json"],
+      { from: "user" },
+    );
+    await createTaskLinkCommand().parseAsync(["draft-3", "--blocked-by", "draft-2"], {
+      from: "user",
+    });
+    expect(process.exitCode).toBeUndefined();
+
+    // 修正の核: create --parent が生の "draft-1" ではなく正規形で保存していること
+    const childA = currentTasksFile.tasks.find((t) => t.title === "子タスク A");
+    const childB = currentTasksFile.tasks.find((t) => t.title === "子タスク B");
+    expect(childA?.parent).toBe("o/r#draft-1");
+    expect(childB?.parent).toBe("o/r#draft-1");
+    expect(childB?.blocked_by).toEqual([{ task: "o/r#draft-2", type: "finish-to-start", lag: 0 }]);
+
+    // push: draft → 実 Issue 変換と関係同期
+    const tasksFile = clone(currentTasksFile);
+    const syncState: SyncState = {
+      last_synced_at: "",
+      project_node_id: "PVT_1",
+      id_map: {},
+      field_ids: {},
+      snapshots: {},
+    };
+    const recorded = {
+      addSubIssueCalls: [] as Array<{ issueId: string; subIssueId: string }>,
+      addBlockedByCalls: [] as Array<{ issueId: string; blockingIssueId: string }>,
+    };
+
+    const { result, tasksFile: pushedTasksFile } = await executePush(
+      makeMockGql(recorded) as any,
+      mockConfig,
+      tasksFile,
+      syncState,
+    );
+
+    expect(result.created).toBe(3);
+
+    // 子の parent 参照が親の新 Issue ID に置換されている (replaceTaskIdReferences が効く)
+    const pushedEpic = pushedTasksFile.tasks.find((t) => t.title === "親 Epic");
+    const pushedChildA = pushedTasksFile.tasks.find((t) => t.title === "子タスク A");
+    const pushedChildB = pushedTasksFile.tasks.find((t) => t.title === "子タスク B");
+    expect(pushedEpic?.id).toBe("o/r#294");
+    expect(pushedChildA?.parent).toBe("o/r#294");
+    expect(pushedChildB?.parent).toBe("o/r#294");
+    expect(pushedEpic?.sub_tasks).toEqual(expect.arrayContaining(["o/r#295", "o/r#296"]));
+    expect(pushedChildB?.blocked_by).toEqual([
+      { task: "o/r#295", type: "finish-to-start", lag: 0 },
+    ]);
+
+    // sub-issue 関係が GitHub に設定されている (スキップされない)
+    expect(recorded.addSubIssueCalls).toEqual(
+      expect.arrayContaining([
+        { issueId: "ISSUE_294", subIssueId: "ISSUE_295" },
+        { issueId: "ISSUE_294", subIssueId: "ISSUE_296" },
+      ]),
+    );
+    expect(recorded.addSubIssueCalls).toHaveLength(2);
+    expect(recorded.addBlockedByCalls).toEqual([
+      { issueId: "ISSUE_296", blockingIssueId: "ISSUE_295" },
+    ]);
+
+    // 「issue_node_id が取得できないため sub-issue 関係をスキップ」警告が出ていないこと
+    const skipWarn = warnSpy.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes("sub-issue 関係をスキップ"),
+    );
+    expect(skipWarn).toBeUndefined();
+  });
+
+  it("番号指定の --parent 293 でも正規形に解決され push で sub-issue 関係が設定される", async () => {
+    // 再現形 2 (Issue #302 コメント): 既存 Issue の番号を --parent に指定した場合
+    currentTasksFile = {
+      tasks: [
+        {
+          id: "o/r#293",
+          type: "epic",
+          github_issue: 293,
+          github_repo: "o/r",
+          parent: null,
+          sub_tasks: [],
+          title: "既存 Epic",
+          body: null,
+          state: "open",
+          state_reason: null,
+          assignees: [],
+          labels: [],
+          milestone: null,
+          linked_prs: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          closed_at: null,
+          custom_fields: {},
+          start_date: null,
+          end_date: null,
+          date: null,
+          blocked_by: [],
+        },
+      ],
+      cache: { comments: {}, reactions: {} },
+    };
+
+    await createCreateCommand().parseAsync(
+      ["--title", "子タスク A", "--type", "task", "--parent", "293", "--json"],
+      { from: "user" },
+    );
+    expect(process.exitCode).toBeUndefined();
+
+    const childA = currentTasksFile.tasks.find((t) => t.title === "子タスク A");
+    expect(childA?.id).toBe("o/r#draft-1");
+    expect(childA?.parent).toBe("o/r#293");
+
+    const tasksFile = clone(currentTasksFile);
+    const syncState: SyncState = {
+      last_synced_at: "",
+      project_node_id: "PVT_1",
+      id_map: {
+        "o/r#293": { issue_number: 293, issue_node_id: "ISSUE_293", project_item_id: "ITEM_293" },
+      },
+      field_ids: {},
+      snapshots: {},
+    };
+    const recorded = {
+      addSubIssueCalls: [] as Array<{ issueId: string; subIssueId: string }>,
+      addBlockedByCalls: [] as Array<{ issueId: string; blockingIssueId: string }>,
+    };
+
+    // 既存 Epic (#293) には snapshot が無いため added 扱いになるが、
+    // draft 子タスクの関係解決は id_map 照合で行われる
+    await executePush(makeMockGql(recorded) as any, mockConfig, tasksFile, syncState);
+
+    expect(recorded.addSubIssueCalls).toContainEqual({
+      issueId: "ISSUE_293",
+      subIssueId: "ISSUE_295",
+    });
+    const skipWarn = warnSpy.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes("sub-issue 関係をスキップ"),
+    );
+    expect(skipWarn).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__tests__/task-commands.test.ts
+++ b/packages/cli/src/__tests__/task-commands.test.ts
@@ -946,6 +946,14 @@ describe("removeDependency", () => {
     expect(result.task.blocked_by).toHaveLength(1);
     expect(result.task.blocked_by[0].task).toBe("owner/repo#3");
   });
+
+  it("# 付き入力でも非正規形の生値を削除できる", () => {
+    const task = makeTask({
+      blocked_by: [{ task: "293", type: "finish-to-start", lag: 0 }],
+    });
+    const result = removeDependency(task, "owner/repo#293", "#293");
+    expect(result.task.blocked_by).toHaveLength(0);
+  });
 });
 
 describe("[FR-HIER-001-AC1] タスクの親子関係を設定・変更・削除できる", () => {

--- a/packages/cli/src/__tests__/task-commands.test.ts
+++ b/packages/cli/src/__tests__/task-commands.test.ts
@@ -932,6 +932,20 @@ describe("removeDependency", () => {
     const result = removeDependency(task, "owner/repo#99");
     expect(result.task.blocked_by).toHaveLength(0);
   });
+
+  it("非正規形で保存された参照も入力の生値で削除できる (#302 以前のデータ修復)", () => {
+    // 過去の create が生値 "293" のまま保存したケース。doctor の修復案内
+    // (link --unblock 293) が no-op にならないことを固定する
+    const task = makeTask({
+      blocked_by: [
+        { task: "293", type: "finish-to-start", lag: 0 },
+        { task: "owner/repo#3", type: "finish-to-start", lag: 0 },
+      ],
+    });
+    const result = removeDependency(task, "owner/repo#293", "293");
+    expect(result.task.blocked_by).toHaveLength(1);
+    expect(result.task.blocked_by[0].task).toBe("owner/repo#3");
+  });
 });
 
 describe("[FR-HIER-001-AC1] タスクの親子関係を設定・変更・削除できる", () => {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -5,6 +5,7 @@ import { createInterface } from "node:readline/promises";
 import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
+import { resolveTaskId } from "../util/task-id.js";
 import {
   ACCEPTANCE_CRITERIA_END_MARKER,
   ACCEPTANCE_CRITERIA_START_MARKER,
@@ -207,6 +208,19 @@ export function createCreateCommand(): Command {
         return;
       }
 
+      // parent 参照の正規化と存在検証 (#302)
+      // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
+      // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
+      // link --set-parent と同じく resolveTaskId で正規形へ解決してから保存する
+      if (parent) {
+        parent = resolveTaskId(parent, config);
+        if (!tasksFile.tasks.some((t) => t.id === parent)) {
+          console.error(`Parent task not found: ${parent}`);
+          process.exitCode = 1;
+          return;
+        }
+      }
+
       if (opts.template) {
         const resolution = await resolveExistingTaskTemplatePath(
           projectRoot,
@@ -284,14 +298,11 @@ export function createCreateCommand(): Command {
       }
 
       // Update parent's sub_tasks if parent specified
+      // (parent の存在は正規化時に検証済み)
       if (parent) {
         const parentTask = tasksFile.tasks.find((t) => t.id === parent);
-        if (parentTask) {
-          if (!parentTask.sub_tasks.includes(taskId)) {
-            parentTask.sub_tasks.push(taskId);
-          }
-        } else {
-          console.warn(`Warning: Parent task "${parent}" not found in tasks.`);
+        if (parentTask && !parentTask.sub_tasks.includes(taskId)) {
+          parentTask.sub_tasks.push(taskId);
         }
       }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -220,6 +220,54 @@ function checkHashIntegrity(tasksFile: TasksFile, syncState: SyncState): CheckRe
   };
 }
 
+/**
+ * 宙ぶらりん参照の検出 [Issue #302]
+ *
+ * parent / blocked_by / sub_tasks がタスク一覧に存在しない ID を指すケースを検出する。
+ * 過去の create --parent が生の "draft-1" / "293" を保存していたバグ (#302) の残骸や、
+ * 手動編集による破損が対象。正規形でない参照は push の関係同期で解決できないため、
+ * link コマンドでの再設定 (正規形へ解決される) を案内する。
+ */
+function checkDanglingReferences(tasks: Task[]): CheckResult {
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const details: string[] = [];
+
+  for (const task of tasks) {
+    if (task.parent && !taskIds.has(task.parent)) {
+      details.push(
+        `${task.id}: parent "${task.parent}" がタスク一覧に存在しません。'gh-gantt link ${task.id} --set-parent <id>' で再設定してください`,
+      );
+    }
+    for (const dep of task.blocked_by) {
+      if (!taskIds.has(dep.task)) {
+        details.push(
+          `${task.id}: blocked_by "${dep.task}" がタスク一覧に存在しません。'gh-gantt link ${task.id} --unblock ${dep.task}' で削除するか正しい ID で再設定してください`,
+        );
+      }
+    }
+    for (const subTaskId of task.sub_tasks) {
+      if (!taskIds.has(subTaskId)) {
+        details.push(`${task.id}: sub_tasks "${subTaskId}" がタスク一覧に存在しません`);
+      }
+    }
+  }
+
+  if (details.length === 0) {
+    return {
+      name: "project-dangling-references",
+      status: "PASS",
+      message: "宙ぶらりんのタスク参照はありません",
+    };
+  }
+
+  return {
+    name: "project-dangling-references",
+    status: "WARN",
+    message: `${details.length} 件の宙ぶらりんなタスク参照があります`,
+    details,
+  };
+}
+
 /** タスク間の依存関係の循環検出（shared の detectCycles を使用） */
 function checkCycles(tasks: Task[]): CheckResult {
   const cycles = detectCycles(tasks);
@@ -512,6 +560,11 @@ async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<Doct
 
     // 6. 循環依存検出
     checks.push(checkCycles(tasksFile.tasks));
+  }
+
+  // 6.5. 宙ぶらりん参照検出 [Issue #302] (tasksFile のみで判定可能)
+  if (tasksFile) {
+    checks.push(checkDanglingReferences(tasksFile.tasks));
   }
 
   // 7. プロジェクトレベルの stale 検出

--- a/packages/cli/src/commands/task/link.ts
+++ b/packages/cli/src/commands/task/link.ts
@@ -23,11 +23,16 @@ export function addDependency(task: Task, blockerTaskId: string): { task: Task; 
 export function removeDependency(
   task: Task,
   blockerTaskId: string,
+  rawInput?: string,
 ): { task: Task; error?: string } {
+  // 過去のバグ (#302 以前の create) で保存された非正規形の参照 ("293" 等) も
+  // 削除できるよう、正規形に加えて入力の生値とも一致判定する
   return {
     task: {
       ...task,
-      blocked_by: task.blocked_by.filter((d) => d.task !== blockerTaskId),
+      blocked_by: task.blocked_by.filter(
+        (d) => d.task !== blockerTaskId && (rawInput === undefined || d.task !== rawInput),
+      ),
       updated_at: new Date().toISOString(),
     },
   };
@@ -121,7 +126,7 @@ export function createTaskLinkCommand(): Command {
 
       if (opts.unblock) {
         const blockerId = resolveTaskId(opts.unblock, config);
-        const unblockResult = removeDependency(tasksFile.tasks[taskIndex], blockerId);
+        const unblockResult = removeDependency(tasksFile.tasks[taskIndex], blockerId, opts.unblock);
         tasksFile.tasks[taskIndex] = unblockResult.task;
         console.log(`Removed dependency: ${resolvedId} no longer blocked by ${blockerId}`);
       }

--- a/packages/cli/src/commands/task/link.ts
+++ b/packages/cli/src/commands/task/link.ts
@@ -26,13 +26,17 @@ export function removeDependency(
   rawInput?: string,
 ): { task: Task; error?: string } {
   // 過去のバグ (#302 以前の create) で保存された非正規形の参照 ("293" 等) も
-  // 削除できるよう、正規形に加えて入力の生値とも一致判定する
+  // 削除できるよう、正規形に加えて入力の生値 (# 付き入力は # を除いた形も) と
+  // 一致判定する
+  const removalKeys = new Set([blockerTaskId]);
+  if (rawInput !== undefined) {
+    removalKeys.add(rawInput);
+    if (rawInput.startsWith("#")) removalKeys.add(rawInput.slice(1));
+  }
   return {
     task: {
       ...task,
-      blocked_by: task.blocked_by.filter(
-        (d) => d.task !== blockerTaskId && (rawInput === undefined || d.task !== rawInput),
-      ),
+      blocked_by: task.blocked_by.filter((d) => !removalKeys.has(d.task)),
       updated_at: new Date().toISOString(),
     },
   };


### PR DESCRIPTION
## Summary

- `gh-gantt create --parent draft-1` / `--parent 293` が入力を正規化せず生保存し、push の draft→実Issue 変換で `replaceTaskIdReferences` / id_map 照合が失敗して sub-issue 関係が「issue_node_id が取得できない」でスキップされるバグ(#302、実運用で 2 度発生)を修正
- `--parent`(対話プロンプト含む)を `resolveTaskId` で正規形へ解決してから保存し、存在しない親はエラー終了(`link --set-parent` と同一挙動)
- 防御層として `doctor` に `project-dangling-references` チェックを追加(既存データの非正規形 parent・宙ぶらりん参照を WARN で列挙し link での修復を案内)
- requirements.yaml に FR-CLI-004-AC3 / NFR-STABILITY-002-AC6 を追加

## レビュー経緯(dev-role)

- executor: 10/10 passed(1057 tests green、req:trace 冪等)
- reviewer: **approve (10/8)**。不正入力が正規形に化ける経路の不在、リグレッションテストが旧コードで fail する実質性(実コマンド駆動 + addSubIssue spy)、doctor の誤検出なし、顕在化経路(push 持続警告 → doctor → link)の閉包を実コードで検証
- reviewer 指摘の minor: serve API の POST /api/tasks に同型の穴(警告なしの生保存)→ **#319 として起票済み**(UI は正規 ID を送るため実害未観測、push 警告 + doctor が事後検出)

Closes #302

## Test plan

- [x] create-parent.test.ts [FR-CLI-004-AC3] 7 tests(4 入力形式の正規化・不正入力/存在しない親のエラー)
- [x] regressions/issue-302-draft-parent-ref.test.ts [NFR-STABILITY-002-AC6] [Issue #302] 2 tests(再現形 1・2 のエンドツーエンド固定)
- [x] doctor.test.ts に dangling-references 検出 3 tests
- [x] pnpm typecheck / test:json(1057 tests) / build / req:trace(冪等) / req:validate / docs:gen green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `create --parent` で親参照を正規形に統一して保存し、存在しない親はエラーで止まるようになりました。
  * 同一 push 内で作成した draft の親子関係が、保存後に正しく関連付けられるようになりました。
  * `doctor` に、参照切れの親子・依存関係を検出するチェックが追加されました。

* **Bug Fixes**
  * 参照形式の揺れによる不整合や、見つからない参照が残る問題を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->