### PR TITLE
fix(api): PATCH の blocked_by / sub_tasks 参照を正規化・存在検証する

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -524,6 +524,16 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/server-api.test.ts
+          - id: FR-API-001-AC3
+            description: |
+              PATCH /api/tasks/:id は blocked_by の各エントリの task 参照を
+              正規形へ解決して保存し、存在しないタスク・自己参照・
+              不正なエントリ形状 (type / lag が DependencySchema に合わない) は
+              400 を返す。sub_tasks は parent から導出される逆リンクのため
+              直接更新を 400 で拒否する (親子関係の正は parent 側、#321)
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/server-api.test.ts
       - id: FR-API-002
         summary: 同期操作 API
         acceptance_criteria:

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -763,6 +763,224 @@ describe("createApiRouter", () => {
     });
   });
 
+  describe("[FR-API-001-AC3] PATCH /api/tasks/:id は blocked_by 参照を正規形へ解決して保存する", () => {
+    beforeEach(async () => {
+      await new ConfigStore(dir).write(buildParentTestConfig());
+      await new TasksStore(dir).write({
+        tasks: [
+          makeServerTask("o/r#draft-1", { type: "epic" }),
+          makeServerTask("o/r#293", { github_issue: 293 }),
+          makeServerTask("o/r#5", { github_issue: 5 }),
+        ],
+        cache: { comments: {}, reactions: {} },
+      });
+    });
+
+    async function patchTask(id: string, body: Record<string, unknown>) {
+      const handler = findRouteHandler(createApiRouter(dir), "/api/tasks/:id", "patch");
+      const { res, captured } = makeCapturingRes();
+      await handler({ params: { id: encodeURIComponent(id) }, body }, res);
+      return captured;
+    }
+
+    it("短縮形 (draft-1 / 293) を正規形に解決して保存する", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [
+          { task: "draft-1", type: "finish-to-start", lag: 0 },
+          { task: "293", type: "start-to-start", lag: 2 },
+        ],
+      });
+
+      expect(statusCode).toBe(200);
+      expect(jsonPayload.blocked_by).toEqual([
+        { task: "o/r#draft-1", type: "finish-to-start", lag: 0 },
+        { task: "o/r#293", type: "start-to-start", lag: 2 },
+      ]);
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#5")?.blocked_by).toEqual([
+        { task: "o/r#draft-1", type: "finish-to-start", lag: 0 },
+        { task: "o/r#293", type: "start-to-start", lag: 2 },
+      ]);
+    });
+
+    it("#付き番号形式 (#293) を正規形 o/r#293 に解決して保存する", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [{ task: "#293", type: "finish-to-start", lag: 0 }],
+      });
+
+      expect(statusCode).toBe(200);
+      expect(jsonPayload.blocked_by).toEqual([
+        { task: "o/r#293", type: "finish-to-start", lag: 0 },
+      ]);
+    });
+
+    it("正規形 (o/r#293) はそのまま受理され type / lag も保存される (UI の既存経路を壊さない)", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [{ task: "o/r#293", type: "finish-to-finish", lag: 3 }],
+      });
+
+      expect(statusCode).toBe(200);
+      expect(jsonPayload.blocked_by).toEqual([
+        { task: "o/r#293", type: "finish-to-finish", lag: 3 },
+      ]);
+    });
+
+    it("存在しないブロッカーを指すエントリは 400 になり保存されない", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [{ task: "draft-99", type: "finish-to-start", lag: 0 }],
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe("Blocker task not found: o/r#draft-99");
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#5")?.blocked_by).toEqual([]);
+    });
+
+    it("blocked_by が配列でない場合は 400 になる", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: "o/r#293",
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe("blocked_by must be an array of dependencies");
+    });
+
+    it("エントリがオブジェクトでない場合は 400 になる", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: ["o/r#293"],
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe("blocked_by must be an array of dependency objects");
+    });
+
+    it("エントリの task が文字列以外の場合は 400 になる", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [{ task: 293, type: "finish-to-start", lag: 0 }],
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe("blocked_by[].task must be a string");
+    });
+
+    it("空文字・空白のみの task は 400 になる", async () => {
+      for (const invalid of ["", "   "]) {
+        const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+          blocked_by: [{ task: invalid, type: "finish-to-start", lag: 0 }],
+        });
+        expect(statusCode).toBe(400);
+        expect(jsonPayload.error).toBe("blocked_by[].task must be a non-empty string");
+      }
+    });
+
+    it("不正な type / 非数値の lag は 400 になる (生保存すると以後の read が Zod で失敗するため)", async () => {
+      const invalidEntries = [
+        { task: "293", type: "unknown-type", lag: 0 },
+        { task: "293", type: "finish-to-start", lag: "2" },
+        { task: "293" },
+      ];
+      for (const entry of invalidEntries) {
+        const { statusCode, jsonPayload } = await patchTask("o/r#5", { blocked_by: [entry] });
+        expect(statusCode).toBe(400);
+        expect(jsonPayload.error).toBe(
+          "blocked_by entry is invalid (expected { task, type, lag })",
+        );
+      }
+    });
+
+    it("短縮形の自己参照 (5 → o/r#5) は正規化後に検出して 400 を返す", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [{ task: "5", type: "finish-to-start", lag: 0 }],
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe("A task cannot be blocked by itself.");
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#5")?.blocked_by).toEqual([]);
+    });
+
+    it("正規化後に重複するエントリは最初の 1 件に dedupe される", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", {
+        blocked_by: [
+          { task: "293", type: "finish-to-start", lag: 0 },
+          { task: "o/r#293", type: "start-to-start", lag: 5 },
+        ],
+      });
+
+      expect(statusCode).toBe(200);
+      expect(jsonPayload.blocked_by).toEqual([
+        { task: "o/r#293", type: "finish-to-start", lag: 0 },
+      ]);
+    });
+
+    it("blocked_by: [] による全依存解除は従来どおり通る", async () => {
+      await new TasksStore(dir).write({
+        tasks: [
+          makeServerTask("o/r#293", { github_issue: 293 }),
+          makeServerTask("o/r#5", {
+            github_issue: 5,
+            blocked_by: [{ task: "o/r#293", type: "finish-to-start", lag: 0 }],
+          }),
+        ],
+        cache: { comments: {}, reactions: {} },
+      });
+
+      const { statusCode, jsonPayload } = await patchTask("o/r#5", { blocked_by: [] });
+
+      expect(statusCode).toBe(200);
+      expect(jsonPayload.blocked_by).toEqual([]);
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#5")?.blocked_by).toEqual([]);
+    });
+  });
+
+  describe("[FR-API-001-AC3] PATCH /api/tasks/:id は sub_tasks の直接更新を拒否する", () => {
+    beforeEach(async () => {
+      await new ConfigStore(dir).write(buildParentTestConfig());
+      await new TasksStore(dir).write({
+        tasks: [
+          makeServerTask("o/r#draft-1", { type: "epic" }),
+          makeServerTask("o/r#5", { github_issue: 5 }),
+        ],
+        cache: { comments: {}, reactions: {} },
+      });
+    });
+
+    async function patchTask(id: string, body: Record<string, unknown>) {
+      const handler = findRouteHandler(createApiRouter(dir), "/api/tasks/:id", "patch");
+      const { res, captured } = makeCapturingRes();
+      await handler({ params: { id: encodeURIComponent(id) }, body }, res);
+      return captured;
+    }
+
+    it("sub_tasks を含む PATCH は 400 になり保存されない (親子関係の正は parent 側)", async () => {
+      const { statusCode, jsonPayload } = await patchTask("o/r#draft-1", {
+        sub_tasks: ["o/r#5"],
+      });
+
+      expect(statusCode).toBe(400);
+      expect(jsonPayload.error).toBe(
+        "sub_tasks is derived from parent and cannot be updated directly; " +
+          "update the child's parent or use POST /api/tasks/:id/reparent",
+      );
+      // 片側リンク (parent 不整合) が保存されないこと
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#draft-1")?.sub_tasks).toEqual([]);
+      expect(written.tasks.find((t) => t.id === "o/r#5")?.parent).toBeNull();
+    });
+
+    it("他フィールドと同時に sub_tasks を送った場合も 400 になり何も更新されない", async () => {
+      const { statusCode } = await patchTask("o/r#draft-1", {
+        title: "更新後タイトル",
+        sub_tasks: [],
+      });
+
+      expect(statusCode).toBe(400);
+      const written = await new TasksStore(dir).read();
+      expect(written.tasks.find((t) => t.id === "o/r#draft-1")?.title).toBe("Task o/r#draft-1");
+    });
+  });
+
   describe("[FR-API-003-AC3] POST /api/tasks/:id/reparent は newParentId を正規形へ解決する", () => {
     beforeEach(async () => {
       await new ConfigStore(dir).write(buildParentTestConfig());

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -12,8 +12,8 @@ import { executePull } from "../sync/pull-executor.js";
 import { createGraphQLClient } from "../github/client.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
 import { resolveTaskId } from "../util/task-id.js";
-import type { Task, StatusValue } from "@gh-gantt/shared";
-import { computeStatusDateUpdates } from "@gh-gantt/shared";
+import type { Task, StatusValue, Dependency } from "@gh-gantt/shared";
+import { computeStatusDateUpdates, DependencySchema } from "@gh-gantt/shared";
 
 /** newParentId から親方向へ遡り taskId に到達する場合 true (循環になる)。 */
 function wouldCreateCycle(tasks: Task[], taskId: string, newParentId: string): boolean {
@@ -210,7 +210,6 @@ export function createApiRouter(projectRoot: string): Router {
         "end_date",
         "date",
         "parent",
-        "sub_tasks",
         "blocked_by",
       ] as const;
 
@@ -272,6 +271,70 @@ export function createApiRouter(projectRoot: string): Router {
           res.status(400).json({ error: `${reviewField} must be a string or null` });
           return;
         }
+      }
+      // sub_tasks は parent から導出される逆リンクで、setParent / removeParent が
+      // parent と対で維持する。直接書き換えは child.parent と parent.sub_tasks の
+      // 食い違いを作れるため拒否し、parent 更新 / reparent へ誘導する (#321)
+      if ("sub_tasks" in updates) {
+        res.status(400).json({
+          error:
+            "sub_tasks is derived from parent and cannot be updated directly; " +
+            "update the child's parent or use POST /api/tasks/:id/reparent",
+        });
+        return;
+      }
+      // blocked_by 参照の正規化と存在検証 (#321, parent と同じ規律)
+      // TasksStore.write は無検証・read は Zod 検証のため、形状不正なエントリを
+      // 生保存すると以後の全 read が失敗する。保存前に正規形へ解決して検証する
+      if ("blocked_by" in updates) {
+        if (!Array.isArray(updates.blocked_by)) {
+          res.status(400).json({ error: "blocked_by must be an array of dependencies" });
+          return;
+        }
+        const normalizedDeps: Dependency[] = [];
+        const seenBlockers = new Set<string>();
+        for (const entry of updates.blocked_by as unknown[]) {
+          if (typeof entry !== "object" || entry === null) {
+            res.status(400).json({ error: "blocked_by must be an array of dependency objects" });
+            return;
+          }
+          const { task: blockerRef, type, lag } = entry as Record<string, unknown>;
+          if (typeof blockerRef !== "string") {
+            res.status(400).json({ error: "blocked_by[].task must be a string" });
+            return;
+          }
+          // 空文字・空白のみは resolveTaskId の fallback で "o/r#" に化けて
+          // 「存在しないブロッカー」と区別できなくなるため明示的に拒否する (parent と同一)
+          if (blockerRef.trim() === "") {
+            res.status(400).json({ error: "blocked_by[].task must be a non-empty string" });
+            return;
+          }
+          const resolvedBlocker = resolveTaskId(blockerRef, config);
+          // type / lag は shared の DependencySchema で検証し、未知プロパティは
+          // 正規形 { task, type, lag } へ落として保存する
+          const parsed = DependencySchema.safeParse({ task: resolvedBlocker, type, lag });
+          if (!parsed.success) {
+            res.status(400).json({
+              error: "blocked_by entry is invalid (expected { task, type, lag })",
+            });
+            return;
+          }
+          // 短縮形の自己参照も正規化後に検出する (CLI addDependency と同一文言)
+          if (resolvedBlocker === taskId) {
+            res.status(400).json({ error: "A task cannot be blocked by itself." });
+            return;
+          }
+          if (!tasksFile.tasks.some((t) => t.id === resolvedBlocker)) {
+            res.status(400).json({ error: `Blocker task not found: ${resolvedBlocker}` });
+            return;
+          }
+          // 正規化後に同一ブロッカーへ潰れた重複は最初の 1 件を優先する
+          // (CLI addDependency の重複 skip と同じ挙動)
+          if (seenBlockers.has(resolvedBlocker)) continue;
+          seenBlockers.add(resolvedBlocker);
+          normalizedDeps.push(parsed.data);
+        }
+        updates.blocked_by = normalizedDeps;
       }
 
       const safeUpdates: Partial<Task> = {};

--- a/packages/cli/src/server/openapi.ts
+++ b/packages/cli/src/server/openapi.ts
@@ -51,8 +51,12 @@ const TaskUpdateRequestSchema = z.object({
     description:
       "親タスク参照。短縮形は正規形に解決して保存される。存在しないタスクを指す場合は 400 を返す",
   }),
-  sub_tasks: z.array(z.string()).optional(),
-  blocked_by: z.array(DependencySchema).optional(),
+  // sub_tasks は parent から導出される逆リンクのため直接更新を受け付けない (#321)。
+  // 指定された場合は 400 を返す (親子変更は parent 更新 / POST /api/tasks/{id}/reparent 経由)
+  blocked_by: z.array(DependencySchema).optional().openapi({
+    description:
+      "依存関係。各エントリの task は短縮形なら正規形に解決して保存される。存在しないタスク・自己参照・不正なエントリ形状は 400 を返す",
+  }),
 });
 registry.register("TaskUpdateRequest", TaskUpdateRequestSchema);
 
@@ -175,7 +179,8 @@ registry.registerPath({
       content: { "application/json": { schema: TaskSchema } },
     },
     400: {
-      description: "バリデーションエラー (存在しない parent 参照を含む)",
+      description:
+        "バリデーションエラー (存在しない parent / blocked_by 参照、blocked_by の自己参照、sub_tasks の直接更新を含む)",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     404: {


### PR DESCRIPTION
## Summary

- PATCH /api/tasks/:id の blocked_by が正規化・存在検証なしに生保存され、不正形状のエントリは tasks.json を実質破損(write 無検証 / read Zod 検証のため以後の全 read が失敗)させ得た(#321、serve API 参照検証三部作の完結編)
- **blocked_by**: 配列・エントリ形状・空文字拒否・resolveTaskId 正規化・自己参照 400(CLI と同一文言)・存在検証 400・正規化後 dedupe の検証チェーンを追加(#319 の parent パターンを踏襲)
- **sub_tasks**: 直接更新を 400 で拒否。親子関係の正は parent 側にあり、sub_tasks は setParent/removeParent が維持する導出逆リンクのため(直接書き換えは child.parent との食い違いを作る)。UI は PATCH で sub_tasks を送っておらず破壊的変更の実影響なし(独立検証済み)。エラーメッセージで parent 更新 / POST /reparent へ誘導
- OpenAPI: TaskUpdateRequest から sub_tasks 削除、blocked_by の正規化挙動を記述
- requirements.yaml に FR-API-001-AC3 を新設

## レビュー経緯(dev-role)

- executor: 8/8 passed(1096 tests green、req:trace 冪等)
- reviewer: **approve (10/8)**。検証チェーンの抜けなし(task キー欠落・null・数値・空文字・type/lag 不正の全経路)、UI 無影響の独立 grep 再確認、「生保存は全 read を破壊」の主張の裏取り済み。minor(Issue 本文への方針変更記録)は amend 済み

Closes #321

## Test plan

- [x] server-api.test.ts [FR-API-001-AC3] 13 tests 追加(計 42 tests green)
- [x] pnpm typecheck / test:json(1096 tests) / build / req:trace(冪等) / req:validate / docs:gen green