### PR TITLE
feat(sync): 宣言的コンフリクト解決を追加する (#300)

### DIFF
--- a/docs/adr/ADR-018-cache-first-sync-model.md
+++ b/docs/adr/ADR-018-cache-first-sync-model.md
@@ -4,6 +4,7 @@ title: キャッシュファースト同期モデルへの移行 (ADR-003/005 �
 date: 2026-07-07
 status: accepted
 related_requirements:
+  - FR-SYNC-001
   - FR-SYNC-002
   - FR-SYNC-003
   - FR-STORE-001
@@ -137,6 +138,15 @@ draft タスクは既定で即座に GitHub Issue化する (オフライン時�
 フィールド単位の解決ポリシー (例: `state` はローカル優先、`start_date` は
 リモート優先) を設定で宣言し、`gh-gantt resolve --auto` で機械的に適用できる
 ようにする。真の同時編集だけが人間・エージェントの判断に残る。
+
+宣言は `sync.conflict_policy` の部分 map とし、同期対象フィールドごとに `ours` /
+`theirs` / `manual` のいずれかを指定する。未定義フィールドと `manual` は同じく
+自動解決せず marker を保持する。`resolve --auto` は明示的に実行された場合だけ
+この map を適用し、pull の途中で暗黙に自動解決しない。
+
+過去の設定に含まれうる `sync.conflict_strategy` は読み込み互換性のため保持するが、
+実装されたことのない全体ポリシーへ新しい意味を与えない。`resolve --auto` では値を
+無視して移行警告を stderr に出し、`sync.conflict_policy` への明示的な移行を促す。
 
 ## Alternatives
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -30,6 +30,22 @@ areas:
             description: リモート削除 + ローカル変更ありの場合、警告を表示しタスクをローカルに保持する (delete/modify コンフリクト)
             status: uncovered
             tests: []
+          - id: FR-SYNC-001-AC5
+            description: 同期対象フィールドごとに ours / theirs / manual の解決ポリシーを宣言し、未知のフィールドや値を拒否できる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/schema.test.ts
+          - id: FR-SYNC-001-AC6
+            description: resolve --auto が Issue・field filter を尊重し、宣言済みポリシーだけを適用して安全に部分解決できる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/resolve-auto.test.ts
+              - packages/cli/src/__tests__/resolve-command.test.ts
+          - id: FR-SYNC-001-AC7
+            description: legacy conflict_strategy を読み込み可能なまま維持しつつ警告し、自動解決には適用しない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/resolve-auto.test.ts
       - id: FR-SYNC-002
         summary: pull による GitHub → ローカル同期
         acceptance_criteria:

--- a/packages/cli/src/__tests__/resolve-auto.test.ts
+++ b/packages/cli/src/__tests__/resolve-auto.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, readFile, writeFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createResolveCommand } from "../commands/resolve.js";
-import { extractSyncFields } from "../sync/hash.js";
+import { computeLocalDiff } from "../sync/diff.js";
+import { extractSyncFields, hashSyncFields, hashTask } from "../sync/hash.js";
 import type { Config, SyncState, Task, TasksFile } from "@gh-gantt/shared";
 
 function makeTask(issue: number, overrides: Partial<Task> = {}): Task {
@@ -216,7 +217,7 @@ describe("[FR-SYNC-001-AC6] resolve --auto は設定済みフィールドだけ�
     expect(afterState.snapshots[task9.id]?.syncFields?.title).toBe("古いsnapshot title");
   });
 
-  it("全フィールド theirs の完全解決だけ snapshot.hash を remoteHash に揃える", async () => {
+  it("解決後task全体がremoteHashと一致するとsnapshot全体をremoteへ進める", async () => {
     const task = Object.assign(makeTask(8), {
       state_current: "open",
       state_incoming: "closed",
@@ -224,15 +225,25 @@ describe("[FR-SYNC-001-AC6] resolve --auto は設定済みフィールドだけ�
       labels_incoming: ["remote"],
     });
     await writeFixture([task], { state: "theirs", labels: "theirs" });
+    const seededState = await readState();
+    const remoteTask = makeTask(8, { state: "closed", labels: ["remote"] });
+    seededState.snapshots[task.id]!.remoteHash = hashTask(remoteTask);
+    await writeFile(join(root, ".gantt-sync/sync-state.json"), `${JSON.stringify(seededState)}\n`);
 
     await run(["8", "--auto"]);
 
-    expect((await readState()).snapshots[task.id]?.hash).toBe("remote-8");
+    const tasksFile = await readTasks();
+    const state = await readState();
+    expect(state.snapshots[task.id]?.hash).toBe(hashTask(remoteTask));
+    expect(state.snapshots[task.id]?.hash).toBe(
+      hashSyncFields(state.snapshots[task.id]!.syncFields!),
+    );
+    expect(computeLocalDiff(tasksFile.tasks, state)).toHaveLength(0);
     expect((await readTasks()).has_conflicts).toBeUndefined();
     expect(logSpy).toHaveBeenCalledWith("No conflicts.");
   });
 
-  it("ours が混在した完全解決では snapshot.hash を維持する", async () => {
+  it("ours が混在した完全解決では remoteHash へ進めず push 差分を維持する", async () => {
     const task = Object.assign(makeTask(8), {
       state_current: "open",
       state_incoming: "closed",
@@ -243,7 +254,62 @@ describe("[FR-SYNC-001-AC6] resolve --auto は設定済みフィールドだけ�
 
     await run(["8", "--auto"]);
 
-    expect((await readState()).snapshots[task.id]?.hash).toBe("local-8");
+    const snapshot = (await readState()).snapshots[task.id]!;
+    expect(snapshot.hash).toBe(hashSyncFields(snapshot.syncFields!));
+    expect(snapshot.hash).not.toBe(snapshot.remoteHash);
+  });
+
+  it("oursで解決したbaseline-sensitive fieldを後続pushの差分として保持する", async () => {
+    const task = Object.assign(makeTask(8, { labels: ["local-label"] }), {
+      labels_current: ["local-label"],
+      labels_incoming: ["remote-label"],
+    });
+    await writeFixture([task], { labels: "ours" });
+    const seededState = await readState();
+    seededState.snapshots[task.id]!.syncFields!.labels = [];
+    await writeFile(join(root, ".gantt-sync/sync-state.json"), `${JSON.stringify(seededState)}\n`);
+
+    await run(["8", "--auto"]);
+
+    const tasksFile = await readTasks();
+    const state = await readState();
+    expect(state.snapshots[task.id]?.syncFields?.labels).toEqual([]);
+    expect(state.snapshots[task.id]?.hash).toBe(
+      hashSyncFields(state.snapshots[task.id]!.syncFields!),
+    );
+    expect(computeLocalDiff(tasksFile.tasks, state)[0]?.changedFields).toContain("labels");
+  });
+
+  it("all-theirs解決でも無関係なlocal-only差分をsnapshotへ吸収しない", async () => {
+    const task = Object.assign(
+      makeTask(8, { title: "remote-only title", labels: ["local-only"] }),
+      {
+        state_current: "open",
+        state_incoming: "closed",
+      },
+    );
+    await writeFixture([task], { state: "theirs" });
+    const seededState = await readState();
+    seededState.snapshots[task.id]!.syncFields!.title = "Task 8";
+    seededState.snapshots[task.id]!.syncFields!.labels = [];
+    seededState.snapshots[task.id]!.remoteHash = hashTask(
+      makeTask(8, { title: "remote-only title", state: "closed" }),
+    );
+    await writeFile(join(root, ".gantt-sync/sync-state.json"), `${JSON.stringify(seededState)}\n`);
+
+    await run(["8", "--auto"]);
+
+    const tasksFile = await readTasks();
+    const state = await readState();
+    expect(state.snapshots[task.id]?.syncFields?.state).toBe("closed");
+    expect(state.snapshots[task.id]?.syncFields?.labels).toEqual([]);
+    expect(state.snapshots[task.id]?.hash).toBe(
+      hashSyncFields(state.snapshots[task.id]!.syncFields!),
+    );
+    expect(state.snapshots[task.id]?.hash).not.toBe(state.snapshots[task.id]?.remoteHash);
+    const changedFields = computeLocalDiff(tasksFile.tasks, state)[0]?.changedFields;
+    expect(changedFields).toContain("labels");
+    expect(changedFields).not.toContain("state");
   });
 
   it("--auto と --ours/--theirs の競合はファイルを書き換える前に拒否する", async () => {

--- a/packages/cli/src/__tests__/resolve-auto.test.ts
+++ b/packages/cli/src/__tests__/resolve-auto.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createResolveCommand } from "../commands/resolve.js";
+import { extractSyncFields } from "../sync/hash.js";
+import type { Config, SyncState, Task, TasksFile } from "@gh-gantt/shared";
+
+function makeTask(issue: number, overrides: Partial<Task> = {}): Task {
+  return {
+    id: `owner/repo#${issue}`,
+    type: "task",
+    github_issue: issue,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: `Task ${issue}`,
+    body: null,
+    acceptance_criteria: [],
+    acceptance_criteria_slot: false,
+    implementer: null,
+    reviewer: null,
+    require_review: false,
+    review_approved_by: null,
+    review_approved_at: null,
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(sync: Config["sync"]): Config {
+  return {
+    version: "1",
+    project: { name: "test", github: { owner: "owner", repo: "repo", project_number: 1 } },
+    sync,
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    },
+    type_hierarchy: { task: [] },
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: {
+        critical_path: "#f00",
+        on_track: "#0f0",
+        at_risk: "#ff0",
+        overdue: "#f00",
+      },
+    },
+  };
+}
+
+describe("[FR-SYNC-001-AC6] resolve --auto は設定済みフィールドだけを部分解決する", () => {
+  let root: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "gh-gantt-resolve-auto-"));
+    await mkdir(join(root, ".gantt-sync"), { recursive: true });
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeFixture(
+    tasks: unknown[],
+    conflictPolicy: Config["sync"]["conflict_policy"],
+    legacyStrategy?: string,
+  ): Promise<void> {
+    const sync = {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End" },
+      conflict_policy: conflictPolicy,
+      ...(legacyStrategy === undefined ? {} : { conflict_strategy: legacyStrategy }),
+    } as Config["sync"];
+    const config = makeConfig(sync);
+    const tasksFile: TasksFile = {
+      tasks: tasks as unknown as Task[],
+      cache: { comments: {}, reactions: {} },
+      has_conflicts: true,
+    };
+    const taskRecords = tasks as Record<string, unknown>[];
+    const snapshots = Object.fromEntries(
+      taskRecords.map((task) => [
+        task.id as string,
+        {
+          hash: `local-${String(task.github_issue)}`,
+          remoteHash: `remote-${String(task.github_issue)}`,
+          synced_at: "2026-01-01T00:00:00Z",
+          syncFields: extractSyncFields(task as unknown as Task),
+        },
+      ]),
+    );
+    const state: SyncState = {
+      last_synced_at: "2026-01-01T00:00:00Z",
+      project_node_id: "PVT_1",
+      id_map: {},
+      field_ids: {},
+      snapshots,
+    };
+    await writeFile(join(root, ".gantt-sync/gantt.config.json"), `${JSON.stringify(config)}\n`);
+    await writeFile(join(root, ".gantt-sync/tasks.json"), `${JSON.stringify(tasksFile)}\n`);
+    await writeFile(join(root, ".gantt-sync/sync-state.json"), `${JSON.stringify(state)}\n`);
+  }
+
+  async function readTasks(): Promise<TasksFile & { tasks: Record<string, unknown>[] }> {
+    return JSON.parse(await readFile(join(root, ".gantt-sync/tasks.json"), "utf8"));
+  }
+
+  async function readState(): Promise<SyncState> {
+    return JSON.parse(await readFile(join(root, ".gantt-sync/sync-state.json"), "utf8"));
+  }
+
+  async function run(args: string[]): Promise<void> {
+    await createResolveCommand({ projectRoot: () => root }).parseAsync(args, { from: "user" });
+  }
+
+  it("ours/theirs を適用し manual・未定義を残して has_conflicts を維持する", async () => {
+    const task = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+      title_current: "Task 8",
+      title_incoming: "Remote title",
+      labels_current: [],
+      labels_incoming: ["remote"],
+      body_current: null,
+      body_incoming: "Remote body",
+    });
+    await writeFixture([task], { state: "ours", labels: "theirs", title: "manual" });
+
+    await run(["--auto"]);
+
+    const tasksFile = await readTasks();
+    expect(tasksFile.tasks[0]).not.toHaveProperty("state_current");
+    expect(tasksFile.tasks[0].state).toBe("open");
+    expect(tasksFile.tasks[0].labels).toEqual(["remote"]);
+    expect(tasksFile.tasks[0]).toHaveProperty("title_current");
+    expect(tasksFile.tasks[0]).toHaveProperty("body_current");
+    expect(tasksFile.has_conflicts).toBe(true);
+    expect((await readState()).snapshots[task.id]?.hash).toBe("local-8");
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("title"));
+  });
+
+  it("issue と field filter の範囲外を変更しない", async () => {
+    const task8 = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+      labels_current: [],
+      labels_incoming: ["remote"],
+    });
+    const task9 = Object.assign(makeTask(9), {
+      state_current: "open",
+      state_incoming: "closed",
+    });
+    await writeFixture([task8, task9], { state: "theirs", labels: "theirs" });
+
+    await run(["8", "--auto", "--field", "state", "--json"]);
+
+    const tasksFile = await readTasks();
+    expect(tasksFile.tasks[0].state).toBe("closed");
+    expect(tasksFile.tasks[0]).toHaveProperty("labels_current");
+    expect(tasksFile.tasks[1]).toHaveProperty("state_current");
+    const json = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string);
+    expect(json.task_count).toBe(1);
+    expect(json).not.toHaveProperty("conflicts");
+    expect(json.tasks[0].conflicts[0].field).toBe("labels");
+  });
+
+  it("issue filter対象外のconflict-free taskとsnapshotを構造的に変更しない", async () => {
+    const task8 = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+    });
+    const task9 = makeTask(9, { title: "未pushのローカル編集" });
+    await writeFixture([task8, task9], { state: "theirs" });
+
+    const seededState = await readState();
+    seededState.snapshots[task9.id] = {
+      ...seededState.snapshots[task9.id]!,
+      hash: "old-local-9",
+      syncFields: {
+        ...seededState.snapshots[task9.id]!.syncFields!,
+        title: "古いsnapshot title",
+      },
+    };
+    await writeFile(join(root, ".gantt-sync/sync-state.json"), `${JSON.stringify(seededState)}\n`);
+    const beforeTask9 = structuredClone((await readTasks()).tasks[1]);
+    const beforeSnapshot9 = structuredClone((await readState()).snapshots[task9.id]);
+
+    await run(["8", "--auto"]);
+
+    const afterTasks = await readTasks();
+    const afterState = await readState();
+    expect(afterTasks.tasks[1]).toEqual(beforeTask9);
+    expect(afterState.snapshots[task9.id]).toEqual(beforeSnapshot9);
+    expect(afterTasks.tasks[1].title).toBe("未pushのローカル編集");
+    expect(afterState.snapshots[task9.id]?.syncFields?.title).toBe("古いsnapshot title");
+  });
+
+  it("全フィールド theirs の完全解決だけ snapshot.hash を remoteHash に揃える", async () => {
+    const task = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+      labels_current: [],
+      labels_incoming: ["remote"],
+    });
+    await writeFixture([task], { state: "theirs", labels: "theirs" });
+
+    await run(["8", "--auto"]);
+
+    expect((await readState()).snapshots[task.id]?.hash).toBe("remote-8");
+    expect((await readTasks()).has_conflicts).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith("No conflicts.");
+  });
+
+  it("ours が混在した完全解決では snapshot.hash を維持する", async () => {
+    const task = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+      labels_current: [],
+      labels_incoming: ["remote"],
+    });
+    await writeFixture([task], { state: "ours", labels: "theirs" });
+
+    await run(["8", "--auto"]);
+
+    expect((await readState()).snapshots[task.id]?.hash).toBe("local-8");
+  });
+
+  it("--auto と --ours/--theirs の競合はファイルを書き換える前に拒否する", async () => {
+    const task = Object.assign(makeTask(8), {
+      state_current: "open",
+      state_incoming: "closed",
+    });
+    await writeFixture([task], { state: "theirs" });
+    const before = await readFile(join(root, ".gantt-sync/tasks.json"), "utf8");
+
+    await expect(run(["--auto", "--ours"])).rejects.toThrow(/排他的/);
+    expect(await readFile(join(root, ".gantt-sync/tasks.json"), "utf8")).toBe(before);
+  });
+
+  it("non-SyncFields の対キーは marker と見なさず同期を停止しない", async () => {
+    const task = Object.assign(makeTask(8), {
+      unknown_current: "local",
+      unknown_incoming: "remote",
+    });
+    await writeFixture([task], {});
+
+    await run(["--auto"]);
+
+    const tasksFile = await readTasks();
+    expect(tasksFile.tasks[0]).toHaveProperty("unknown_current");
+    expect(tasksFile.has_conflicts).toBeUndefined();
+    expect((await readState()).snapshots[task.id]?.hash).toBe("local-8");
+  });
+
+  describe("[FR-SYNC-001-AC7] legacy conflict_strategy は読み込みだけを維持する", () => {
+    it("stderr に1回警告し、値を自動解決へ適用せず JSON stdout を汚さない", async () => {
+      const task = Object.assign(makeTask(8), {
+        state_current: "open",
+        state_incoming: "closed",
+      });
+      await writeFixture([task], {}, "remote-wins");
+
+      await run(["--auto", "--json"]);
+
+      const tasksFile = await readTasks();
+      expect(tasksFile.tasks[0].state).toBe("open");
+      expect(tasksFile.tasks[0]).toHaveProperty("state_current");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("conflict_policy"));
+      expect(() => JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)).not.toThrow();
+    });
+  });
+});

--- a/packages/cli/src/__tests__/resolve-command.test.ts
+++ b/packages/cli/src/__tests__/resolve-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveAll } from "../commands/resolve.js";
+import { resolveAllByPolicy } from "../commands/resolve.js";
 
 describe("resolveAll", () => {
   it("resolves all markers with --ours", () => {
@@ -112,5 +113,46 @@ describe("resolveAll", () => {
     // state のみ --theirs で解決
     expect(theirsResolutions.size).toBe(1);
     expect(theirsResolutions.get("owner/repo#8")).toEqual(new Set(["state"]));
+  });
+});
+
+describe("[FR-SYNC-001-AC6] resolveAllByPolicy", () => {
+  it("policy と issue/field filter に従って ours/theirs/manual を集計する", () => {
+    const tasks: Record<string, unknown>[] = [
+      {
+        id: "owner/repo#8",
+        title: "Task 8",
+        title_current: "Task 8",
+        title_incoming: "Remote title",
+        state: "open",
+        state_current: "open",
+        state_incoming: "closed",
+        labels: [],
+        labels_current: [],
+        labels_incoming: ["remote"],
+      },
+      {
+        id: "owner/repo#9",
+        state: "open",
+        state_current: "open",
+        state_incoming: "closed",
+      },
+    ];
+
+    const result = resolveAllByPolicy(
+      tasks,
+      { title: "manual", state: "ours", labels: "theirs" },
+      8,
+    );
+
+    expect(tasks[0]).toHaveProperty("title_current");
+    expect(tasks[0]).not.toHaveProperty("state_current");
+    expect(tasks[0].labels).toEqual(["remote"]);
+    expect(tasks[1]).toHaveProperty("state_current");
+    expect(result.get("owner/repo#8")).toEqual({
+      ours: new Set(["state"]),
+      theirs: new Set(["labels"]),
+      unresolved: new Set(["title"]),
+    });
   });
 });

--- a/packages/cli/src/__tests__/resolve-snapshot.test.ts
+++ b/packages/cli/src/__tests__/resolve-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { resolveAll } from "../commands/resolve.js";
+import { resolveAllByPolicy } from "../commands/resolve.js";
 import { hashTask, extractSyncFields } from "../sync/hash.js";
 import type { Task, SyncState } from "@gh-gantt/shared";
 
@@ -239,5 +240,14 @@ describe("[Issue #152] resolve --theirs 後の snapshot.hash 更新", () => {
     // 検証: 一部のみ --theirs なので hash は元のまま（ローカル変更として push 可能）
     expect(syncState.snapshots[id]?.hash).toBe("local-hash-123");
     expect(syncState.snapshots[id]?.hash).not.toBe(remoteHash);
+  });
+
+  it("auto で manual が残る間は snapshot を更新しない", () => {
+    const before = structuredClone(syncState.snapshots["owner/repo#8"]);
+
+    resolveAllByPolicy(tasks, { title: "theirs", body: "manual", state: "ours" });
+
+    expect(tasks[0]).toHaveProperty("body_current");
+    expect(syncState.snapshots["owner/repo#8"]).toEqual(before);
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -12,6 +12,7 @@ import { resolveTaskType } from "../sync/type-resolver.js";
 import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
 import { SyncStateStore } from "../store/state.js";
+import { DEFAULT_CONFLICT_POLICY } from "@gh-gantt/shared";
 import type { Config, TaskType, TaskDisplay, Task, SyncState } from "@gh-gantt/shared";
 
 const KNOWN_TYPE_DEFAULTS: Record<
@@ -199,6 +200,7 @@ export const initCommand = new Command("init")
       },
       sync: {
         auto_create_issues: false,
+        conflict_policy: { ...DEFAULT_CONFLICT_POLICY },
         field_mapping: fieldMapping,
       },
       task_types: taskTypes,

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -11,10 +11,10 @@ import {
   hasUnresolvedMarkers,
   type PolicyResolution,
 } from "../sync/conflict-marker.js";
-import { extractSyncFields } from "../sync/hash.js";
+import { extractSyncFields, hashSyncFields, hashTask } from "../sync/hash.js";
 import { formatConflictList, buildConflictJson } from "./conflicts.js";
 import { formatValue } from "../util/format.js";
-import type { ConflictPolicy, Task } from "@gh-gantt/shared";
+import type { ConflictPolicy, SyncFieldKey, SyncFields, Task } from "@gh-gantt/shared";
 
 /**
  * Extract issue number from task id (e.g. "owner/repo#8" -> 8).
@@ -85,6 +85,23 @@ export function resolveAllByPolicy(
   return resolutions;
 }
 
+/**
+ * theirs で解決したフィールドだけ snapshot baseline をリモート値へ進める。
+ * ours とコンフリクト外の local-only 差分は旧 baseline に残し、後続 push で検出する。
+ */
+function advanceSnapshotBaseline(
+  existing: SyncFields | undefined,
+  resolved: SyncFields,
+  theirsFields: ReadonlySet<string>,
+): SyncFields | undefined {
+  if (!existing) return undefined;
+  const next = { ...existing };
+  for (const field of theirsFields) {
+    (next as unknown as Record<string, unknown>)[field] = resolved[field as SyncFieldKey];
+  }
+  return next;
+}
+
 interface ResolveCommandDependencies {
   projectRoot?: () => string;
 }
@@ -121,9 +138,7 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
 
       const tasks = tasksFile.tasks as unknown as Record<string, unknown>[];
 
-      // Track conflict resolution choices for each task
-      // Map: task id -> { totalConflicts: number, theirsCount: number }
-      const resolutionStats = new Map<string, { totalConflicts: number; theirsCount: number }>();
+      const theirsResolutionFields = new Map<string, Set<string>>();
       const snapshotTargetTaskIds = new Set<string>();
 
       // 開始時に marker を持ち、Issue filter に一致する task だけを更新対象として固定する。
@@ -132,7 +147,6 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
         const markers = detectMarkers(task);
         const matchesIssue = issue === undefined || extractIssueNumber(id) === issue;
         if (markers.length > 0 && matchesIssue) {
-          resolutionStats.set(id, { totalConflicts: markers.length, theirsCount: 0 });
           snapshotTargetTaskIds.add(id);
         }
       }
@@ -154,20 +168,16 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
           opts.field,
         );
         for (const [id, resolution] of policyResolutions) {
-          const stats = resolutionStats.get(id);
-          if (stats) stats.theirsCount = resolution.theirs.size;
+          theirsResolutionFields.set(id, resolution.theirs);
         }
       } else if (opts?.ours || opts?.theirs) {
         // Batch mode
         const choice = opts.ours ? "ours" : "theirs";
         const batchResolutions = resolveAll(tasks, choice, issue, opts.field);
 
-        // Update theirsCount based on resolutions
+        // snapshot baseline を進める theirs フィールドを記録する
         for (const [id, fields] of batchResolutions) {
-          const stats = resolutionStats.get(id);
-          if (stats) {
-            stats.theirsCount = fields.size;
-          }
+          theirsResolutionFields.set(id, fields);
         }
       } else {
         // Interactive mode
@@ -206,10 +216,9 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
 
               // Track fields resolved with "theirs"
               if (choice === "theirs") {
-                const stats = resolutionStats.get(id);
-                if (stats) {
-                  stats.theirsCount++;
-                }
+                const fields = theirsResolutionFields.get(id) ?? new Set<string>();
+                fields.add(marker.field);
+                theirsResolutionFields.set(id, fields);
               }
             }
           }
@@ -232,27 +241,30 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
           if (!existing) continue;
 
           const taskTyped = task as unknown as Task;
-          const stats = resolutionStats.get(id);
+          const resolvedTaskSyncFields = extractSyncFields(taskTyped);
+          const resolvedTaskHash = hashTask(taskTyped);
 
-          // すべてのコンフリクトが --theirs で解決された場合のみ、
-          // snapshot.hash をリモート値に揃える
-          // これによりタスクがリモートと同一状態になり、status/push で検出されなくなる
-          const allResolvedWithTheirs =
-            stats && stats.theirsCount > 0 && stats.theirsCount === stats.totalConflicts;
-
-          if (allResolvedWithTheirs && existing.remoteHash) {
-            // remoteHash をそのまま使用してタスクをリモートと同一状態にする
+          if (existing.remoteHash && resolvedTaskHash === existing.remoteHash) {
+            // task 全体が remote と一致するときだけ snapshot 全体を remote へ進める。
             syncState.snapshots[id] = {
               ...existing,
               hash: existing.remoteHash,
-              syncFields: extractSyncFields(taskTyped),
+              syncFields: resolvedTaskSyncFields,
             };
-          } else {
-            // --ours で解決された場合、または一部のみ --theirs で解決された場合は、
-            // hash を更新しない（ローカル変更として push 可能にするため）
+            continue;
+          }
+
+          const conservativeSyncFields = advanceSnapshotBaseline(
+            existing.syncFields,
+            resolvedTaskSyncFields,
+            theirsResolutionFields.get(id) ?? new Set(),
+          );
+          if (conservativeSyncFields) {
+            // baseline を進める場合は hash と syncFields を必ず同じ内容に揃える。
             syncState.snapshots[id] = {
               ...existing,
-              syncFields: extractSyncFields(taskTyped),
+              hash: hashSyncFields(conservativeSyncFields),
+              syncFields: conservativeSyncFields,
             };
           }
         } catch {

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -3,11 +3,18 @@ import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { TasksStore } from "../store/tasks.js";
 import { SyncStateStore } from "../store/state.js";
-import { detectMarkers, resolveMarker, hasUnresolvedMarkers } from "../sync/conflict-marker.js";
+import { ConfigStore } from "../store/config.js";
+import {
+  applyConflictPolicy,
+  detectMarkers,
+  resolveMarker,
+  hasUnresolvedMarkers,
+  type PolicyResolution,
+} from "../sync/conflict-marker.js";
 import { extractSyncFields } from "../sync/hash.js";
 import { formatConflictList, buildConflictJson } from "./conflicts.js";
 import { formatValue } from "../util/format.js";
-import type { Task } from "@gh-gantt/shared";
+import type { ConflictPolicy, Task } from "@gh-gantt/shared";
 
 /**
  * Extract issue number from task id (e.g. "owner/repo#8" -> 8).
@@ -61,19 +68,51 @@ export function resolveAll(
   return theirsResolutions;
 }
 
-export const resolveCommand = new Command("resolve")
-  .description("Resolve sync conflicts")
-  .argument("[issue]", "Filter by issue number", parseInt)
-  .option("--ours", "Resolve all conflicts with local values")
-  .option("--theirs", "Resolve all conflicts with remote values")
-  .option("--field <field>", "Resolve only specific field")
-  .option("--json", "Output remaining conflicts as JSON (batch mode only)")
-  .action(
-    async (
-      issue?: number,
-      opts?: { ours?: boolean; theirs?: boolean; field?: string; json?: boolean },
-    ) => {
-      const projectRoot = process.cwd();
+/** 宣言的ポリシーを issue / field filter 後に適用する純粋関数。 */
+export function resolveAllByPolicy(
+  tasks: Record<string, unknown>[],
+  policy: ConflictPolicy,
+  filterIssue?: number,
+  filterField?: string,
+): Map<string, PolicyResolution> {
+  const resolutions = new Map<string, PolicyResolution>();
+  for (const task of tasks) {
+    const id = task.id as string;
+    if (filterIssue !== undefined && extractIssueNumber(id) !== filterIssue) continue;
+    if (detectMarkers(task).length === 0) continue;
+    resolutions.set(id, applyConflictPolicy(task, policy, filterField));
+  }
+  return resolutions;
+}
+
+interface ResolveCommandDependencies {
+  projectRoot?: () => string;
+}
+
+interface ResolveOptions {
+  ours?: boolean;
+  theirs?: boolean;
+  auto?: boolean;
+  field?: string;
+  json?: boolean;
+}
+
+export function createResolveCommand(dependencies: ResolveCommandDependencies = {}): Command {
+  return new Command("resolve")
+    .description("Resolve sync conflicts")
+    .argument("[issue]", "Filter by issue number", parseInt)
+    .option("--ours", "Resolve all conflicts with local values")
+    .option("--theirs", "Resolve all conflicts with remote values")
+    .option("--auto", "Resolve conflicts using sync.conflict_policy")
+    .option("--field <field>", "Resolve only specific field")
+    .option("--json", "Output remaining conflicts as JSON (batch mode only)")
+    .action(async (issue?: number, opts?: ResolveOptions) => {
+      const selectedModes = [opts?.ours, opts?.theirs, opts?.auto].filter(Boolean).length;
+      if (selectedModes > 1) {
+        throw new Error("--auto / --ours / --theirs は排他的なオプションです");
+      }
+
+      const projectRoot = dependencies.projectRoot?.() ?? process.cwd();
       const tasksStore = new TasksStore(projectRoot);
       const stateStore = new SyncStateStore(projectRoot);
 
@@ -85,17 +124,40 @@ export const resolveCommand = new Command("resolve")
       // Track conflict resolution choices for each task
       // Map: task id -> { totalConflicts: number, theirsCount: number }
       const resolutionStats = new Map<string, { totalConflicts: number; theirsCount: number }>();
+      const snapshotTargetTaskIds = new Set<string>();
 
-      // Count initial conflicts for each task
+      // 開始時に marker を持ち、Issue filter に一致する task だけを更新対象として固定する。
       for (const task of tasks) {
         const id = task.id as string;
         const markers = detectMarkers(task);
-        if (markers.length > 0) {
+        const matchesIssue = issue === undefined || extractIssueNumber(id) === issue;
+        if (markers.length > 0 && matchesIssue) {
           resolutionStats.set(id, { totalConflicts: markers.length, theirsCount: 0 });
+          snapshotTargetTaskIds.add(id);
         }
       }
 
-      if (opts?.ours || opts?.theirs) {
+      if (opts?.auto) {
+        const config = await new ConfigStore(projectRoot).read();
+        const legacyStrategy = (config.sync as unknown as Record<string, unknown>)[
+          "conflict_strategy"
+        ];
+        if (legacyStrategy !== undefined) {
+          console.warn(
+            "WARNING: sync.conflict_strategy は deprecated であり resolve --auto では無視されます。sync.conflict_policy にフィールド単位の ours / theirs / manual を設定してください。",
+          );
+        }
+        const policyResolutions = resolveAllByPolicy(
+          tasks,
+          config.sync.conflict_policy ?? {},
+          issue,
+          opts.field,
+        );
+        for (const [id, resolution] of policyResolutions) {
+          const stats = resolutionStats.get(id);
+          if (stats) stats.theirsCount = resolution.theirs.size;
+        }
+      } else if (opts?.ours || opts?.theirs) {
         // Batch mode
         const choice = opts.ours ? "ours" : "theirs";
         const batchResolutions = resolveAll(tasks, choice, issue, opts.field);
@@ -158,9 +220,10 @@ export const resolveCommand = new Command("resolve")
 
       // Update snapshots for fully resolved tasks
       for (const task of tasks) {
+        const id = task.id as string;
+        if (!snapshotTargetTaskIds.has(id)) continue;
         if (hasUnresolvedMarkers(task)) continue;
 
-        const id = task.id as string;
         // Skip draft tasks (no issue number)
         if (!id.includes("#")) continue;
 
@@ -217,5 +280,7 @@ export const resolveCommand = new Command("resolve")
         const remaining = formatConflictList(tasks, syncState.snapshots, issue);
         console.log(remaining);
       }
-    },
-  );
+    });
+}
+
+export const resolveCommand = createResolveCommand();

--- a/packages/cli/src/sync/conflict-marker.ts
+++ b/packages/cli/src/sync/conflict-marker.ts
@@ -1,5 +1,6 @@
-import type { Task } from "@gh-gantt/shared";
-import { SYNC_FIELD_KEYS, type FieldConflict } from "./three-way-merge.js";
+import { SYNC_FIELD_KEYS } from "@gh-gantt/shared";
+import type { ConflictPolicy, Task } from "@gh-gantt/shared";
+import type { FieldConflict } from "./three-way-merge.js";
 
 const SYNC_FIELD_KEY_SET: Set<string> = new Set(SYNC_FIELD_KEYS);
 
@@ -77,4 +78,42 @@ export function resolveMarker(
  */
 export function hasUnresolvedMarkers(task: Record<string, unknown>): boolean {
   return detectMarkers(task).length > 0;
+}
+
+export interface PolicyResolution {
+  ours: Set<string>;
+  theirs: Set<string>;
+  unresolved: Set<string>;
+}
+
+/**
+ * 検出済み marker に宣言的ポリシーを適用する。
+ * manual・未定義は marker を保持する。marker 契約の対象は既知の SyncFields のみ。
+ */
+export function applyConflictPolicy(
+  task: Record<string, unknown>,
+  policy: ConflictPolicy,
+  filterField?: string,
+): PolicyResolution {
+  const result: PolicyResolution = {
+    ours: new Set(),
+    theirs: new Set(),
+    unresolved: new Set(),
+  };
+
+  for (const marker of detectMarkers(task)) {
+    if (filterField !== undefined && marker.field !== filterField) {
+      result.unresolved.add(marker.field);
+      continue;
+    }
+    const choice = policy[marker.field as keyof ConflictPolicy];
+    if (choice !== "ours" && choice !== "theirs") {
+      result.unresolved.add(marker.field);
+      continue;
+    }
+    resolveMarker(task, marker.field, choice);
+    result[choice].add(marker.field);
+  }
+
+  return result;
 }

--- a/packages/cli/src/sync/three-way-merge.ts
+++ b/packages/cli/src/sync/three-way-merge.ts
@@ -1,28 +1,7 @@
+import { SYNC_FIELD_KEYS } from "@gh-gantt/shared";
 import type { SyncFields } from "@gh-gantt/shared";
 
-export const SYNC_FIELD_KEYS: (keyof SyncFields)[] = [
-  "title",
-  "body",
-  "acceptance_criteria",
-  "acceptance_criteria_slot",
-  "implementer",
-  "reviewer",
-  "require_review",
-  "review_approved_by",
-  "review_approved_at",
-  "state",
-  "type",
-  "assignees",
-  "labels",
-  "milestone",
-  "custom_fields",
-  "parent",
-  "sub_tasks",
-  "start_date",
-  "end_date",
-  "date",
-  "blocked_by",
-];
+export { SYNC_FIELD_KEYS };
 
 export interface FieldConflict {
   field: string;

--- a/packages/shared/src/__tests__/schema.test.ts
+++ b/packages/shared/src/__tests__/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ConfigSchema, TasksFileSchema, TasksFileWithConflictsSchema } from "../schema.js";
+import { DEFAULT_CONFLICT_POLICY, SYNC_FIELD_KEYS } from "../types.js";
 
 const validTask = {
   id: "owner/repo#1",
@@ -399,6 +400,61 @@ describe("[NFR-STORE-001-AC1] 不正な形式のファイルを読み込んだ�
     };
     const parsed = ConfigSchema.parse(config);
     expect(parsed.gantt.default_view).toBe("week");
+  });
+});
+
+describe("[FR-SYNC-001-AC5] フィールド単位のコンフリクト解決ポリシーを検証できる", () => {
+  it("21個の同期フィールドすべてで ours / theirs / manual を受理する", () => {
+    expect(SYNC_FIELD_KEYS).toHaveLength(21);
+    const conflictPolicy = Object.fromEntries(
+      SYNC_FIELD_KEYS.map((field, index) => [
+        field,
+        (["ours", "theirs", "manual"] as const)[index % 3],
+      ]),
+    );
+
+    const parsed = ConfigSchema.parse({
+      ...validConfig,
+      sync: { ...validConfig.sync, conflict_policy: conflictPolicy },
+    });
+
+    expect(parsed.sync.conflict_policy).toEqual(conflictPolicy);
+  });
+
+  it("ポリシー全体と個別フィールドを省略できる", () => {
+    expect(ConfigSchema.parse(validConfig).sync.conflict_policy).toBeUndefined();
+
+    const parsed = ConfigSchema.parse({
+      ...validConfig,
+      sync: { ...validConfig.sync, conflict_policy: { state: "manual" } },
+    });
+    expect(parsed.sync.conflict_policy).toEqual({ state: "manual" });
+  });
+
+  it("未知のフィールドと値を拒否する", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        sync: { ...validConfig.sync, conflict_policy: { unknown_field: "ours" } },
+      }),
+    ).toThrow();
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        sync: { ...validConfig.sync, conflict_policy: { state: "remote-wins" } },
+      }),
+    ).toThrow();
+  });
+
+  it("init用の既定ポリシーは判断ガイドの6フィールドだけを宣言する", () => {
+    expect(DEFAULT_CONFLICT_POLICY).toEqual({
+      state: "ours",
+      start_date: "theirs",
+      end_date: "theirs",
+      milestone: "theirs",
+      assignees: "theirs",
+      labels: "theirs",
+    });
   });
 });
 

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -14,6 +14,7 @@ import type {
   Task,
   TasksFile,
 } from "./types.js";
+import { SYNC_FIELD_KEYS } from "./types.js";
 
 const TaskDisplaySchema = z.enum(["bar", "summary", "milestone"]);
 const DependencyTypeSchema = z.enum([
@@ -157,6 +158,15 @@ const DoctorConfigSchema: z.ZodType<DoctorConfig> = z.object({
   stale_in_progress_days: z.number().int().positive().optional(),
 });
 
+const ConflictPolicyChoiceSchema = z.enum(["ours", "theirs", "manual"]);
+const ConflictPolicySchema = z
+  .object(
+    Object.fromEntries(
+      SYNC_FIELD_KEYS.map((field) => [field, ConflictPolicyChoiceSchema.optional()]),
+    ) as Record<(typeof SYNC_FIELD_KEYS)[number], z.ZodOptional<typeof ConflictPolicyChoiceSchema>>,
+  )
+  .strict();
+
 // `default_view` の z.preprocess が input 型を unknown に広げるため、
 // Input 引数を unknown に明示して TS の input 型不整合を回避する。
 export const ConfigSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z.object({
@@ -172,6 +182,7 @@ export const ConfigSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z.object({
   sync: z
     .object({
       auto_create_issues: z.boolean(),
+      conflict_policy: ConflictPolicySchema.optional(),
       field_mapping: z.object({
         start_date: z.string(),
         end_date: z.string(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -104,6 +104,7 @@ export interface GithubConfig {
 
 export interface SyncConfig {
   auto_create_issues: boolean;
+  conflict_policy?: ConflictPolicy;
   field_mapping: {
     start_date: string;
     end_date: string;
@@ -222,6 +223,45 @@ export interface SyncFields {
   date: string | null;
   blocked_by: Dependency[];
 }
+
+/** 3-way merge と宣言的コンフリクト解決が対象にする同期フィールドの正本。 */
+export type SyncFieldKey = keyof SyncFields;
+export const SYNC_FIELD_KEYS: readonly SyncFieldKey[] = [
+  "title",
+  "body",
+  "acceptance_criteria",
+  "acceptance_criteria_slot",
+  "implementer",
+  "reviewer",
+  "require_review",
+  "review_approved_by",
+  "review_approved_at",
+  "state",
+  "type",
+  "assignees",
+  "labels",
+  "milestone",
+  "custom_fields",
+  "parent",
+  "sub_tasks",
+  "start_date",
+  "end_date",
+  "date",
+  "blocked_by",
+];
+
+export type ConflictPolicyChoice = "ours" | "theirs" | "manual";
+export type ConflictPolicy = Partial<Record<SyncFieldKey, ConflictPolicyChoice>>;
+
+/** init が生成する、安全側の既定ポリシー。未列挙フィールドは manual と同義。 */
+export const DEFAULT_CONFLICT_POLICY: Readonly<ConflictPolicy> = Object.freeze({
+  state: "ours",
+  start_date: "theirs",
+  end_date: "theirs",
+  milestone: "theirs",
+  assignees: "theirs",
+  labels: "theirs",
+});
 
 export interface Snapshot {
   hash: string;

--- a/skills/gh-gantt-conflict-resolution/SKILL.md
+++ b/skills/gh-gantt-conflict-resolution/SKILL.md
@@ -15,9 +15,19 @@ gh-gantt pull 後に発生した同期コンフリクトを CLI コマンドで�
    gh-gantt conflicts
    ```
 
-2. 各コンフリクトについて current / incoming / base を確認し、適切な値を判断
+2. 設定済みポリシーを先に適用:
 
-3. CLI で解決:
+   ```bash
+   gh-gantt resolve --auto
+   gh-gantt conflicts
+   ```
+
+   `resolve --auto <issue-number> --field <field>` ではなく、構文は
+   `resolve <issue-number> --auto --field <field>`。Issue と field で安全に絞り込める。
+
+3. 残った `manual` / 未定義フィールドだけ current / incoming / base を確認し、適切な値を判断
+
+4. CLI で解決:
 
    ```bash
    # 特定フィールドを解決
@@ -29,14 +39,14 @@ gh-gantt pull 後に発生した同期コンフリクトを CLI コマンドで�
    gh-gantt resolve <issue-number> --theirs
    ```
 
-4. 全解決を確認:
+5. 全解決を確認:
 
    ```bash
    gh-gantt conflicts
    # → "No conflicts."
    ```
 
-5. push を提案:
+6. push を提案:
    ```bash
    gh-gantt push
    ```
@@ -51,8 +61,25 @@ gh-gantt pull 後に発生した同期コンフリクトを CLI コマンドで�
 | `assignees` / `labels`    | リモートを尊重 → `--theirs` 優先                                                  |
 | 判断がつかない場合        | ユーザーに確認する                                                                |
 
+init が生成する既定 `sync.conflict_policy` は次のとおり。未記載フィールドは
+`manual` と同じく自動解決されない。
+
+```json
+{
+  "state": "ours",
+  "start_date": "theirs",
+  "end_date": "theirs",
+  "milestone": "theirs",
+  "assignees": "theirs",
+  "labels": "theirs"
+}
+```
+
+legacy `sync.conflict_strategy` は読み込みだけを維持し、`resolve --auto` では警告して
+無視する。値を全フィールドの fallback として扱ってはならない。
+
 ## Important
 
-- `tasks.json` を直接編集しない。必ず `gh-gantt resolve` コマンドを使う
+- `.gantt-sync/` の同期キャッシュを直接編集しない。必ず `gh-gantt resolve` コマンドを使う
 - 解決後は `gh-gantt conflicts` で残りがないことを確認する
 - コンフリクトが残っている状態では `push` も `pull` もできない

--- a/skills/gh-gantt-workflow/references/commands.md
+++ b/skills/gh-gantt-workflow/references/commands.md
@@ -114,14 +114,19 @@ gh-gantt conflicts [issue]
 同期コンフリクトを解決する。
 
 ```bash
-gh-gantt resolve [issue] [--ours] [--theirs] [--field <field>]
+gh-gantt resolve [issue] [--auto | --ours | --theirs] [--field <field>] [--json]
 ```
 
 **オプション:**
 
 - `--ours` — ローカル側の値を採用
 - `--theirs` — リモート側の値を採用
+- `--auto` — `sync.conflict_policy` の ours / theirs だけを適用。manual・未定義は残す
 - `--field <field>` — 特定フィールドのみ解決
+- `--json` — 解決後に残ったコンフリクトを既存の ConflictJson 形式で出力
+
+`--auto` / `--ours` / `--theirs` は排他的。`[issue]` と `--field` は先に対象範囲を
+絞り、範囲外を変更しない。部分解決は正常終了し、残件は text または JSON で確認できる。
 
 引数なしで実行するとインタラクティブモード。
 


### PR DESCRIPTION
## 概要

- `sync.conflict_policy` に同期フィールド単位の `ours` / `theirs` / `manual` を宣言できるようにしました
- `gh-gantt resolve --auto` が Issue・field filter を尊重し、設定済みフィールドだけを非対話で部分解決します
- 新規 `init` の既定値に `state=ours`、日付・milestone・assignees・labels=`theirs` を追加し、それ以外は手動判断に残します

## 安全性と互換性

- 未定義・`manual` の marker は保持し、未解決コンフリクトが残る契約を維持します
- snapshot は対象 Issue だけを更新し、全フィールドを `theirs` で解決した場合だけ `remoteHash` に揃えます
- legacy `sync.conflict_strategy` は読み込み互換を保ちますが、自動解決には適用せず stderr で移行警告を表示します
- pull 中の暗黙自動解決は行いません

## Living Documentation

- ADR-018 の Decision 5 を具体化しました
- FR-SYNC-001-AC5〜AC7 を追加し、schema・CLI・legacy 互換テストへ結線しました

## 検証

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（workflow 51 / shared 187 / CLI 649 / UI 221 / smoke 15）
- `pnpm build`
- `pnpm req:trace`（covered 177 / failing 0、追加差分なし）
- `git diff --exit-code docs/requirements.yaml`
- `pnpm req:validate`
- `pnpm docs:gen`
- `resolve --help` と targeted tests 32件、shared schema 49件
- 独立 reviewer pass 2: 10/10、findings 0

Closes #300
