### PR TITLE
docs(workflow): Graph Contract と Run Graph の責務境界を定義する

### DIFF
--- a/.gantt-sync/workflow.md
+++ b/.gantt-sync/workflow.md
@@ -59,6 +59,13 @@
 
 振る舞い変更を伴う開発では、Issue 作成時または実装中に `gh-gantt-living-documentation` スキルを invoke して、要件 AC の追加とテスト名への `[ID]` 付与を行うこと。
 
+## Graph Contract
+
+正典は`docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md`とする。
+
+- **現行 (#327)**: plan_id、plan_version、authority binding値のないunversioned provisional projectionとして、外部orchestratorが`.dev-flow`のJSON/schema/manual gateを運用する。製品はeventを受理しない。
+- **#328以後**: 製品control planeがversion bindingとeventを検証・受理する。外部runnerはexecutionだけを担う。
+
 ## Dev-Role Config
 
 `gh-gantt-dev-role` スキル用の設定。orchestrator / planner / implementer / executor / reviewer の各ロールが参照する。

--- a/docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md
+++ b/docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md
@@ -1,0 +1,234 @@
+---
+id: ADR-021
+title: Graph Contract と Run Graph の責務境界を定義する
+date: 2026-07-30
+status: accepted
+related_requirements:
+  - NFR-STABILITY-014
+---
+
+## Context
+
+gh-gantt は GitHub Issues / Projects 由来の仕事構造、repository-owned workflow、dev-role artifact、
+外側loopの実績を持つ。しかし、計画、仕事、権限、実行履歴の正本と、固定workflowの実行を追う
+ID・遷移・証拠は単一契約になっていない。task status と run status、retry と review improvement、
+外部runnerと製品の責務を分けなければ、durable実行履歴や並列化を安全に追加できない。
+
+一次資料に明記された事実として、[OpenAI Symphonyの固定commit版仕様](https://github.com/openai/symphony/blob/f8e8b8a670c799f6e0ade7a8c25c4bf4a4a56ec7/SPEC.md)は
+orchestratorの単一authority、明示的state machine、reconciliation、workspaceとagent subprocessの
+execution層を定義する。一方、scheduler stateはin-memoryで、restart時に正確なstateを永続storeから
+復元する仕様ではない。[Anthropic公式記事](https://www.anthropic.com/engineering/building-effective-agents)は
+事前定義workflowと動的agentを区別し、単純な構成から必要な場合だけ複雑化するよう勧める。
+
+gh-gantt固有の推論として、計画・仕事・権限・実績を別graphに分け、version、authority、evidence、
+budget、human gateで結ぶ設計規律をGraph Engineeringと呼ぶ。参照資料はこの名称を定義していないため、
+Graph Engineeringを確立済みの外部標準として扱わない。
+
+## Decision
+
+### 正準4 graphと正本
+
+| graph      | authoritative definition        | canonical artifact / store        | current #327                                                  | after #328            |
+| ---------- | ------------------------------- | --------------------------------- | ------------------------------------------------------------- | --------------------- |
+| Plan Graph | Graph Contract topology         | versioned plan artifact           | ADR-021 + workflowのunversioned provisional projection        | Graph Contract store  |
+| Org Graph  | Graph Contract role / authority | versioned authority binding       | ADR-021 + Dev-Role Configのunversioned provisional projection | Graph Contract store  |
+| Work Graph | GitHub Issues / Projects        | GitHub remote task / relation     | GitHub remoteが正本、.gantt-syncはcache                       | 変更なし              |
+| Run Graph  | accepted run event              | append-only Run Graph event store | 正準storeなし、.dev-flow artifactはevidence                   | Run Graph event store |
+
+Graph ContractはPlan GraphのtopologyとOrg Graphのrole / authorityを定義し、Work Graphの対象を参照する。
+versioned contract導入後、repository-owned workflowはcontract ID/versionの選択、repository固有config、
+verify commandを設定する。
+Run Graph eventはWork Graphを暗黙に変更しない。
+
+### version bindingと競合規則
+
+- 現行#327にはplan_id、plan_version、authority bindingの値がない。ADR-021とrepository-owned workflowは
+  unversioned provisional projectionであり、versioned Graph Contract実装済みの証拠にはしない。
+- 現行は外部orchestratorがworkflow、JSON Schema、manual gateの整合を確認するが、ID/versionのexact bindingや
+  fail-closed validationを実行したとは扱わない。
+- exact bindingとfail-closed validationは#328以後に導入する。Graph Contractは`plan_id`、`plan_version`、
+  `schema_version`、versioned authority bindingを持ち、workflowは`plan_id`と`plan_version`をexact bindingする。
+  workflowはGraph Contractを再定義しない。
+- #328以後の優先順位は、Work Graph dataはGitHub remote、Plan/Org topologyはbindingされたGraph Contract、
+  actual executionはaccepted Run Graph eventの順にそれぞれのscope内で正本とする。
+- workflowの散文やrole referenceがbindingされたcontractと競合した場合、推測で一方を選ばず
+  fail-closedで`waiting_human`へ送る。missing、unsupported、ambiguous versionも同じ扱いにする。
+- #328以後は製品control planeがbindingされたcontractを検証してeventを受理する。machine schemaと
+  ADRの説明が競合する場合はeventをfail-closedで拒否し、schema/ADR reconciliationを人間へ要求する。
+
+### Graph Contractの最小表現
+
+versioned Graph Contractは次を表現する。
+
+- `role`: Org Graph actor classとauthority binding
+- `node`: stable node ID、role、input/output artifact contract、node lifecycle
+- `edge`: stable edge ID、source、target、transition condition
+- `artifact`: artifact ID、schema、producer attempt、content hashまたはbounded reference
+- `evidence`: evidence ID、producer、attempt、provenance、bounded reference
+- `authority`: transitionの要求、承認、限定overrideを許可された主体
+- `budget`: verify retry、review improvement、将来のtime/cost/concurrencyの独立上限
+- `human gate`: approval requirement、待機理由、decision evidence
+- `schema version`: reader compatibilityとmigration rule
+
+artifactはrole間のデータ契約、evidenceは判断根拠であり、両方にprovenanceを持たせる。本文全体を
+複製せずcontent hashまたはbounded referenceを使う。`run ID`、`node ID`、`attempt ID`、
+`artifact ID`、`evidence ID`は安定opaque IDとし、task、plan version、producer attemptのlineageを保つ。
+
+### 正準状態集合
+
+tracker task stateはGitHub/project configの外部stateであり、次のRun Graph stateへ混在させない。
+
+| entity  | states                                                                       | terminal                                         |
+| ------- | ---------------------------------------------------------------------------- | ------------------------------------------------ |
+| run     | pending, running, paused, waiting_human, completed, failed, cancelled        | completed, failed, cancelled                     |
+| node    | pending, ready, running, paused, waiting_human, completed, failed, cancelled | completed, failed, cancelled                     |
+| attempt | created, running, succeeded, failed, timed_out, stalled, cancelled           | succeeded, failed, timed_out, stalled, cancelled |
+
+### 正準transition
+
+`terminal or checkpoint`が`checkpoint`の行だけ同じrun内でresume/migrateできる。terminal stateからは
+新しいrunまたはnode/attemptを作らない限り再開しない。不正eventはrefusal列どおりstateを変えず、
+reject evidenceを残す。`same state`はsourceの個別stateを保つ意味である。
+
+#### Run transition
+
+| source                                     | event or guard                                       | target            | terminal or checkpoint | refusal                    |
+| ------------------------------------------ | ---------------------------------------------------- | ----------------- | ---------------------- | -------------------------- |
+| run.pending                                | start + exact version/target valid                   | run.running       | no                     | reject; keep pending       |
+| run.running                                | pause + checkpoint persisted                         | run.paused        | checkpoint             | reject; keep running       |
+| run.paused                                 | resume + checkpoint/artifact/evidence valid          | run.running       | no                     | reject; keep paused        |
+| run.running                                | human_gate_required or budget_exceeded               | run.waiting_human | checkpoint             | reject; keep running       |
+| run.waiting_human                          | human_approved + authority/decision evidence valid   | run.running       | no                     | reject; keep waiting_human |
+| run.running                                | complete + required nodes/gates complete             | run.completed     | terminal               | reject; keep running       |
+| run.running                                | fail + non-retryable                                 | run.failed        | terminal               | reject; keep running       |
+| run.{pending,running,paused,waiting_human} | cancel + authority evidence valid                    | run.cancelled     | terminal               | reject; keep source        |
+| run.{paused,waiting_human}                 | migrate + supported version/migration evidence valid | same state        | checkpoint             | reject; keep source        |
+| run.{completed,failed,cancelled}           | stale_event                                          | same state        | terminal               | reject; keep source        |
+
+#### Node transition
+
+| source                                            | event or guard                                     | target             | terminal or checkpoint | refusal                    |
+| ------------------------------------------------- | -------------------------------------------------- | ------------------ | ---------------------- | -------------------------- |
+| node.pending                                      | dependencies_satisfied                             | node.ready         | no                     | reject; keep pending       |
+| node.ready                                        | attempt_started + authority valid                  | node.running       | no                     | reject; keep ready         |
+| node.running                                      | pause + checkpoint persisted                       | node.paused        | checkpoint             | reject; keep running       |
+| node.paused                                       | resume + checkpoint/artifact/evidence valid        | node.running       | no                     | reject; keep paused        |
+| node.running                                      | human_gate_required or budget_exceeded             | node.waiting_human | checkpoint             | reject; keep running       |
+| node.waiting_human                                | human_approved + authority/decision evidence valid | node.running       | no                     | reject; keep waiting_human |
+| node.running                                      | attempt_succeeded + schema-valid node outcome      | node.completed     | terminal               | reject; keep running       |
+| node.running                                      | non-retryable node outcome                         | node.failed        | terminal               | reject; keep running       |
+| node.{pending,ready,running,paused,waiting_human} | cancel + authority evidence valid                  | node.cancelled     | terminal               | reject; keep source        |
+| node.{completed,failed,cancelled}                 | stale_event                                        | same state         | terminal               | reject; keep source        |
+
+#### Attempt transition
+
+| source                                                 | event or guard                    | target            | terminal or checkpoint | refusal              |
+| ------------------------------------------------------ | --------------------------------- | ----------------- | ---------------------- | -------------------- |
+| attempt.created                                        | start + current attempt ID        | attempt.running   | no                     | reject; keep created |
+| attempt.running                                        | succeed + evidence valid          | attempt.succeeded | terminal               | reject; keep running |
+| attempt.running                                        | fail + failure evidence valid     | attempt.failed    | terminal               | reject; keep running |
+| attempt.running                                        | timeout                           | attempt.timed_out | terminal               | reject; keep running |
+| attempt.running                                        | stall                             | attempt.stalled   | terminal               | reject; keep running |
+| attempt.running                                        | cancel + authority evidence valid | attempt.cancelled | terminal               | reject; keep running |
+| attempt.{succeeded,failed,timed_out,stalled,cancelled} | stale_event                       | same state        | terminal               | reject; keep source  |
+
+### Cross-entity propagation
+
+attemptはexecution mechanicsであり、attemptのterminal eventだけではnode outcomeにならない。
+control planeはattempt eventとschema-valid node outcomeを別々に検証し、次の表だけで親entityへ伝播する。
+
+| source                             | event or guard                                                      | target                              | run effect                       | identity / lineage                 |
+| ---------------------------------- | ------------------------------------------------------------------- | ----------------------------------- | -------------------------------- | ---------------------------------- |
+| attempt.succeeded                  | schema-valid node outcome                                           | node.completed + evaluate Plan edge | run.running                      | terminal attempt preserved         |
+| attempt.{failed,timed_out,stalled} | retryable + attempt_count < attempt budget                          | node.ready                          | run.running                      | new monotonic attempt ID + lineage |
+| attempt.{failed,timed_out,stalled} | retryable + attempt_count >= attempt budget                         | node.waiting_human                  | run.waiting_human checkpoint     | terminal attempt preserved         |
+| attempt.{failed,timed_out,stalled} | non-retryable                                                       | node.failed                         | run.failed terminal              | terminal attempt preserved         |
+| executor role node                 | schema-valid verify_failed outcome + retry budget available         | new implementer Run node ID         | run.running + evaluate Plan edge | source node remains completed      |
+| reviewer role node                 | schema-valid request-changes outcome + improvement budget available | new implementer Run node ID         | run.running + evaluate Plan edge | source node remains completed      |
+
+retryableなfailed、timed_out、stalledでは、終端attemptを変更せずnodeをreadyへ戻すと同時に、同じnodeの
+単調増加する新attempt IDとlineageを作る。attempt budgetを使い切ったretryable failureはnodeとrunを
+`waiting_human` checkpointへ送り、non-retryable failureだけがnodeとrunを`failed` terminalへ送る。
+
+### Fixed dev-role transition
+
+このtableは最初のPlan Graphを定義する。`waiting_human`は停止handoffであり、外部runnerが必須human gateを
+bypassできない。限定bypassはcontractが許可したedgeだけをauthority、理由、対象、時刻、evidence付きで
+実行する。
+
+各role nodeはschema-valid outcomeを出して`completed`となり、表のtargetはPlan edgeが作る新しいRun nodeを
+表す。`verify_failed`と`request-changes`でもterminalなsource nodeを再openせず、新しいtarget role Run node IDを
+作る。
+
+| source      | event or guard                                                               | target        | outcome             | evidence                                       |
+| ----------- | ---------------------------------------------------------------------------- | ------------- | ------------------- | ---------------------------------------------- |
+| planner     | plan_valid + schema-valid                                                    | implementer   | CONTINUE            | plan artifact                                  |
+| planner     | plan_invalid or evidence_missing                                             | waiting_human | BLOCKED             | validation evidence                            |
+| implementer | implementation_valid + evidence present                                      | executor      | CONTINUE            | implementation artifact                        |
+| implementer | implementation_invalid or evidence_missing                                   | waiting_human | BLOCKED             | validation evidence                            |
+| executor    | verify_passed                                                                | reviewer      | CONTINUE            | all command evidence                           |
+| executor    | verify_failed + retry_count < maxExecutorRetries                             | implementer   | RETRY               | failure evidence + new implementer Run node ID |
+| executor    | verify_failed + retry_count >= maxExecutorRetries                            | waiting_human | BLOCKED             | failure evidence                               |
+| reviewer    | approve                                                                      | human / PR    | READY_FOR_PR        | independent review artifact                    |
+| reviewer    | request-changes + no critical + improvement_count < maxImprovementIterations | implementer   | IMPROVE             | findings + new implementer Run node ID         |
+| reviewer    | budget exhausted + only minor remains                                        | human / PR    | CONDITIONAL_HANDOFF | remaining findings in PR description           |
+| reviewer    | budget exhausted + major remains                                             | waiting_human | BLOCKED             | remaining major findings                       |
+| reviewer    | critical finding                                                             | waiting_human | ESCALATED           | critical finding evidence                      |
+| any role    | required evidence missing                                                    | waiting_human | BLOCKED             | missing evidence list                          |
+| human / PR  | approved / merged                                                            | terminal      | COMPLETED           | human decision + PR evidence                   |
+
+### Budget計数規則
+
+- 初回executor attemptはretry_count=0とする。executor failureからimplementerへ戻るedgeを受理すると
+  `retry_count`を1増やす。`maxExecutorRetries`は初回後の追加retry回数であり、値2ならexecutorは最大3回。
+- 初回reviewer passはimprovement_count=0とする。reviewerの`request-changes`からimplementerへ戻るedgeを
+  受理すると1増やす。`maxImprovementIterations`はreviewer起点の追加改善回数であり、値3ならreviewerは最大4回。
+- evidence欠落はbudgetを消費せずBLOCKED、critical findingは残budgetに関係なくESCALATEDとする。
+- improvement budget超過時、minorだけならCONDITIONAL_HANDOFF、majorが残ればBLOCKEDとする。
+- retryは古いattemptを再開せず、単調増加する新しいattempt IDとlineageを作る。terminal/stale attemptの
+  updateは拒否する。
+
+### control planeとexecution planeの段階境界
+
+現行(#327)は外部orchestratorがworkspace、agent subprocess、tool/command、JSON artifact、schema validation、
+manual gateを運用する。`.dev-flow`はignored evidenceであり、durable Run Graphでも製品control planeでもない。
+
+#328以後、gh-ganttの製品control planeがbinding validation、stable ID、transition、budget、authority、
+human gate、checkpoint、idempotent event受付、bounded status viewを担う。外部runnerはexecution planeとして
+処理し、schema-valid outcome/artifact/evidence eventを返す。provider SDK、agent subprocess、任意shell
+executor、PR reply/resolve/mergeは製品へ内蔵しない。
+
+### versioned拡張
+
+- 並列化(#329)はready frontier、claim、lease、bounded concurrency、join conditionを追加する。
+- 動的変更(#331)はapproval付きproposalを検証して新しいplan versionを作る。実行中versionを直接変更しない。
+- 可視化(#330)はplanned topologyとactual transitionを重ねる。
+
+Issue #327ではTypeScript schema、store、CLI event commandを実装しない。
+
+## Alternatives
+
+### Work GraphとRun Graphをtask statusへ統合する
+
+GitHub statusだけでroleとattemptを表すと再試行履歴とevidenceが失われ、人間の仕事状態とrunnerの一時状態が
+競合するため採用しない。
+
+### gh-ganttへrunnerとprovider SDKを内蔵する
+
+[Symphonyのcoordination/execution分離](https://github.com/openai/symphony/blob/f8e8b8a670c799f6e0ade7a8c25c4bf4a4a56ec7/SPEC.md#32-abstraction-levels)を
+参考に一体化も検討したが、agent/CI固有の実行方式をcontrol planeへ持ち込み、general-purpose workflow
+engineへscopeが広がるため採用しない。これは一次資料の要請ではなくgh-gantt固有の推論である。
+
+### 動的graphと並列実行を同時に導入する
+
+[Anthropic公式記事の単純な構成から始める指針](https://www.anthropic.com/engineering/building-effective-agents#when-and-when-not-to-use-agents)に
+照らし、ID、authority、failure semanticsを実測する前にmutation surfaceを増やさない。まず一Issueの
+fixed graph、次にbounded parallelism、最後にapproval-gated mutationの順で追加する。
+
+## Consequences
+
+- ADR-021が4 graph、state、transition、budget、責務境界の唯一の設計正典となる。
+- active workflow/skill/view文書は文脈固有の操作とADR-021への導線だけを持つ。
+- 現行artifact handoffを製品control plane実装済みとは扱わず、durable Run Graphは#328に残す。
+- NFR-STABILITY-014は将来製品挙動が実装されるまで`uncovered`を維持する。
+- #329と#331はstable ID、lineage、schema version、fail-closed規則を壊さず拡張する。

--- a/docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md
+++ b/docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md
@@ -150,6 +150,22 @@ retryableなfailed、timed_out、stalledでは、終端attemptを変更せずnod
 単調増加する新attempt IDとlineageを作る。attempt budgetを使い切ったretryable failureはnodeとrunを
 `waiting_human` checkpointへ送り、non-retryable failureだけがnodeとrunを`failed` terminalへ送る。
 
+### Safety preflight precedence
+
+review artifactのdeclared verdictを適用する前に、次のpriority順で安全性を評価する。同じpriority内の
+BLOCKED条件は同じ停止結果へ集約し、priority 3へ到達した場合だけ通常verdict edgeを選ぶ。
+
+| priority | condition                                  | declared verdict       | result                    | evidence                            |
+| -------- | ------------------------------------------ | ---------------------- | ------------------------- | ----------------------------------- |
+| 1        | critical finding present                   | approve                | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | comment                | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | request-changes        | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | block                  | ESCALATED                 | critical finding evidence           |
+| 2        | required evidence missing                  | any                    | BLOCKED                   | missing evidence list               |
+| 2        | verify-result inconsistency                | any                    | BLOCKED                   | verification inconsistency evidence |
+| 2        | verdict/finding semantic contract mismatch | any                    | BLOCKED                   | semantic validation evidence        |
+| 3        | all safety guards passed                   | contract-valid verdict | apply normal verdict edge | validated review artifact           |
+
 ### Fixed dev-role transition
 
 このtableは最初のPlan Graphを定義する。`waiting_human`は停止handoffであり、外部runnerが必須human gateを
@@ -160,22 +176,28 @@ bypassできない。限定bypassはcontractが許可したedgeだけをauthorit
 表す。`verify_failed`と`request-changes`でもterminalなsource nodeを再openせず、新しいtarget role Run node IDを
 作る。
 
-| source      | event or guard                                                               | target        | outcome             | evidence                                       |
-| ----------- | ---------------------------------------------------------------------------- | ------------- | ------------------- | ---------------------------------------------- |
-| planner     | plan_valid + schema-valid                                                    | implementer   | CONTINUE            | plan artifact                                  |
-| planner     | plan_invalid or evidence_missing                                             | waiting_human | BLOCKED             | validation evidence                            |
-| implementer | implementation_valid + evidence present                                      | executor      | CONTINUE            | implementation artifact                        |
-| implementer | implementation_invalid or evidence_missing                                   | waiting_human | BLOCKED             | validation evidence                            |
-| executor    | verify_passed                                                                | reviewer      | CONTINUE            | all command evidence                           |
-| executor    | verify_failed + retry_count < maxExecutorRetries                             | implementer   | RETRY               | failure evidence + new implementer Run node ID |
-| executor    | verify_failed + retry_count >= maxExecutorRetries                            | waiting_human | BLOCKED             | failure evidence                               |
-| reviewer    | approve                                                                      | human / PR    | READY_FOR_PR        | independent review artifact                    |
-| reviewer    | request-changes + no critical + improvement_count < maxImprovementIterations | implementer   | IMPROVE             | findings + new implementer Run node ID         |
-| reviewer    | budget exhausted + only minor remains                                        | human / PR    | CONDITIONAL_HANDOFF | remaining findings in PR description           |
-| reviewer    | budget exhausted + major remains                                             | waiting_human | BLOCKED             | remaining major findings                       |
-| reviewer    | critical finding                                                             | waiting_human | ESCALATED           | critical finding evidence                      |
-| any role    | required evidence missing                                                    | waiting_human | BLOCKED             | missing evidence list                          |
-| human / PR  | approved / merged                                                            | terminal      | COMPLETED           | human decision + PR evidence                   |
+Safety preflight precedenceはcross-cutting guardであり、declared verdictに関係なく通常verdict edgeより先に
+適用する。`any role + required evidence missing`もnormal verdictのfallbackではなく、criticalの次に通常edgeを
+preemptする。Fixed transition tableはpreflightで受理される停止edgeと、その通過後だけ選べる通常edgeを示す。
+
+| source      | event or guard                                                                                           | target        | outcome             | evidence                                       |
+| ----------- | -------------------------------------------------------------------------------------------------------- | ------------- | ------------------- | ---------------------------------------------- |
+| planner     | plan_valid + schema-valid                                                                                | implementer   | CONTINUE            | plan artifact                                  |
+| planner     | plan_invalid or evidence_missing                                                                         | waiting_human | BLOCKED             | validation evidence                            |
+| implementer | implementation_valid + evidence present                                                                  | executor      | CONTINUE            | implementation artifact                        |
+| implementer | implementation_invalid or evidence_missing                                                               | waiting_human | BLOCKED             | validation evidence                            |
+| executor    | verify_passed                                                                                            | reviewer      | CONTINUE            | all command evidence                           |
+| executor    | verify_failed + retry_count < maxExecutorRetries                                                         | implementer   | RETRY               | failure evidence + new implementer Run node ID |
+| executor    | verify_failed + retry_count >= maxExecutorRetries                                                        | waiting_human | BLOCKED             | failure evidence                               |
+| reviewer    | critical finding present                                                                                 | waiting_human | ESCALATED           | critical finding evidence                      |
+| any role    | required evidence missing                                                                                | waiting_human | BLOCKED             | missing evidence list                          |
+| reviewer    | verify-result inconsistency or verdict/finding semantic contract mismatch                                | waiting_human | BLOCKED             | review validation evidence                     |
+| reviewer    | approve + findings empty                                                                                 | human / PR    | READY_FOR_PR        | independent review artifact                    |
+| reviewer    | request-changes + (major or plan/implementation mismatch) + improvement_count < maxImprovementIterations | implementer   | IMPROVE             | findings + new implementer Run node ID         |
+| reviewer    | comment + minor/nit only                                                                                 | human / PR    | CONDITIONAL_HANDOFF | remaining findings evidence                    |
+| reviewer    | budget exhausted + request-changes remains                                                               | waiting_human | BLOCKED             | remaining request-changes evidence             |
+| reviewer    | block + blocking reason/evidence + no critical                                                           | waiting_human | BLOCKED             | blocking evidence                              |
+| human / PR  | approved / merged                                                                                        | terminal      | COMPLETED           | human decision + PR evidence                   |
 
 ### Budget計数規則
 
@@ -184,7 +206,8 @@ bypassできない。限定bypassはcontractが許可したedgeだけをauthorit
 - 初回reviewer passはimprovement_count=0とする。reviewerの`request-changes`からimplementerへ戻るedgeを
   受理すると1増やす。`maxImprovementIterations`はreviewer起点の追加改善回数であり、値3ならreviewerは最大4回。
 - evidence欠落はbudgetを消費せずBLOCKED、critical findingは残budgetに関係なくESCALATEDとする。
-- improvement budget超過時、minorだけならCONDITIONAL_HANDOFF、majorが残ればBLOCKEDとする。
+- CONDITIONAL_HANDOFFはreviewerがschema-valid `comment`を返した場合だけ選ぶ。improvement budget超過時に
+  request-changesが残れば、major findingまたはplan/implementation mismatchをseverityだけで`comment`へ降格せずBLOCKEDとする。
 - retryは古いattemptを再開せず、単調増加する新しいattempt IDとlineageを作る。terminal/stale attemptの
   updateは拒否する。
 
@@ -193,7 +216,7 @@ bypassできない。限定bypassはcontractが許可したedgeだけをauthorit
 現行(#327)は外部orchestratorがworkspace、agent subprocess、tool/command、JSON artifact、schema validation、
 manual gateを運用する。`.dev-flow`はignored evidenceであり、durable Run Graphでも製品control planeでもない。
 
-#328以後、gh-ganttの製品control planeがbinding validation、stable ID、transition、budget、authority、
+Issue #328以後、gh-ganttの製品control planeがbinding validation、stable ID、transition、budget、authority、
 human gate、checkpoint、idempotent event受付、bounded status viewを担う。外部runnerはexecution planeとして
 処理し、schema-valid outcome/artifact/evidence eventを返す。provider SDK、agent subprocess、任意shell
 executor、PR reply/resolve/mergeは製品へ内蔵しない。

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -138,3 +138,9 @@ score =
 ## 9. 循環依存の扱い
 
 `blocked_by` に循環がある場合、`calculateCriticalPath()` は timing を計算できない。Project Map は ViewModel の `warnings` に循環を記録し、Dependency Map で警告表示する。循環があっても他パネルはクラッシュしない。
+
+## 10. Graph Contractとの関係
+
+Project MapはWork Graphの派生viewであり、graph contractの正典はADR-021とする。
+本viewは実行履歴を生成せず、taskを暗黙に変更しない。planned-vs-actual表示は#330まで未実装である。
+後続拡張は、#329のclaim/lease/joinと#331のapproval proposal/new plan versionをADR-021で確認する。

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1421,3 +1421,55 @@ areas:
             status: covered
             tests:
               - tests/workflow/project-config.test.ts
+      - id: NFR-STABILITY-014
+        summary: Graph Contract に基づく durable Run Graph の統制
+        acceptance_criteria:
+          - id: NFR-STABILITY-014-AC1
+            description: |
+              Plan Graph、Work Graph、Org Graph、Run Graph が別の正本と責務を持ち、
+              versioned Graph Contract を介して参照される
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC2
+            description: |
+              gh-gantt control plane が contract validation、stable ID、transition、
+              budget、authority、human gate、checkpoint、bounded view を統制し、
+              external runner が execution plane として outcome event を返す
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC3
+            description: |
+              Graph Contract が role、node、edge、transition condition、artifact、
+              evidence、authority、budget、human gate、schema version を表現する
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC4
+            description: |
+              run、node、attempt、artifact、evidence の安定 ID と lineage を保持し、
+              task、run、node、attempt の状態を別々に扱う
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC5
+            description: |
+              停止、取消、失敗、再開、checkpoint、migration の意味論を持ち、
+              unsupported schema version と古い attempt の update を拒否する
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC6
+            description: |
+              fixed dev-role graph が transition guard、evidence、verify retry と
+              review improvement の独立 budget、不正 transition の拒否を持つ
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC7
+            description: |
+              bypass は許可 edge、authority、理由、evidence に限定され、
+              外部 runner は必須 human gate を bypass できない
+            status: uncovered
+            tests: []
+          - id: NFR-STABILITY-014-AC8
+            description: |
+              bounded parallelism と approval-gated な Work Graph 変更を、
+              stable ID と event lineage を壊さない versioned extension として追加できる
+            status: uncovered
+            tests: []

--- a/skills/gh-gantt-dev-role/SKILL.md
+++ b/skills/gh-gantt-dev-role/SKILL.md
@@ -73,6 +73,13 @@ Evidence: 読み込んだ config path、role 名、検証した artifact path、
 4. reference の HARD-GATE を満たしてから role を実行する。
 5. 出力を `scratchpadDir/<issue-number>/` に schema 準拠で保存する。
 
+## Graph Contract 上の位置づけ
+
+正典はADR-021とする。本スキル固有の責務はrole artifactを受け渡すことだけである。
+
+- **現行 (#327)**: 外部orchestratorが`.dev-flow`のJSON/schema/manual gateを運用する。
+- **#328以後**: 製品control planeがeventを受理し、本スキルを使う外部runnerはexecutionだけを担う。
+
 ## 共通 Artifact
 
 | ファイル                         | 作成 role    | schema                                                                                             |

--- a/skills/gh-gantt-dev-role/SKILL.md
+++ b/skills/gh-gantt-dev-role/SKILL.md
@@ -73,12 +73,11 @@ Evidence: 読み込んだ config path、role 名、検証した artifact path、
 4. reference の HARD-GATE を満たしてから role を実行する。
 5. 出力を `scratchpadDir/<issue-number>/` に schema 準拠で保存する。
 
-## Graph Contract 上の位置づけ
+## Project Contract Discovery
 
-正典はADR-021とする。本スキル固有の責務はrole artifactを受け渡すことだけである。
-
-- **現行 (#327)**: 外部orchestratorが`.dev-flow`のJSON/schema/manual gateを運用する。
-- **#328以後**: 製品control planeがeventを受理し、本スキルを使う外部runnerはexecutionだけを担う。
+`.gantt-sync/workflow.md`にproject-owned Graph Contractセクションや設計文書への参照がある場合、
+Config Discoveryと同時に読み、role transition、budget、human gate、control/execution境界へ適用する。
+本スキルはproject固有のcontract IDやroadmapをhard-codeせず、role artifactの受け渡しだけを汎用定義する。
 
 ## 共通 Artifact
 

--- a/skills/gh-gantt-dev-role/references/orchestrator.md
+++ b/skills/gh-gantt-dev-role/references/orchestrator.md
@@ -33,20 +33,48 @@ Evidence: sync status、conflict status、Issue 番号、config path、verify co
 6. `executor` を pass 1 として呼び、`03-verify-result-pass-1.json` を作成させる。
 7. executor が failed の場合は `maxExecutorRetries` まで implementer に戻す。
 8. executor が passed になったら `reviewer` を呼び、`04-review-pass-<n>.json` を作成させる。
-9. reviewer が `request-changes` または `block` の場合、`maxImprovementIterations` まで implementer に findings を渡して再実行する。
-10. 終了条件を判定する。
-11. PR 作成に進める場合は `gh-gantt-pr` または project の `prCreator` に引き継ぐ。
-12. PR 作成後は `gh-gantt-workflow` の PR 後レビューサイクルを開始する。
-13. 最終判断を `99-orchestrator-decision.md` に保存する。
+9. review artifactをSafety preflight precedenceで検証する。critical findingが1件でもあればdeclared verdictに
+   関係なく`ESCALATED`とする。
+10. criticalがない場合も、required evidence missing、verify-result inconsistency、またはverdict/finding semantic
+    contract mismatchがあれば、通常verdict edgeより先に`BLOCKED`とする。
+11. preflight通過後だけReviewer verdict operationを適用する。schema-valid `comment`はminor / nitだけ、
+    `approve`はfindings empty、`request-changes`はmajorまたはplan/implementation mismatchを要求する。
+12. 改善budget超過時に`request-changes`が残ればseverityだけで`comment`へ降格せず`BLOCKED`とし、
+    `block`はblocking reason/evidenceを保持して`BLOCKED`とする。
+13. 終了条件を判定する。
+14. PR 作成に進める場合は `gh-gantt-pr` または project の `prCreator` に引き継ぐ。
+15. PR 作成後は `gh-gantt-workflow` の PR 後レビューサイクルを開始する。
+16. 最終判断を `99-orchestrator-decision.md` に保存する。
 
-## 固定 Plan Graph
+## Project Contract Discovery
 
-ADR-021のFixed dev-role transitionを正典とする。orchestratorは同ADRのBudget計数規則に従い、
-各artifactとevidenceを検証してからedgeを選ぶ。終了結果は`BLOCKED`、`ESCALATED`、
-`READY_FOR_PR`、`CONDITIONAL_HANDOFF`、`COMPLETED`のいずれかとし、独自の遷移や計数規則を加えない。
+`.gantt-sync/workflow.md`にproject-owned Graph Contractセクションや設計文書への参照がある場合は、
+そのrole transitionとbudget規則を正典として各artifactとevidenceを検証してからedgeを選ぶ。
+project contractがない場合も必須human gateと独立executor/reviewerをbypassしない。終了結果は
+`BLOCKED`、`ESCALATED`、`READY_FOR_PR`、`CONDITIONAL_HANDOFF`、`COMPLETED`のいずれかとする。
 
-現行は外部orchestratorがこの判断を行う。#328以後に製品control planeがeventを受理する場合も、
-必須human gateと独立executor/reviewerをbypassしない。
+### Safety preflight precedence
+
+| priority | condition                                  | declared verdict       | result                    | evidence                            |
+| -------- | ------------------------------------------ | ---------------------- | ------------------------- | ----------------------------------- |
+| 1        | critical finding present                   | approve                | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | comment                | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | request-changes        | ESCALATED                 | critical finding evidence           |
+| 1        | critical finding present                   | block                  | ESCALATED                 | critical finding evidence           |
+| 2        | required evidence missing                  | any                    | BLOCKED                   | missing evidence list               |
+| 2        | verify-result inconsistency                | any                    | BLOCKED                   | verification inconsistency evidence |
+| 2        | verdict/finding semantic contract mismatch | any                    | BLOCKED                   | semantic validation evidence        |
+| 3        | all safety guards passed                   | contract-valid verdict | apply normal verdict edge | validated review artifact           |
+
+### Reviewer verdict operation
+
+| verdict         | guard                                                                                   | action                               | status              |
+| --------------- | --------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
+| approve         | contract-valid + findings empty                                                         | human / PR                           | READY_FOR_PR        |
+| comment         | contract-valid + minor/nit only                                                         | preserve remaining findings evidence | CONDITIONAL_HANDOFF |
+| request-changes | contract-valid + (major or plan/implementation mismatch) + improvement budget available | implementer improvement              | IMPROVE             |
+| request-changes | contract-valid + (major or plan/implementation mismatch) + improvement budget exhausted | waiting_human                        | BLOCKED             |
+| block           | contract-valid + blocking reason/evidence + no critical                                 | waiting_human                        | BLOCKED             |
 
 ## 出力契約
 

--- a/skills/gh-gantt-dev-role/references/orchestrator.md
+++ b/skills/gh-gantt-dev-role/references/orchestrator.md
@@ -39,21 +39,20 @@ Evidence: sync status、conflict status、Issue 番号、config path、verify co
 12. PR 作成後は `gh-gantt-workflow` の PR 後レビューサイクルを開始する。
 13. 最終判断を `99-orchestrator-decision.md` に保存する。
 
-## 終了条件
+## 固定 Plan Graph
 
-| 条件                                                       | 判定                                          |
-| ---------------------------------------------------------- | --------------------------------------------- |
-| executor passed かつ reviewer approve                      | PR 作成へ進む                                 |
-| executor が `maxExecutorRetries` 回連続 failed             | `BLOCKED`                                     |
-| reviewer が critical finding を残した                      | `ESCALATED`                                   |
-| `maxImprovementIterations` 到達後に minor finding のみ残る | PR description に残課題を書いて人間レビューへ |
-| Issue / config / artifact が欠落                           | `BLOCKED`                                     |
+ADR-021のFixed dev-role transitionを正典とする。orchestratorは同ADRのBudget計数規則に従い、
+各artifactとevidenceを検証してからedgeを選ぶ。終了結果は`BLOCKED`、`ESCALATED`、
+`READY_FOR_PR`、`CONDITIONAL_HANDOFF`、`COMPLETED`のいずれかとし、独自の遷移や計数規則を加えない。
+
+現行は外部orchestratorがこの判断を行う。#328以後に製品control planeがeventを受理する場合も、
+必須human gateと独立executor/reviewerをbypassしない。
 
 ## 出力契約
 
 `99-orchestrator-decision.md` に以下を含める。
 
-- `status`: `READY_FOR_PR` / `BLOCKED` / `ESCALATED`
+- `status`: `READY_FOR_PR` / `CONDITIONAL_HANDOFF` / `BLOCKED` / `ESCALATED` / `COMPLETED`
 - 対象 Issue
 - 使用 config path
 - 実行した pass 数

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -16,14 +16,11 @@ description: gh-gantt の開発サイクル全体を回すオーケストレー�
 
 注: `gh-gantt init` がワークフローファイルの自動生成に対応している場合はそちらを使用する。
 
-## Graph Contract との責務境界
+## Project Contract Discovery
 
-正典はADR-021とする。本スキルはWork Graphからtaskを選び、dev-roleへ引き継ぐ。
-
-- **現行 (#327)**: 外部orchestratorがJSON/schema/manual gateを運用する。
-- **#328以後**: 製品control planeがeventを受理し、外部runnerはexecutionだけを担う。
-
-後続拡張は、#329のclaim/lease/joinと#331のapproval proposal/new plan versionをADR-021で確認する。
+`.gantt-sync/workflow.md`にproject-owned Graph Contractセクションや設計文書への参照がある場合は、
+task選定とdev-roleへの引き継ぎ前に読み、project固有のbinding、段階境界、roadmapへ従う。
+本スキルは特定projectのcontract IDやIssue番号をhard-codeしない。
 
 ## ライフサイクルフック
 

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -16,6 +16,15 @@ description: gh-gantt の開発サイクル全体を回すオーケストレー�
 
 注: `gh-gantt init` がワークフローファイルの自動生成に対応している場合はそちらを使用する。
 
+## Graph Contract との責務境界
+
+正典はADR-021とする。本スキルはWork Graphからtaskを選び、dev-roleへ引き継ぐ。
+
+- **現行 (#327)**: 外部orchestratorがJSON/schema/manual gateを運用する。
+- **#328以後**: 製品control planeがeventを受理し、外部runnerはexecutionだけを担う。
+
+後続拡張は、#329のclaim/lease/joinと#331のapproval proposal/new plan versionをADR-021で確認する。
+
 ## ライフサイクルフック
 
 このスキルは以下のフックポイントを定義する。各フックで `.gantt-sync/workflow.md` に対応するセクションが存在すれば、そのアクションを実行する。定義がなければスキップする。

--- a/skills/gh-gantt-workflow/references/autonomous-loop.md
+++ b/skills/gh-gantt-workflow/references/autonomous-loop.md
@@ -2,10 +2,13 @@
 
 外側ループ（タスクを選ぶ → 完了させる → 次を選ぶ）をコード駆動で回す手順。
 決定論的な部分（選定・停止判定・実績記録）は gh-gantt CLI が行い、
-エージェントは設計・実装だけを担う（ADR-016 / ADR-017）。
+エージェントは設計・実装だけを担う。
 
-外側のWork Graph iterationと内側の固定dev-role graphは区別する。意味論の正典はADR-021とし、
-現行の`.dev-flow`はartifact handoffに留まる。durable Run Graphは#328で追加する。
+## Project Contract Discovery
+
+`.gantt-sync/workflow.md`にproject-owned Graph Contractセクションや設計文書への参照がある場合は、
+外側のWork Graph iterationと内側のdev-role graphの境界、artifact、event、停止条件へ適用する。
+この汎用手順は特定projectのcontract IDやroadmapをhard-codeしない。
 
 ## 1 イテレーションの手順
 
@@ -34,16 +37,16 @@
 
 ## センサー結線（検証とループの接続）
 
-検証（`verifyCommands` / dev-role の executor gate, ADR-014）は外側ループのセンサーであり、
+検証（`verifyCommands` / dev-role の executor gate）は外側ループのセンサーであり、
 検証失敗は**新規 Issue 化せず、同一イテレーション内の retry** として扱う
-（`loop.onVerifyFailure: retry`, ADR-016 案D）。
+（`loop.onVerifyFailure: retry`）。
 
 - リトライ予算は dev-role の `maxExecutorRetries` に従う。予算内に合格しなければ
   `--outcome verify_failed` で記録して次の decide に進む
 - 各試行は `--verify "<command>=pass|fail"` で失敗分も含めて漏れなく記録する
   （attempt は指定順で採番）。記録した attempt 分布が
   `gh-gantt loop status` の Loop metrics（改善反復ヒストグラム・停滞警告）の入力になる
-- Living Documentation 採用プロジェクト（ADR-012）では、各イテレーションの record 前に
+- Living Documentation 採用プロジェクトでは、各イテレーションの record 前に
   `pnpm req:trace` → `pnpm req:validate` を 1 回実行して要件トレーサビリティの陳腐化を防ぎ、
   結果を `--verify "req:validate=pass"` として記録する
 

--- a/skills/gh-gantt-workflow/references/autonomous-loop.md
+++ b/skills/gh-gantt-workflow/references/autonomous-loop.md
@@ -4,6 +4,9 @@
 決定論的な部分（選定・停止判定・実績記録）は gh-gantt CLI が行い、
 エージェントは設計・実装だけを担う（ADR-016 / ADR-017）。
 
+外側のWork Graph iterationと内側の固定dev-role graphは区別する。意味論の正典はADR-021とし、
+現行の`.dev-flow`はartifact handoffに留まる。durable Run Graphは#328で追加する。
+
 ## 1 イテレーションの手順
 
 1. **observe** — `gh-gantt pull` で最新化する。コンフリクト検出時は

--- a/tests/workflow/graph-contract.test.ts
+++ b/tests/workflow/graph-contract.test.ts
@@ -123,6 +123,8 @@ describe("Graph Contract の公開文書契約", () => {
     expect(binding).toContain("waiting_human");
     expect(binding).toContain("現行#327");
     expect(binding).toContain("#328以後");
+    expect(body).toContain("Issue #328以後");
+    expect(body).not.toMatch(/^#328/m);
   });
 
   it("run/node/attemptの正準状態集合を完全一致で定義する", async () => {
@@ -451,35 +453,7 @@ describe("Graph Contract の公開文書契約", () => {
       ),
       devTransition(
         "reviewer",
-        "approve",
-        "human / PR",
-        "READY_FOR_PR",
-        "independent review artifact",
-      ),
-      devTransition(
-        "reviewer",
-        "request-changes + no critical + improvement_count < maxImprovementIterations",
-        "implementer",
-        "IMPROVE",
-        "findings + new implementer Run node ID",
-      ),
-      devTransition(
-        "reviewer",
-        "budget exhausted + only minor remains",
-        "human / PR",
-        "CONDITIONAL_HANDOFF",
-        "remaining findings in PR description",
-      ),
-      devTransition(
-        "reviewer",
-        "budget exhausted + major remains",
-        "waiting_human",
-        "BLOCKED",
-        "remaining major findings",
-      ),
-      devTransition(
-        "reviewer",
-        "critical finding",
+        "critical finding present",
         "waiting_human",
         "ESCALATED",
         "critical finding evidence",
@@ -490,6 +464,48 @@ describe("Graph Contract の公開文書契約", () => {
         "waiting_human",
         "BLOCKED",
         "missing evidence list",
+      ),
+      devTransition(
+        "reviewer",
+        "verify-result inconsistency or verdict/finding semantic contract mismatch",
+        "waiting_human",
+        "BLOCKED",
+        "review validation evidence",
+      ),
+      devTransition(
+        "reviewer",
+        "approve + findings empty",
+        "human / PR",
+        "READY_FOR_PR",
+        "independent review artifact",
+      ),
+      devTransition(
+        "reviewer",
+        "request-changes + (major or plan/implementation mismatch) + improvement_count < maxImprovementIterations",
+        "implementer",
+        "IMPROVE",
+        "findings + new implementer Run node ID",
+      ),
+      devTransition(
+        "reviewer",
+        "comment + minor/nit only",
+        "human / PR",
+        "CONDITIONAL_HANDOFF",
+        "remaining findings evidence",
+      ),
+      devTransition(
+        "reviewer",
+        "budget exhausted + request-changes remains",
+        "waiting_human",
+        "BLOCKED",
+        "remaining request-changes evidence",
+      ),
+      devTransition(
+        "reviewer",
+        "block + blocking reason/evidence + no critical",
+        "waiting_human",
+        "BLOCKED",
+        "blocking evidence",
       ),
       devTransition(
         "human / PR",
@@ -505,33 +521,122 @@ describe("Graph Contract の公開文書契約", () => {
     expect(budget).toContain("追加retry回数");
     expect(budget).toContain("初回reviewer passはimprovement_count=0");
     expect(budget).toContain("reviewer起点の追加改善回数");
-    expect(orchestrator).toContain("ADR-021のFixed dev-role transitionを正典とする");
+    expect(budget).toContain("schema-valid `comment`");
+    expect(budget).toContain("request-changesが残れば");
+    expect(budget).toContain("severityだけで`comment`へ降格せずBLOCKED");
+    const safetyPreflight = [
+      preflight(
+        "1",
+        "critical finding present",
+        "approve",
+        "ESCALATED",
+        "critical finding evidence",
+      ),
+      preflight(
+        "1",
+        "critical finding present",
+        "comment",
+        "ESCALATED",
+        "critical finding evidence",
+      ),
+      preflight(
+        "1",
+        "critical finding present",
+        "request-changes",
+        "ESCALATED",
+        "critical finding evidence",
+      ),
+      preflight("1", "critical finding present", "block", "ESCALATED", "critical finding evidence"),
+      preflight("2", "required evidence missing", "any", "BLOCKED", "missing evidence list"),
+      preflight(
+        "2",
+        "verify-result inconsistency",
+        "any",
+        "BLOCKED",
+        "verification inconsistency evidence",
+      ),
+      preflight(
+        "2",
+        "verdict/finding semantic contract mismatch",
+        "any",
+        "BLOCKED",
+        "semantic validation evidence",
+      ),
+      preflight(
+        "3",
+        "all safety guards passed",
+        "contract-valid verdict",
+        "apply normal verdict edge",
+        "validated review artifact",
+      ),
+    ];
+    expect(parseMarkdownTable(adr, "### Safety preflight precedence")).toEqual(safetyPreflight);
+    expect(parseMarkdownTable(orchestrator, "### Safety preflight precedence")).toEqual(
+      safetyPreflight,
+    );
+    const fixedTransition = extractMarkdownSection(adr, "### Fixed dev-role transition");
+    expect(fixedTransition).toContain("cross-cutting guard");
+    expect(fixedTransition).toContain("通常verdict edgeより先");
+    expect(orchestrator).toContain("Project Contract Discovery");
+    expect(orchestrator).toContain("schema-valid `comment`");
+    expect(orchestrator).toContain("`request-changes`が残れば");
+    expect(orchestrator).toContain("severityだけで`comment`へ降格せず");
+    expect(parseMarkdownTable(orchestrator, "### Reviewer verdict operation")).toEqual([
+      reviewerOperation("approve", "contract-valid + findings empty", "human / PR", "READY_FOR_PR"),
+      reviewerOperation(
+        "comment",
+        "contract-valid + minor/nit only",
+        "preserve remaining findings evidence",
+        "CONDITIONAL_HANDOFF",
+      ),
+      reviewerOperation(
+        "request-changes",
+        "contract-valid + (major or plan/implementation mismatch) + improvement budget available",
+        "implementer improvement",
+        "IMPROVE",
+      ),
+      reviewerOperation(
+        "request-changes",
+        "contract-valid + (major or plan/implementation mismatch) + improvement budget exhausted",
+        "waiting_human",
+        "BLOCKED",
+      ),
+      reviewerOperation(
+        "block",
+        "contract-valid + blocking reason/evidence + no critical",
+        "waiting_human",
+        "BLOCKED",
+      ),
+    ]);
     const outputContract = extractMarkdownSection(orchestrator, "## 出力契約");
     expect(outputContract).toContain(
       "`status`: `READY_FOR_PR` / `CONDITIONAL_HANDOFF` / `BLOCKED` / `ESCALATED` / `COMPLETED`",
     );
   });
 
-  it("active workflowは現行manual gateと#328後の製品control planeを区別する", async () => {
-    const paths = [
-      ".gantt-sync/workflow.md",
+  it("project workflowだけがrepo固有contractを持ちshared skillsはproject contractをdiscoverする", async () => {
+    const projectWorkflow = await readRepoFile(".gantt-sync/workflow.md");
+    expect(projectWorkflow).toContain("ADR-021");
+    expect(projectWorkflow).toContain("現行 (#327)");
+    expect(projectWorkflow).toContain("外部orchestrator");
+    expect(projectWorkflow).toContain("JSON/schema/manual gate");
+    expect(projectWorkflow).toContain("#328以後");
+    expect(projectWorkflow).toContain("製品control plane");
+
+    const sharedSkillPaths = [
       "skills/gh-gantt-dev-role/SKILL.md",
+      "skills/gh-gantt-dev-role/references/orchestrator.md",
       "skills/gh-gantt-workflow/SKILL.md",
+      "skills/gh-gantt-workflow/references/autonomous-loop.md",
     ] as const;
 
-    for (const path of paths) {
+    for (const path of sharedSkillPaths) {
       const content = await readRepoFile(path);
-      expect(content).toContain("ADR-021");
-      expect(content).toContain("現行 (#327)");
-      expect(content).toContain("外部orchestrator");
-      expect(content).toContain("JSON/schema/manual gate");
-      expect(content).toContain("#328以後");
-      expect(content).toContain("製品control plane");
+      expect(content).toContain("Project Contract Discovery");
+      expect(content).toContain(".gantt-sync/workflow.md");
+      expect(content).not.toContain("ADR-021");
+      expect(content).not.toMatch(/#(?:327|328|329|330|331)\b/);
     }
-
-    const workflowSkill = await readRepoFile("skills/gh-gantt-workflow/SKILL.md");
-    expect(workflowSkill).toContain("#329のclaim/lease/join");
-    expect(workflowSkill).toContain("#331のapproval proposal/new plan version");
 
     const projectMap = await readRepoFile("docs/project-map.md");
     const mapSection = extractMarkdownSection(projectMap, "## 10. Graph Contractとの関係");
@@ -653,5 +758,25 @@ function propagation(
     target,
     "run effect": runEffect,
     "identity / lineage": identityOrLineage,
+  };
+}
+
+function reviewerOperation(verdict: string, guard: string, action: string, status: string) {
+  return { verdict, guard, action, status };
+}
+
+function preflight(
+  priority: string,
+  condition: string,
+  declaredVerdict: string,
+  result: string,
+  evidence: string,
+) {
+  return {
+    priority,
+    condition,
+    "declared verdict": declaredVerdict,
+    result,
+    evidence,
   };
 }

--- a/tests/workflow/graph-contract.test.ts
+++ b/tests/workflow/graph-contract.test.ts
@@ -1,0 +1,657 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseAdrFile } from "@gh-gantt/shared";
+import { parse } from "yaml";
+import { z } from "zod";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+const AcceptanceCriteriaSchema = z.object({
+  id: z.string().min(1),
+  description: z.string().min(1),
+  status: z.enum(["covered", "failing", "uncovered"]),
+  tests: z.array(z.string().min(1)),
+});
+
+const RequirementsSchema = z.object({
+  areas: z.array(
+    z.object({
+      id: z.string().min(1),
+      requirements: z.array(
+        z.object({
+          id: z.string().min(1),
+          acceptance_criteria: z.array(AcceptanceCriteriaSchema).min(1),
+        }),
+      ),
+    }),
+  ),
+});
+
+async function readRepoFile(path: string): Promise<string> {
+  const content = await readFile(resolve(repoRoot, path), "utf-8");
+  return z.string().min(1).parse(content);
+}
+
+function extractMarkdownSection(content: string, heading: string): string {
+  const start = content.indexOf(heading);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const level = heading.match(/^#+/)?.[0].length ?? 2;
+  const tail = content.slice(start + heading.length);
+  const nextHeading = tail.search(new RegExp(`^#{1,${level}}\\s`, "m"));
+  return content.slice(
+    start,
+    nextHeading === -1 ? undefined : start + heading.length + nextHeading,
+  );
+}
+
+function parseMarkdownTable(content: string, heading: string): Array<Record<string, string>> {
+  const lines = extractMarkdownSection(content, heading).split("\n");
+  const tableStart = lines.findIndex((line) => line.trim().startsWith("|"));
+  expect(tableStart).toBeGreaterThanOrEqual(0);
+
+  const parseRow = (line: string) =>
+    line
+      .trim()
+      .slice(1, -1)
+      .split("|")
+      .map((cell) => cell.trim().replaceAll("`", ""));
+  const headers = parseRow(lines[tableStart] ?? "");
+  const rows: Array<Record<string, string>> = [];
+
+  for (const line of lines.slice(tableStart + 2)) {
+    if (!line.trim().startsWith("|")) break;
+    const cells = parseRow(line);
+    rows.push(Object.fromEntries(headers.map((header, index) => [header, cells[index] ?? ""])));
+  }
+  return rows;
+}
+
+describe("Graph Contract の公開文書契約", () => {
+  it("ADR-021 は4 graphの正典、canonical artifact/store、段階境界を一意にする", async () => {
+    const content = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+    const { frontmatter, body } = parseAdrFile(content);
+
+    expect(frontmatter).toMatchObject({
+      id: "ADR-021",
+      status: "accepted",
+      related_requirements: ["NFR-STABILITY-014"],
+    });
+    for (const heading of ["## Context", "## Decision", "## Alternatives", "## Consequences"]) {
+      expect(body).toContain(heading);
+    }
+
+    expect(parseMarkdownTable(body, "### 正準4 graphと正本")).toEqual([
+      {
+        graph: "Plan Graph",
+        "authoritative definition": "Graph Contract topology",
+        "canonical artifact / store": "versioned plan artifact",
+        "current #327": "ADR-021 + workflowのunversioned provisional projection",
+        "after #328": "Graph Contract store",
+      },
+      {
+        graph: "Org Graph",
+        "authoritative definition": "Graph Contract role / authority",
+        "canonical artifact / store": "versioned authority binding",
+        "current #327": "ADR-021 + Dev-Role Configのunversioned provisional projection",
+        "after #328": "Graph Contract store",
+      },
+      {
+        graph: "Work Graph",
+        "authoritative definition": "GitHub Issues / Projects",
+        "canonical artifact / store": "GitHub remote task / relation",
+        "current #327": "GitHub remoteが正本、.gantt-syncはcache",
+        "after #328": "変更なし",
+      },
+      {
+        graph: "Run Graph",
+        "authoritative definition": "accepted run event",
+        "canonical artifact / store": "append-only Run Graph event store",
+        "current #327": "正準storeなし、.dev-flow artifactはevidence",
+        "after #328": "Run Graph event store",
+      },
+    ]);
+
+    const binding = extractMarkdownSection(body, "### version bindingと競合規則");
+    expect(binding).toContain("plan_id");
+    expect(binding).toContain("plan_version");
+    expect(binding).toContain("現行#327にはplan_id、plan_version、authority bindingの値がない");
+    expect(binding).toContain("unversioned provisional projection");
+    expect(binding).toContain("workflowはGraph Contractを再定義しない");
+    expect(binding).toContain("exact bindingとfail-closed validationは#328以後");
+    expect(binding).toContain("fail-closed");
+    expect(binding).toContain("waiting_human");
+    expect(binding).toContain("現行#327");
+    expect(binding).toContain("#328以後");
+  });
+
+  it("run/node/attemptの正準状態集合を完全一致で定義する", async () => {
+    const adr = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+
+    expect(parseMarkdownTable(adr, "### 正準状態集合")).toEqual([
+      {
+        entity: "run",
+        states: "pending, running, paused, waiting_human, completed, failed, cancelled",
+        terminal: "completed, failed, cancelled",
+      },
+      {
+        entity: "node",
+        states: "pending, ready, running, paused, waiting_human, completed, failed, cancelled",
+        terminal: "completed, failed, cancelled",
+      },
+      {
+        entity: "attempt",
+        states: "created, running, succeeded, failed, timed_out, stalled, cancelled",
+        terminal: "succeeded, failed, timed_out, stalled, cancelled",
+      },
+    ]);
+  });
+
+  it("run遷移表はpause/resume/human/cancel/migration/stale eventを一意にする", async () => {
+    const adr = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+
+    expect(parseMarkdownTable(adr, "#### Run transition")).toEqual([
+      transition(
+        "run.pending",
+        "start + exact version/target valid",
+        "run.running",
+        "no",
+        "reject; keep pending",
+      ),
+      transition(
+        "run.running",
+        "pause + checkpoint persisted",
+        "run.paused",
+        "checkpoint",
+        "reject; keep running",
+      ),
+      transition(
+        "run.paused",
+        "resume + checkpoint/artifact/evidence valid",
+        "run.running",
+        "no",
+        "reject; keep paused",
+      ),
+      transition(
+        "run.running",
+        "human_gate_required or budget_exceeded",
+        "run.waiting_human",
+        "checkpoint",
+        "reject; keep running",
+      ),
+      transition(
+        "run.waiting_human",
+        "human_approved + authority/decision evidence valid",
+        "run.running",
+        "no",
+        "reject; keep waiting_human",
+      ),
+      transition(
+        "run.running",
+        "complete + required nodes/gates complete",
+        "run.completed",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "run.running",
+        "fail + non-retryable",
+        "run.failed",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "run.{pending,running,paused,waiting_human}",
+        "cancel + authority evidence valid",
+        "run.cancelled",
+        "terminal",
+        "reject; keep source",
+      ),
+      transition(
+        "run.{paused,waiting_human}",
+        "migrate + supported version/migration evidence valid",
+        "same state",
+        "checkpoint",
+        "reject; keep source",
+      ),
+      transition(
+        "run.{completed,failed,cancelled}",
+        "stale_event",
+        "same state",
+        "terminal",
+        "reject; keep source",
+      ),
+    ]);
+  });
+
+  it("node遷移表はready/attempt/pause/human/cancel/stale eventを一意にする", async () => {
+    const adr = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+
+    expect(parseMarkdownTable(adr, "#### Node transition")).toEqual([
+      transition(
+        "node.pending",
+        "dependencies_satisfied",
+        "node.ready",
+        "no",
+        "reject; keep pending",
+      ),
+      transition(
+        "node.ready",
+        "attempt_started + authority valid",
+        "node.running",
+        "no",
+        "reject; keep ready",
+      ),
+      transition(
+        "node.running",
+        "pause + checkpoint persisted",
+        "node.paused",
+        "checkpoint",
+        "reject; keep running",
+      ),
+      transition(
+        "node.paused",
+        "resume + checkpoint/artifact/evidence valid",
+        "node.running",
+        "no",
+        "reject; keep paused",
+      ),
+      transition(
+        "node.running",
+        "human_gate_required or budget_exceeded",
+        "node.waiting_human",
+        "checkpoint",
+        "reject; keep running",
+      ),
+      transition(
+        "node.waiting_human",
+        "human_approved + authority/decision evidence valid",
+        "node.running",
+        "no",
+        "reject; keep waiting_human",
+      ),
+      transition(
+        "node.running",
+        "attempt_succeeded + schema-valid node outcome",
+        "node.completed",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "node.running",
+        "non-retryable node outcome",
+        "node.failed",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "node.{pending,ready,running,paused,waiting_human}",
+        "cancel + authority evidence valid",
+        "node.cancelled",
+        "terminal",
+        "reject; keep source",
+      ),
+      transition(
+        "node.{completed,failed,cancelled}",
+        "stale_event",
+        "same state",
+        "terminal",
+        "reject; keep source",
+      ),
+    ]);
+  });
+
+  it("attempt遷移表はterminal reasonとstale event拒否を一意にする", async () => {
+    const adr = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+
+    expect(parseMarkdownTable(adr, "#### Attempt transition")).toEqual([
+      transition(
+        "attempt.created",
+        "start + current attempt ID",
+        "attempt.running",
+        "no",
+        "reject; keep created",
+      ),
+      transition(
+        "attempt.running",
+        "succeed + evidence valid",
+        "attempt.succeeded",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "attempt.running",
+        "fail + failure evidence valid",
+        "attempt.failed",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "attempt.running",
+        "timeout",
+        "attempt.timed_out",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition("attempt.running", "stall", "attempt.stalled", "terminal", "reject; keep running"),
+      transition(
+        "attempt.running",
+        "cancel + authority evidence valid",
+        "attempt.cancelled",
+        "terminal",
+        "reject; keep running",
+      ),
+      transition(
+        "attempt.{succeeded,failed,timed_out,stalled,cancelled}",
+        "stale_event",
+        "same state",
+        "terminal",
+        "reject; keep source",
+      ),
+    ]);
+
+    expect(parseMarkdownTable(adr, "### Cross-entity propagation")).toEqual([
+      propagation(
+        "attempt.succeeded",
+        "schema-valid node outcome",
+        "node.completed + evaluate Plan edge",
+        "run.running",
+        "terminal attempt preserved",
+      ),
+      propagation(
+        "attempt.{failed,timed_out,stalled}",
+        "retryable + attempt_count < attempt budget",
+        "node.ready",
+        "run.running",
+        "new monotonic attempt ID + lineage",
+      ),
+      propagation(
+        "attempt.{failed,timed_out,stalled}",
+        "retryable + attempt_count >= attempt budget",
+        "node.waiting_human",
+        "run.waiting_human checkpoint",
+        "terminal attempt preserved",
+      ),
+      propagation(
+        "attempt.{failed,timed_out,stalled}",
+        "non-retryable",
+        "node.failed",
+        "run.failed terminal",
+        "terminal attempt preserved",
+      ),
+      propagation(
+        "executor role node",
+        "schema-valid verify_failed outcome + retry budget available",
+        "new implementer Run node ID",
+        "run.running + evaluate Plan edge",
+        "source node remains completed",
+      ),
+      propagation(
+        "reviewer role node",
+        "schema-valid request-changes outcome + improvement budget available",
+        "new implementer Run node ID",
+        "run.running + evaluate Plan edge",
+        "source node remains completed",
+      ),
+    ]);
+    const propagationSection = extractMarkdownSection(adr, "### Cross-entity propagation");
+    expect(propagationSection).toContain("attemptはexecution mechanics");
+    expect(propagationSection).toContain("terminal eventだけではnode outcomeにならない");
+  });
+
+  it("fixed dev-role graphはretry計数と停止/handoff edgeを完全一致で定義する", async () => {
+    const [adr, orchestrator] = await Promise.all([
+      readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md"),
+      readRepoFile("skills/gh-gantt-dev-role/references/orchestrator.md"),
+    ]);
+
+    expect(parseMarkdownTable(adr, "### Fixed dev-role transition")).toEqual([
+      devTransition(
+        "planner",
+        "plan_valid + schema-valid",
+        "implementer",
+        "CONTINUE",
+        "plan artifact",
+      ),
+      devTransition(
+        "planner",
+        "plan_invalid or evidence_missing",
+        "waiting_human",
+        "BLOCKED",
+        "validation evidence",
+      ),
+      devTransition(
+        "implementer",
+        "implementation_valid + evidence present",
+        "executor",
+        "CONTINUE",
+        "implementation artifact",
+      ),
+      devTransition(
+        "implementer",
+        "implementation_invalid or evidence_missing",
+        "waiting_human",
+        "BLOCKED",
+        "validation evidence",
+      ),
+      devTransition("executor", "verify_passed", "reviewer", "CONTINUE", "all command evidence"),
+      devTransition(
+        "executor",
+        "verify_failed + retry_count < maxExecutorRetries",
+        "implementer",
+        "RETRY",
+        "failure evidence + new implementer Run node ID",
+      ),
+      devTransition(
+        "executor",
+        "verify_failed + retry_count >= maxExecutorRetries",
+        "waiting_human",
+        "BLOCKED",
+        "failure evidence",
+      ),
+      devTransition(
+        "reviewer",
+        "approve",
+        "human / PR",
+        "READY_FOR_PR",
+        "independent review artifact",
+      ),
+      devTransition(
+        "reviewer",
+        "request-changes + no critical + improvement_count < maxImprovementIterations",
+        "implementer",
+        "IMPROVE",
+        "findings + new implementer Run node ID",
+      ),
+      devTransition(
+        "reviewer",
+        "budget exhausted + only minor remains",
+        "human / PR",
+        "CONDITIONAL_HANDOFF",
+        "remaining findings in PR description",
+      ),
+      devTransition(
+        "reviewer",
+        "budget exhausted + major remains",
+        "waiting_human",
+        "BLOCKED",
+        "remaining major findings",
+      ),
+      devTransition(
+        "reviewer",
+        "critical finding",
+        "waiting_human",
+        "ESCALATED",
+        "critical finding evidence",
+      ),
+      devTransition(
+        "any role",
+        "required evidence missing",
+        "waiting_human",
+        "BLOCKED",
+        "missing evidence list",
+      ),
+      devTransition(
+        "human / PR",
+        "approved / merged",
+        "terminal",
+        "COMPLETED",
+        "human decision + PR evidence",
+      ),
+    ]);
+
+    const budget = extractMarkdownSection(adr, "### Budget計数規則");
+    expect(budget).toContain("初回executor attemptはretry_count=0");
+    expect(budget).toContain("追加retry回数");
+    expect(budget).toContain("初回reviewer passはimprovement_count=0");
+    expect(budget).toContain("reviewer起点の追加改善回数");
+    expect(orchestrator).toContain("ADR-021のFixed dev-role transitionを正典とする");
+    const outputContract = extractMarkdownSection(orchestrator, "## 出力契約");
+    expect(outputContract).toContain(
+      "`status`: `READY_FOR_PR` / `CONDITIONAL_HANDOFF` / `BLOCKED` / `ESCALATED` / `COMPLETED`",
+    );
+  });
+
+  it("active workflowは現行manual gateと#328後の製品control planeを区別する", async () => {
+    const paths = [
+      ".gantt-sync/workflow.md",
+      "skills/gh-gantt-dev-role/SKILL.md",
+      "skills/gh-gantt-workflow/SKILL.md",
+    ] as const;
+
+    for (const path of paths) {
+      const content = await readRepoFile(path);
+      expect(content).toContain("ADR-021");
+      expect(content).toContain("現行 (#327)");
+      expect(content).toContain("外部orchestrator");
+      expect(content).toContain("JSON/schema/manual gate");
+      expect(content).toContain("#328以後");
+      expect(content).toContain("製品control plane");
+    }
+
+    const workflowSkill = await readRepoFile("skills/gh-gantt-workflow/SKILL.md");
+    expect(workflowSkill).toContain("#329のclaim/lease/join");
+    expect(workflowSkill).toContain("#331のapproval proposal/new plan version");
+
+    const projectMap = await readRepoFile("docs/project-map.md");
+    const mapSection = extractMarkdownSection(projectMap, "## 10. Graph Contractとの関係");
+    expect(mapSection).toContain("Work Graphの派生view");
+    expect(mapSection).toContain("正典はADR-021");
+    expect(mapSection).toContain("#330");
+    expect(mapSection).toContain("#329のclaim/lease/join");
+    expect(mapSection).toContain("#331のapproval proposal/new plan version");
+    expect(mapSection.length).toBeLessThan(700);
+  });
+
+  it("NFR-STABILITY-014はAC1からAC8を固有意味のまま未実装として保持する", async () => {
+    const requirements = RequirementsSchema.parse(
+      parse(await readRepoFile("docs/requirements.yaml")) as unknown,
+    );
+    const stability = requirements.areas.find((area) => area.id === "STABILITY");
+    const requirement = stability?.requirements.find((entry) => entry.id === "NFR-STABILITY-014");
+    const criteria = requirement?.acceptance_criteria ?? [];
+
+    expect(criteria.map((entry) => entry.id)).toEqual(
+      Array.from({ length: 8 }, (_, index) => `NFR-STABILITY-014-AC${index + 1}`),
+    );
+    const meanings: Record<string, string[]> = {
+      "NFR-STABILITY-014-AC1": [
+        "Plan Graph",
+        "Work Graph",
+        "Org Graph",
+        "Run Graph",
+        "versioned Graph Contract",
+      ],
+      "NFR-STABILITY-014-AC2": [
+        "control plane",
+        "external runner",
+        "execution plane",
+        "outcome event",
+      ],
+      "NFR-STABILITY-014-AC3": [
+        "role",
+        "node",
+        "edge",
+        "artifact",
+        "authority",
+        "budget",
+        "human gate",
+        "schema version",
+      ],
+      "NFR-STABILITY-014-AC4": ["run", "node", "attempt", "artifact", "evidence", "lineage"],
+      "NFR-STABILITY-014-AC5": ["停止", "取消", "失敗", "再開", "checkpoint", "migration", "拒否"],
+      "NFR-STABILITY-014-AC6": [
+        "fixed dev-role graph",
+        "verify retry",
+        "review improvement",
+        "不正 transition",
+      ],
+      "NFR-STABILITY-014-AC7": ["bypass", "authority", "evidence", "human gate"],
+      "NFR-STABILITY-014-AC8": ["bounded parallelism", "Work Graph", "versioned extension"],
+    };
+
+    for (const entry of criteria) {
+      const description = entry.description.replaceAll(/\s+/g, " ");
+      for (const term of meanings[entry.id] ?? []) expect(description).toContain(term);
+      expect(entry.status).toBe("uncovered");
+      expect(entry.tests).toEqual([]);
+    }
+
+    const testSource = await readRepoFile("tests/workflow/graph-contract.test.ts");
+    expect(testSource).not.toMatch(/\[NFR-STABILITY-014-AC\d+\]/);
+  });
+
+  it("ADR-021は一次資料の事実と推論を分離しGraph Engineeringを外部標準化しない", async () => {
+    const adr = await readRepoFile("docs/adr/ADR-021-graph-contract-and-run-graph-boundary.md");
+
+    expect(adr).toContain(
+      "https://github.com/openai/symphony/blob/f8e8b8a670c799f6e0ade7a8c25c4bf4a4a56ec7/SPEC.md",
+    );
+    expect(adr).toContain("https://www.anthropic.com/engineering/building-effective-agents");
+    expect(adr).toContain("一次資料に明記された事実");
+    expect(adr).toContain("gh-gantt固有の推論");
+    expect(adr).toContain("Graph Engineeringを確立済みの外部標準として扱わない");
+  });
+});
+
+function transition(
+  source: string,
+  eventOrGuard: string,
+  target: string,
+  terminalOrCheckpoint: string,
+  refusal: string,
+) {
+  return {
+    source,
+    "event or guard": eventOrGuard,
+    target,
+    "terminal or checkpoint": terminalOrCheckpoint,
+    refusal,
+  };
+}
+
+function devTransition(
+  source: string,
+  eventOrGuard: string,
+  target: string,
+  outcome: string,
+  evidence: string,
+) {
+  return { source, "event or guard": eventOrGuard, target, outcome, evidence };
+}
+
+function propagation(
+  source: string,
+  eventOrGuard: string,
+  target: string,
+  runEffect: string,
+  identityOrLineage: string,
+) {
+  return {
+    source,
+    "event or guard": eventOrGuard,
+    target,
+    "run effect": runEffect,
+    "identity / lineage": identityOrLineage,
+  };
+}


### PR DESCRIPTION
## Summary

- ADR-021でPlan / Work / Org / Run Graphの正本、Graph Contract、状態・遷移・budget・human gateを定義
- 現行の外部orchestratorと、#328以後のgh-gantt control plane / 外部runner execution planeの境界を明文化
- NFR-STABILITY-014のAC1〜AC8を将来の製品実装に対する`uncovered`要件として追加
- active workflow / dev-role / Project MapをADR-021へ結線し、公開文書契約テストを追加
- 一次資料の事実とgh-gantt固有の推論を分離し、Graph Engineeringを外部標準とは扱わないことを明記

Closes #327

## Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（全1,138 tests）
- `pnpm build`
- `pnpm req:trace`
- `git diff --exit-code docs/requirements.yaml`
- `pnpm req:validate`
- `pnpm docs:gen`
- focused Graph Contract tests 9/9、関連workflow tests 26/26
- Standards / Spec独立レビュー: 10/10、findingなし
- native betterleaks 1.5.0: staged差分・commit済み公開差分とも漏洩なし
- digest固定Docker betterleaks 1.1.2: staged差分・commit済み公開差分・pre-commit hookとも漏洩なし（skipなし）
- pre-push CI相当ゲート: 全件成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Graph Contract と Run Graph の責務境界、正準グラフ、状態遷移、検証ルールを文書化しました。
  * プロジェクトマップ、要件、ワークフロー、開発ロールの説明を更新しました。
  * オーケストレーターの終了判定とステータス定義を更新しました。

* **テスト**
  * Graph Contract、遷移ルール、予算、イベント受理、関連ドキュメントの整合性を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->