### PR TITLE
feat(store): Work Graph Cacheをworktree間で共有する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ gh-gantt CLI はグローバルにインストール済み。`gh-gantt` コマ�
 代わりに GitHub Labels でタスクの種類を管理している（`gantt.config.json` の `task_types` で定義）。
 利用可能なタイプ: `task`, `epic`, `feature`, `milestone`
 
-**IMPORTANT: `.gantt-sync/` 配下の同期データ（`tasks.json`, `sync-state.json`, `loop-state.json`）を直接読み書きしてはならない。**
+**IMPORTANT: git-common-dir 配下の Work Graph Cache（`tasks.json`, `sync-state.json`, `comments.json`）と、
+`.gantt-sync/` 配下の workspace-local journal（`loop-state.json`, Run Graph）を直接読み書きしてはならない。**
 常に `gh-gantt` CLI コマンドを使うこと。直接操作はバリデーションをバイパスし、同期状態を破損させる。
 設定ファイル（`gantt.config.json`, `workflow.md`）は直接編集してよい。
 
@@ -51,7 +52,7 @@ gh-gantt CLI はグローバルにインストール済み。`gh-gantt` コマ�
 
 ## エフェメラル環境でのブートストラップ
 
-Claude Code on the web や CI などの新品コンテナには `.gantt-sync/` の同期データも
+Claude Code on the web や CI などの新品コンテナには git-common-dir 配下の Work Graph Cache も
 グローバル install 済みの gh-gantt CLI も存在しない。以下の手順でゼロから再構成できる。
 
 ```bash
@@ -60,7 +61,7 @@ pnpm install && pnpm build
 # 認証: gh CLI がない環境では GITHUB_TOKEN（または GH_TOKEN）を設定する
 export GITHUB_TOKEN=<token>
 
-# 同期データの再構成（tasks.json / sync-state.json 不在なら GitHub から初回同期する）
+# Work Graph Cache の再構成（tasks.json / sync-state.json 不在なら GitHub から初回同期する）
 node packages/cli/dist/index.js pull
 
 # 現在地の確認
@@ -193,5 +194,6 @@ pnpm workspaces モノレポ。`packages/` 配下に3パッケージ：
 - ビルド: vp pack (cli/shared)、vp build (ui) — すべて vite-plus 統合
 - テスト: vp test (Vitest 4.1 ベース、vite-plus 同梱)
 - リント: vp check (Oxlint + Oxfmt)
-- ローカルデータ: `.gantt-sync/`（gitignore 済み）
+- Work Graph Cache: git-common-dir 配下の `gh-gantt/cache/project-storage/`（worktree 間共有、Git 管理外）
+- workspace-local データ: `.gantt-sync/`（config / workflow を除き gitignore 済み）
 - 秘密情報スキャン: docker 前提の `betterleaks` を pre-commit + CI で実行 (詳細は ADR-011)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,13 @@ _Avoid_: Run plan, workflow state
 GitHub Issues / Projects が正本となる、人間の仕事とその親子・依存関係の graph。
 _Avoid_: Run state, execution queue
 
+**Work Graph Cache**:
+GitHub が正本の Work Graph をローカルに再構築する projection と同期用 merge base。
+同じ Git repository と GitHub Project identity の worktree 間で共有できるが、Run Graph や workspace-local journal ではない。
+最初の shared slot access で lazy initialize し、初版は read/write 共通の exclusive repository lease を callback 終了まで保持する。
+分岐した legacy cache は fail-closed で停止し、operator が `gh-gantt storage migrate --from <worktree>` で正本を明示する。
+_Avoid_: Task database, Run Graph store
+
 **Org Graph**:
 role と、遷移・承認・override を行える authority の graph。
 _Avoid_: Assignee list, agent roster

--- a/docs/adr/ADR-018-cache-first-sync-model.md
+++ b/docs/adr/ADR-018-cache-first-sync-model.md
@@ -10,6 +10,8 @@ related_requirements:
   - FR-STORE-001
   - FR-STORE-002
   - FR-STORE-003
+  - FR-STORE-004
+  - NFR-STABILITY-015
 ---
 
 ## Context
@@ -126,6 +128,11 @@ GitHub を唯一の真実源 (single source of truth) とし、`.gantt-sync/` �
 worktree からの並行 pull / push は後勝ちで同期結果を上書きしうる。排他制御の
 設計・実装は #299 のスコープに含める。
 
+#299 の具体的な配置、GitHub Project identity ごとの versioned namespace、
+tasks/sync-state の atomic snapshot-set、all-worktree legacy migration、
+read/write 共通の初版 exclusive repository lease、non-git fallback の契約は ADR-023 を正本とする。
+ADR-023 は本 ADR の cache 分類を変更せず、その実装境界を確定する。
+
 ### 4. ローカル専用データを排除する
 
 draft タスクは既定で即座に GitHub Issue化する (オフライン時のみ `--draft` で
@@ -188,6 +195,9 @@ write-through push (Decision 2) で同期窓を短縮すれば得られる利益
 - ADR-005 の「`.gantt-sync/` にローカルデータを永続化する」は維持するが、
   永続化の意味が「唯一のデータ」から「破棄可能なキャッシュ」へ変わる。
 - `gantt.config.json` / `workflow.md` の git コミットが必要になる (#295)。
+- #299 の共有対象は Work Graph Cache (`tasks.json`, `sync-state.json`, `comments.json`)
+  に限る。`loop-state.json`、Graph Contract、Run Graph は workspace-local を維持する
+  （配置と lease の詳細は ADR-023、Run Graph の正本は ADR-022）。
 - 本 ADR の decision に従い、以下の実装タスクが必要になる: stale チェック +
   auto-pull (#296)、write-through push (#297)、draft 即時実体化と `date`
   フィールド整理 (#298)、git-common-dir 化によるワークツリー間共有 (#299)、

--- a/docs/adr/ADR-018-cache-first-sync-model.md
+++ b/docs/adr/ADR-018-cache-first-sync-model.md
@@ -128,7 +128,7 @@ GitHub を唯一の真実源 (single source of truth) とし、`.gantt-sync/` �
 worktree からの並行 pull / push は後勝ちで同期結果を上書きしうる。排他制御の
 設計・実装は #299 のスコープに含める。
 
-#299 の具体的な配置、GitHub Project identity ごとの versioned namespace、
+Issue `#299` の具体的な配置、GitHub Project identity ごとの versioned namespace、
 tasks/sync-state の atomic snapshot-set、all-worktree legacy migration、
 read/write 共通の初版 exclusive repository lease、non-git fallback の契約は ADR-023 を正本とする。
 ADR-023 は本 ADR の cache 分類を変更せず、その実装境界を確定する。

--- a/docs/adr/ADR-022-durable-run-graph-event-journal.md
+++ b/docs/adr/ADR-022-durable-run-graph-event-journal.md
@@ -54,6 +54,12 @@ resume command は `not_started` / `committed` / `reconciled` / `unknown` の si
 Issue #328 は single writer の固定 dev-role profile だけを実装する。parallel claim / lease / join と
 multi-process compare-and-append は #329、動的 plan version は #331 で追加する。
 
+ADR-023 / Issue #299 が導入する read/write 共通の exclusive repository lease と atomic snapshot-set は、GitHub が正本の
+Work Graph Cache (`tasks.json`, `sync-state.json`, `comments.json`) だけを対象とする。Graph Contract と
+Run Graph event journal は #299 では移動せず、`<workspace>/.gantt-sync/run-graph/` に残す。Run Graph の
+repository共有は、#329 の entity version、claim、lease、multi-process compare-and-append が実装・検証された
+後に、accepted event lineage を維持する別の意思決定として扱う。
+
 ## Alternatives
 
 ### loop-state.json を Run Graph snapshot へ拡張する

--- a/docs/adr/ADR-023-project-storage-layout-and-lease.md
+++ b/docs/adr/ADR-023-project-storage-layout-and-lease.md
@@ -126,7 +126,9 @@ reader/writer lease は、実際の contention と安全性を測定してから
 
 lock owner record は host、pid、nonce、access、開始時刻を持つ。live owner または生死を判定できない owner の
 lock は盗まない。同一 host で pid が存在しないことを確認でき、読み直した owner nonce が一致するときだけ
-compare-and-recover する。timeout は owner 情報を含む診断を返し、workspace-local cache へfallbackしない。
+atomic recovery claim を取得して compare-and-recover する。他collectorのclaimが存在する場合は回収せず、claim取得後に
+owner nonceが変わった場合もactive pathを変更しない。timeout は owner 情報を含む診断を返し、workspace-local cache
+へfallbackしない。
 解放時はnonce一致を確認したactive lock directoryをnonce固有のretired pathへatomic renameしてから削除し、
 解放と次ownerの取得が競合しても新しいlockを再帰削除しない。callback内では即時の`process.exit()`を使わず、
 `finally`によるlease解放を必ず通す。
@@ -144,7 +146,7 @@ Git hook が export する `GIT_DIR`、`GIT_WORK_TREE` 等の repository 選択�
 
 ### Run Graph の扱い
 
-#299 の repository lease と snapshot-set は Work Graph Cache のための統制であり、Graph Contract と
+Issue `#299` の repository lease と snapshot-set は Work Graph Cache のための統制であり、Graph Contract と
 Run Graph event journal には適用しない。ADR-022 の Run Graph は #329 で entity version、claim、lease、
 multi-process compare-and-append が実装・検証されるまで workspace-local を維持する。#329 完了後も共有化は
 自動ではなく、accepted event lineage を壊さないことを確認する別の意思決定を必要とする。

--- a/docs/adr/ADR-023-project-storage-layout-and-lease.md
+++ b/docs/adr/ADR-023-project-storage-layout-and-lease.md
@@ -1,0 +1,196 @@
+---
+id: ADR-023
+title: Project Storage の配置・移行・repository lease を一つの Interface に閉じ込める
+date: 2026-07-30
+status: accepted
+related_requirements:
+  - FR-STORE-004
+  - NFR-STABILITY-001
+  - NFR-STABILITY-015
+---
+
+## Context
+
+ADR-018 は `tasks.json`、`sync-state.json`、`comments.json` を GitHub から再構築できる
+cache とし、`git rev-parse --git-common-dir` 起点で同一 repository の worktree 間に
+共有する方針を定めた。一方、従来の Store は caller から渡された workspace root の
+`.gantt-sync/` を個別に読み書きするため、linked worktree ごとに Work Graph の projection と
+merge base が複製される。
+
+単に保存先だけを共有すると、次の問題が残る。
+
+- `tasks.json` と `sync-state.json` を別々に置換する途中を reader が観測できる。
+- 複数 worktree の read-modify-write が後勝ちになり、remote I/O 中の競合も防げない。
+- 既存 worktree に残る legacy cache のどれを採用するかが曖昧になる。
+- Git の検出失敗を non-git と誤認すると、新しい workspace-local cache が生まれて
+  split-brain になる。
+- 同じ `.gantt-sync/` にある config、outer loop journal、Graph Contract、Run Graph まで
+  一律に共有すると、Work Graph Cache と実行履歴の正本が混ざる。
+
+このため、caller が配置や lock の詳細を組み立てない deep Project Storage module が必要である。
+
+## Decision
+
+### 案A+B hybrid: 一つの公開 Interface と内部の closed StorageSlot catalog
+
+案Aの公開 seam を採用し、Project Storage module の入口を次の一つに限定する。
+
+```ts
+withProjectStorage(root, { mode, scope }, callback);
+```
+
+`mode` は `read` または `write`、`scope` は `shared-cache`、`workspace`、または両方を更新する
+`all` である。callback は型付けされた storage 操作だけを受け取り、
+物理 path、generation、lock record、migration manifest を受け取らない。案BをImplementation内だけに採用し、
+保存対象をclosed `StorageSlot` catalogに列挙して、callerに動的登録、任意path、scopeの上書きを許可しない。
+
+catalog は次の配置を固定する。
+
+| StorageSlot                        | scope                              | 性質                                      |
+| ---------------------------------- | ---------------------------------- | ----------------------------------------- |
+| `tasks`, `sync-state`, `comments`  | repository-shared Work Graph Cache | GitHub から再構築できる projection / base |
+| `config`, `workflow`, `loop-state` | workspace-local                    | 設定またはローカル観測 journal            |
+| `graph-contracts`, `run-graph`     | workspace-local                    | Plan/Org 契約と accepted event journal    |
+
+`loop-state.json` は Run Graph ではなく outer loop の観測 journal であり、どちらも #299 の
+共有対象にしない。
+
+### versioned repository namespace
+
+Git repository では、workspace-local の Zod 検証済み config から GitHub Project identity
+（正規化した owner、repository、project number）を導出し、次の versioned namespace を使う。
+
+```text
+<git-common-dir>/gh-gantt/cache/project-storage/v1/<project-key>/
+  snapshots/<generation>/tasks.json
+  snapshots/<generation>/sync-state.json
+  CURRENT
+  comments.json
+  migration.json
+<git-common-dir>/gh-gantt/locks/work-graph-cache.lock/owner.json
+```
+
+同じ Git repository 内でも GitHub Project identity が異なれば cache namespace を分ける。
+`project-key` は正規化した Project identity の fingerprint から導出し、identity を path へ直接露出しない。
+namespace version を path に含め、将来の layout 変更を暗黙の上書きにしない。
+repository lease は worktree や project namespace の外側に置き、同一 repository の Project Storage
+操作を統制する。
+
+### atomic snapshot-set
+
+`tasks.json` と `sync-state.json` は一つの snapshot-set として扱う。writer は新しい generation
+directory に両方を書き、各ファイルの Zod validation を完了してから、一時 pointer の atomic rename により
+`CURRENT` を publish する。reader は `CURRENT` が指す generation のファイルだけを読む。publish 前に失敗した
+generation は正本にならず、旧 `CURRENT` を維持する。snapshot hash と tasks 内容の整合性検証は
+NFR-STABILITY-001-AC1 の未充足事項であり、この publish 処理が保証するとはみなさない。
+
+`comments.json` は同じ repository-shared namespace に置くが、tasks/sync-state の merge base ではないため
+snapshot-set には含めない。repository lease 内で atomic replace し、remote取得の各batchでは `flush()` により
+durable checkpointをpublishする。欠損時と破損したlegacy commentsは GitHub から再構築する。
+
+### all-worktree legacy migration
+
+共有 namespace に snapshot がない最初の shared slot access だけ、初版の exclusive repository lease 内で
+copy-once migration を行う。
+Git が登録している全 worktree を列挙し、各 `<worktree>/.gantt-sync/` の legacy `tasks.json` と
+`sync-state.json` を次の順に検査する。
+
+1. 両方がない worktree は候補なしとする。いずれかがある場合は config を先に検証し、別の GitHub Project
+   identity を指す worktree は現在namespaceの候補から除外する。
+2. 同じidentityで一方だけ存在する場合は欠損として停止する。全候補を Zod 検証し、正準化した JSON から
+   pair の canonical fingerprint を計算する。破損した任意のcomments cacheは候補pairを止めず欠損扱いにする。
+3. 候補が一つ、または全 fingerprint が一致する場合だけ、新generationへcopyして`CURRENT`をpublishする。
+4. 候補の相違、欠損、破損は自動選択せず fail-closed にする。
+5. `migration.json` に project identity、移行元、fingerprint、対象worktreeを記録する。
+6. 移行後も全worktreeを照合し、記録にないlegacy pairの出現または記録済みfingerprintの変化を
+   旧CLI等による再書込みとみなしてfail-closedにする。
+
+legacy file は自動削除も dual-write もしない。移行元を残しても、manifest と fingerprint により
+新しい CLI が変化を無視して進むことはない。
+
+候補が分岐した場合、通常の shared slot access は `LEGACY_CACHE_DIVERGED` で停止する。operator は候補を確認し、
+`gh-gantt storage migrate --from <worktree>` で正本にする legacy pair を明示する。`--json` は同じ操作の結果を
+machine-readable に返す。指定元に候補がなければ `LEGACY_SOURCE_NOT_FOUND` で停止し、自動選択や後勝ち更新を
+行わない。選択した pair を新 generation として publish し、全候補の fingerprint を migration manifest に記録する。
+
+### 初版の exclusive repository lease
+
+`withProjectStorage` は lazy session を callback に渡し、callback を呼ぶ前には Git discovery、shared cache の
+作成、repository lease の取得を行わない。最初の shared slot access で layout を解決して repository-wide lease を
+取得し、途中の `flush()`、remote I/O、callback 完了時の final flush を経て `finally` で解放するまで保持する。
+callback が shared slot に触れない mock / validation-only path は Project Storage を通じて filesystem に触れない。
+
+初版は `mode: "read"` と `mode: "write"` のどちらも同じ exclusive lease を使って直列化する。`mode` と `scope` は
+書き込み可否と対象 slot を制限するが、reader の並行実行を許可するものではない。shared reader 同士を並行化する
+reader/writer lease は、実際の contention と安全性を測定してから行う後続最適化とする。
+
+lock owner record は host、pid、nonce、access、開始時刻を持つ。live owner または生死を判定できない owner の
+lock は盗まない。同一 host で pid が存在しないことを確認でき、読み直した owner nonce が一致するときだけ
+compare-and-recover する。timeout は owner 情報を含む診断を返し、workspace-local cache へfallbackしない。
+解放時はnonce一致を確認したactive lock directoryをnonce固有のretired pathへatomic renameしてから削除し、
+解放と次ownerの取得が競合しても新しいlockを再帰削除しない。callback内では即時の`process.exit()`を使わず、
+`finally`によるlease解放を必ず通す。
+
+### 明確な non-git fallback
+
+Git adapter が「この root は Git repository ではない」と明確に判定した場合だけ、従来どおり
+`<root>/.gantt-sync/` に全slotを置く。Git executable 不在、timeout、permission error、不正な出力、
+common-dir 解決失敗は non-git と同一視せず fail-closed にする。これにより Git worktree 内の一時障害から
+workspace-local cache が新設されることを防ぐ。
+
+### Run Graph の扱い
+
+#299 の repository lease と snapshot-set は Work Graph Cache のための統制であり、Graph Contract と
+Run Graph event journal には適用しない。ADR-022 の Run Graph は #329 で entity version、claim、lease、
+multi-process compare-and-append が実装・検証されるまで workspace-local を維持する。#329 完了後も共有化は
+自動ではなく、accepted event lineage を壊さないことを確認する別の意思決定を必要とする。
+
+## Alternatives
+
+### 案A: callback scope を持つ一入口の `withProjectStorage`
+
+公開 seam を一つにでき、最初の shared slot access から callback 終了までを lease 期間として強制できる。
+shared slot に触れない callback は lazy のまま完了できる。caller は `root`、`read|write`、実行内容だけを
+指定するため、remote I/O を含む scope から lock が抜けにくい。一方、
+内部の保存対象と publish 規則を自由な path 操作のままにすると、slot ごとの配置判断が分散する。
+このため公開 Interface と scope 規律を採用し、内部構造は案Bで補う。
+
+### 案B: closed StorageSlot catalog と atomic snapshot-set
+
+Work Graph Cache と workspace-local state のscope、Zod schema、atomic publish policyをclosed catalogに集約し、
+tasks/sync-stateを一つのsnapshot-setとして扱える。これを公開catalogにするとcallerがslotやpathへ依存し、
+案Aの小さいInterfaceを損なう。そのためcatalogとsnapshot-setはImplementation内だけに採用する。
+
+### 案C: 既存 Store caller を維持する lazy resolver
+
+`new TasksStore(root)`、`new SyncStateStore(root)` 等を維持し、各Storeが保存先を遅延解決する。
+caller変更は小さいが、複数slotのread-modify-writeとremote I/Oを覆うleaseはStore単体では表せない。
+各CLI commandとHTTP requestに別途lease適用を要求すると、適用漏れが型とInterfaceの外に残り、
+単一writer保証を破れるため採用しない。
+
+### 採用: 案A+B hybrid
+
+案Aの`withProjectStorage`だけを公開し、そのImplementationに案Bのclosed catalog、配置解決、migration、
+snapshot-set、repository leaseを置く。これによりlease期間をcallerのcallback scopeとして強制しながら、
+StorageSlot追加時の変更をmodule内へ局所化する。案Cのcaller互換性より、lease適用漏れを構造的に防ぐことを優先する。
+
+## Consequences
+
+- linked worktree ごとの pull と別々の merge base を減らし、同じ Work Graph Cache を参照できる。
+- 既存の Store 直接生成 caller は `withProjectStorage` callback へ移行した。新しい caller もこの一入口を使い、
+  repository lease の適用漏れを防ぐ。
+- mutating caller は型付きStoreのwrite後に`flush()`を完了してから成功結果を返し、publish失敗時に成功ログや
+  HTTP成功応答を先行させない。shared cacheとworkspace journalを同じ操作で更新する`loop complete`は`all`を使う。
+- tasks/sync-state の中途半端な世代は `CURRENT` から参照されず、process crash 後も旧世代を読める。
+- 長い remote I/O は read/write 共通の exclusive repository lease を長時間保持し、別worktreeを待たせる。
+  整合性を優先し、shared reader の並行化と optimistic concurrency は別の意思決定とする。
+- 初回migrationでlegacy候補が一致しないrepositoryは fail-closed で停止する。operator が
+  `storage migrate --from` で正本を明示した場合だけ共有 generation を更新するため、誤った候補を選ばない
+  運用上の確認が必要になる。
+- orphan generation の回収、network filesystem の分散lock、旧CLIとのdual-writeは別課題とする。
+- 現在の regression は、実 Git linked worktree の共有 / 非共有配置、non-git fallback、legacy migration の
+  一致・分岐・欠損・破損・破損comments・別Projectの不完全pair・移行後変更、publish 前 callback 失敗、
+  live / dead / 生死判定不能 owner、
+  同一process内の別process identity、真の別 OS process による lease 直列化、明示的 migration、
+  shared slot 非接触 callback の filesystem 非接触、linked worktree から追加 pull なしで実行する `status` を検証する。
+  CLI の `pull` / `push` を実 linked worktree で通す end-to-end smoke は未検証である。

--- a/docs/adr/ADR-023-project-storage-layout-and-lease.md
+++ b/docs/adr/ADR-023-project-storage-layout-and-lease.md
@@ -138,6 +138,10 @@ Git adapter が「この root は Git repository ではない」と明確に判�
 common-dir 解決失敗は non-git と同一視せず fail-closed にする。これにより Git worktree 内の一時障害から
 workspace-local cache が新設されることを防ぐ。
 
+Git hook が export する `GIT_DIR`、`GIT_WORK_TREE` 等の repository 選択環境変数は、
+`projectRoot` を正本として実行する Git subprocess へ継承しない。環境変数は `git -C <projectRoot>` より
+優先され得るため、継承すると hook を起動した repository を誤って検出・操作する危険がある。
+
 ### Run Graph の扱い
 
 #299 の repository lease と snapshot-set は Work Graph Cache のための統制であり、Graph Contract と
@@ -192,5 +196,7 @@ StorageSlot追加時の変更をmodule内へ局所化する。案Cのcaller互�
   一致・分岐・欠損・破損・破損comments・別Projectの不完全pair・移行後変更、publish 前 callback 失敗、
   live / dead / 生死判定不能 owner、
   同一process内の別process identity、真の別 OS process による lease 直列化、明示的 migration、
-  shared slot 非接触 callback の filesystem 非接触、linked worktree から追加 pull なしで実行する `status` を検証する。
-  CLI の `pull` / `push` を実 linked worktree で通す end-to-end smoke は未検証である。
+  shared slot 非接触 callback の filesystem 非接触、Git hook の repository 選択環境変数からの分離、
+  linked worktree から追加 pull なしで実行する `status`、CLI の `pull` / `push` を検証する。
+  linked worktree と CLI process は実物だが、GitHub transport は mock、`push` は dry-run であり、
+  remote write を伴う end-to-end smoke は未検証である。

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1543,7 +1543,8 @@ areas:
           - id: NFR-STABILITY-015-AC1
             description: |
               tasks.json と sync-state.json は同じ generation に保存し、callback が publish 前に
-              失敗した場合は旧 CURRENT generation の両ファイルを維持する
+              失敗した場合は旧 CURRENT generation の両ファイルを維持する。CURRENT が指す
+              generation の片側 member 欠損は空 cache とみなさず fail-closed にする
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
@@ -1557,7 +1558,8 @@ areas:
           - id: NFR-STABILITY-015-AC3
             description: |
               live owner の lease は timeout 後も回収せず STORAGE_BUSY を返し、同一 host で
-              process の死亡と owner nonce を確認できる lease だけを回収する
+              process の死亡と owner nonce を確認でき、atomic recovery claim を取得した
+              collector だけが lease を回収する
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1054,6 +1054,45 @@ areas:
             status: covered
             tests:
               - packages/shared/src/__tests__/schema.test.ts
+      - id: FR-STORE-004
+        summary: worktree 間で共有する Work Graph Cache の配置
+        acceptance_criteria:
+          - id: FR-STORE-004-AC1
+            description: |
+              同じ git-common-dir と GitHub Project identity を持つ linked worktree は
+              tasks.json、sync-state.json、comments.json を共有し、config、workflow、
+              loop-state、Graph Contract、Run Graph は workspace-local に保持する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: FR-STORE-004-AC2
+            description: |
+              Work Graph Cache は git-common-dir 配下の versioned namespace に置かれ、
+              owner、repository、project number が異なる GitHub Project の cache を混在させない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: FR-STORE-004-AC3
+            description: |
+              全登録 worktree の legacy tasks/sync-state は Zod 検証と canonical fingerprint が
+              一致する場合だけ一度移行され、相違、片側欠損、破損、移行後の変更は fail-closed になる
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: FR-STORE-004-AC4
+            description: |
+              明確な non-git directory だけが従来の projectRoot/.gantt-sync layout を使い、
+              Git discovery の実行異常は workspace-local cache へ fallback しない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: FR-STORE-004-AC5
+            description: |
+              legacy cache が分岐した場合は通常 access を fail-closed にし、operator が
+              storage migrate --from <worktree> で明示した候補だけを共有 generation に publish する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
       - id: NFR-STORE-001
         summary: スキーマバリデーション
         acceptance_criteria:
@@ -1498,3 +1537,57 @@ areas:
               stable ID と event lineage を壊さない versioned extension として追加できる
             status: uncovered
             tests: []
+      - id: NFR-STABILITY-015
+        summary: Work Graph Cache のsnapshot整合性とrepository lease
+        acceptance_criteria:
+          - id: NFR-STABILITY-015-AC1
+            description: |
+              tasks.json と sync-state.json は同じ generation に保存し、callback が publish 前に
+              失敗した場合は旧 CURRENT generation の両ファイルを維持する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC2
+            description: |
+              別 process identity の session は先行 lease の解放まで shared slot access を待ち、
+              真の別 OS process 間でも同じ順序で直列化される
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC3
+            description: |
+              live owner の lease は timeout 後も回収せず STORAGE_BUSY を返し、同一 host で
+              process の死亡と owner nonce を確認できる lease だけを回収する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC4
+            description: |
+              実 Git linked worktree は tasks、sync-state、comments を共有し、config、workflow、
+              loop-state、Graph Contract、Run Graph を workspace-local に保持する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC5
+            description: |
+              最初の shared slot access で lazy initialize し、read/write 共通の exclusive repository lease を
+              callback 完了時の final flush まで保持する。shared slot 非接触 callback は filesystem に触れない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC6
+            description: |
+              実 Git linked worktree 上で、固有のpullなしに CLI status が共有 Work Graph Cache を読み取る
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
+          - id: NFR-STABILITY-015-AC7
+            description: 生死を判定できない owner の lease は回収しない
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+          - id: NFR-STABILITY-015-AC8
+            description: 実 Git linked worktree 上で CLI の pull と push が共有 Work Graph Cache と互換に動作する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1591,3 +1591,10 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
+          - id: NFR-STABILITY-015-AC9
+            description: |
+              Git hook 由来の repository 選択環境変数を Git subprocess へ継承せず、
+              caller が指定した projectRoot の repository だけを検出・操作する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts

--- a/packages/cli/src/__tests__/comments.test.ts
+++ b/packages/cli/src/__tests__/comments.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CommentsStore } from "../store/comments.js";
 import { fetchAllComments, fetchIssueComments } from "../github/comments.js";
+import { saveCommentsCheckpoint } from "../commands/pull.js";
 import type { CommentsFile } from "@gh-gantt/shared";
 
 describe("CommentsStore", () => {
@@ -205,6 +206,20 @@ describe("fetchAllComments", () => {
     // All 3 should be fetched
     expect(gql).toHaveBeenCalledTimes(3);
     expect(result.comments["o/r#1"]?.[0].id).toBe("C_1_new");
+  });
+});
+
+describe("saveCommentsCheckpoint", () => {
+  it("comments batchを書き込んだ直後にdurable publishする", async () => {
+    const write = vi.fn(async () => undefined);
+    const flush = vi.fn(async () => undefined);
+    const data: CommentsFile = { version: "1", fetched_at: {}, comments: {} };
+
+    await saveCommentsCheckpoint({ commentsStore: { write }, flush }, data);
+
+    expect(write).toHaveBeenCalledWith(data);
+    expect(flush).toHaveBeenCalledOnce();
+    expect(write.mock.invocationCallOrder[0]).toBeLessThan(flush.mock.invocationCallOrder[0]);
   });
 });
 

--- a/packages/cli/src/__tests__/comments.test.ts
+++ b/packages/cli/src/__tests__/comments.test.ts
@@ -209,8 +209,8 @@ describe("fetchAllComments", () => {
   });
 });
 
-describe("saveCommentsCheckpoint", () => {
-  it("comments batchを書き込んだ直後にdurable publishする", async () => {
+describe("コメントのチェックポイント保存", () => {
+  it("コメント一括分を書き込んだ直後に永続公開する", async () => {
     const write = vi.fn(async () => undefined);
     const flush = vi.fn(async () => undefined);
     const data: CommentsFile = { version: "1", fetched_at: {}, comments: {} };

--- a/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
@@ -1,0 +1,186 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../github/client.js", () => ({
+  createGraphQLClient: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("../../github/projects.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../github/projects.js")>();
+  return {
+    ...original,
+    checkRemoteChanges: vi.fn().mockResolvedValue(false),
+    fetchProject: vi.fn().mockResolvedValue({
+      projectNodeId: "PVT_issue_299",
+      projectTitle: "Issue 299 fixture",
+      fields: [],
+      items: [],
+    }),
+    fetchRepositoryMetadata: vi.fn().mockResolvedValue({
+      labelMap: new Map(),
+      milestoneMap: new Map(),
+      milestones: [],
+    }),
+  };
+});
+
+import { statusCommand } from "../../commands/status.js";
+import { pullCommand } from "../../commands/pull.js";
+import { pushCommand } from "../../commands/push.js";
+import { withProjectStorage } from "../../store/project-storage.js";
+
+const execFileAsync = promisify(execFile);
+const createdRoots: string[] = [];
+let originalExitCode: typeof process.exitCode;
+
+const CONFIG = `${JSON.stringify(
+  {
+    version: "1",
+    project: {
+      name: "Issue 299 fixture",
+      github: { owner: "fixture", repo: "repository", project_number: 1 },
+    },
+    sync: {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000000", github_label: null },
+    },
+    type_hierarchy: { task: [] },
+    statuses: { field_name: "Status", values: { Done: { color: "#00ff00", done: true } } },
+    gantt: {
+      default_view: "month",
+      working_days: [1, 2, 3, 4, 5],
+      colors: {
+        critical_path: "#ff0000",
+        on_track: "#00ff00",
+        at_risk: "#ffff00",
+        overdue: "#ff0000",
+      },
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+const TASKS = `${JSON.stringify({ tasks: [], cache: { comments: {}, reactions: {} } }, null, 2)}\n`;
+
+const SYNC_STATE = `${JSON.stringify(
+  {
+    last_synced_at: "2026-07-30T00:00:00.000Z",
+    project_node_id: "PVT_issue_299",
+    id_map: {},
+    field_ids: {},
+    snapshots: {},
+  },
+  null,
+  2,
+)}\n`;
+
+async function runGit(root: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", ["-C", root, ...args]);
+}
+
+beforeEach(() => {
+  originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+});
+
+afterEach(async () => {
+  process.exitCode = originalExitCode;
+  vi.restoreAllMocks();
+  await Promise.all(
+    createdRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("[NFR-STABILITY-015] [Issue #299] statusはlinked worktreeから共有cacheを読む", () => {
+  it("[NFR-STABILITY-015-AC6] linked worktree固有のpullなしで共有tasks/sync-stateを使ってstatusを表示する", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "gh-gantt-issue-299-status-"));
+    createdRoots.push(parent);
+    const repository = join(parent, "repository");
+    const linked = join(parent, "linked");
+    await mkdir(join(repository, ".gantt-sync"), { recursive: true });
+    await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+    await runGit(repository, "config", "user.email", "issue-299@example.invalid");
+    await runGit(repository, "config", "user.name", "Issue 299 Test");
+    await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);
+    await writeFile(join(repository, "README.md"), "fixture\n");
+    await runGit(repository, "add", "README.md", ".gantt-sync/gantt.config.json");
+    await runGit(repository, "commit", "-m", "test: fixture");
+    await runGit(repository, "worktree", "add", "-b", "fixture-linked", linked);
+
+    await withProjectStorage(
+      repository,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        await storage.tasksStore.write(JSON.parse(TASKS));
+        await storage.stateStore.write(JSON.parse(SYNC_STATE));
+      },
+    );
+
+    await expect(access(join(linked, ".gantt-sync", "tasks.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(access(join(linked, ".gantt-sync", "sync-state.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    vi.spyOn(process, "cwd").mockReturnValue(linked);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await statusCommand.parseAsync(["status", "--json"], { from: "user" });
+
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({
+      last_synced_at: "2026-07-30T00:00:00.000Z",
+      local_tasks: 0,
+      remote_tasks: 0,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("[NFR-STABILITY-015-AC8] real linked worktreeでCLI pullとpush dry-runが共有cacheを継続利用する", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "gh-gantt-issue-299-sync-"));
+    createdRoots.push(parent);
+    const repository = join(parent, "repository");
+    const linked = join(parent, "linked");
+    await mkdir(join(repository, ".gantt-sync"), { recursive: true });
+    await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+    await runGit(repository, "config", "user.email", "issue-299@example.invalid");
+    await runGit(repository, "config", "user.name", "Issue 299 Test");
+    await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);
+    await writeFile(join(repository, "README.md"), "fixture\n");
+    await runGit(repository, "add", "README.md", ".gantt-sync/gantt.config.json");
+    await runGit(repository, "commit", "-m", "test: fixture");
+    await runGit(repository, "worktree", "add", "-b", "fixture-linked", linked);
+    await withProjectStorage(
+      repository,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        await storage.tasksStore.write(JSON.parse(TASKS));
+        await storage.stateStore.write(JSON.parse(SYNC_STATE));
+      },
+    );
+
+    vi.spyOn(process, "cwd").mockReturnValue(linked);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await pullCommand.parseAsync(["pull", "--json"], { from: "user" });
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({
+      summary: { added: 0, updated: 0, conflicts: 0, removed: 0 },
+    });
+
+    log.mockClear();
+    await pushCommand.parseAsync(["push", "--dry-run", "--json"], { from: "user" });
+    expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toMatchObject({
+      changes: [],
+      dry_run: true,
+      estimated_api_calls: 0,
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
@@ -37,6 +37,32 @@ const execFileAsync = promisify(execFile);
 const createdRoots: string[] = [];
 let originalExitCode: typeof process.exitCode;
 
+function gitCommandEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  for (const name of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  ]) {
+    delete environment[name];
+  }
+  return environment;
+}
+
 const CONFIG = `${JSON.stringify(
   {
     version: "1",
@@ -83,7 +109,7 @@ const SYNC_STATE = `${JSON.stringify(
 )}\n`;
 
 async function runGit(root: string, ...args: string[]): Promise<void> {
-  await execFileAsync("git", ["-C", root, ...args]);
+  await execFileAsync("git", ["-C", root, ...args], { env: gitCommandEnvironment() });
 }
 
 beforeEach(() => {
@@ -106,7 +132,9 @@ describe("[NFR-STABILITY-015] [Issue #299] statusはlinked worktreeから共有c
     const repository = join(parent, "repository");
     const linked = join(parent, "linked");
     await mkdir(join(repository, ".gantt-sync"), { recursive: true });
-    await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+    await execFileAsync("git", ["init", "--initial-branch=main", repository], {
+      env: gitCommandEnvironment(),
+    });
     await runGit(repository, "config", "user.email", "issue-299@example.invalid");
     await runGit(repository, "config", "user.name", "Issue 299 Test");
     await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);
@@ -149,7 +177,9 @@ describe("[NFR-STABILITY-015] [Issue #299] statusはlinked worktreeから共有c
     const repository = join(parent, "repository");
     const linked = join(parent, "linked");
     await mkdir(join(repository, ".gantt-sync"), { recursive: true });
-    await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+    await execFileAsync("git", ["init", "--initial-branch=main", repository], {
+      env: gitCommandEnvironment(),
+    });
     await runGit(repository, "config", "user.email", "issue-299@example.invalid");
     await runGit(repository, "config", "user.name", "Issue 299 Test");
     await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);

--- a/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-status-shared-cache.test.ts
@@ -9,6 +9,10 @@ vi.mock("../../github/client.js", () => ({
   createGraphQLClient: vi.fn(() => vi.fn()),
 }));
 
+vi.mock("../../github/comments.js", () => ({
+  fetchAllComments: vi.fn(),
+}));
+
 vi.mock("../../github/projects.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../github/projects.js")>();
   return {
@@ -31,6 +35,7 @@ vi.mock("../../github/projects.js", async (importOriginal) => {
 import { statusCommand } from "../../commands/status.js";
 import { pullCommand } from "../../commands/pull.js";
 import { pushCommand } from "../../commands/push.js";
+import { fetchAllComments } from "../../github/comments.js";
 import { withProjectStorage } from "../../store/project-storage.js";
 
 const execFileAsync = promisify(execFile);
@@ -212,5 +217,40 @@ describe("[NFR-STABILITY-015] [Issue #299] statusはlinked worktreeから共有c
       estimated_api_calls: 0,
     });
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("[NFR-STABILITY-015-AC8] quick-skipしたpull dry-runは--with-commentsでもcomment cacheを書き換えない", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "gh-gantt-issue-299-dry-run-"));
+    createdRoots.push(parent);
+    const repository = join(parent, "repository");
+    await mkdir(join(repository, ".gantt-sync"), { recursive: true });
+    await execFileAsync("git", ["init", "--initial-branch=main", repository], {
+      env: gitCommandEnvironment(),
+    });
+    await runGit(repository, "config", "user.email", "issue-299@example.invalid");
+    await runGit(repository, "config", "user.name", "Issue 299 Test");
+    await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);
+    await writeFile(join(repository, "README.md"), "fixture\n");
+    await runGit(repository, "add", "README.md", ".gantt-sync/gantt.config.json");
+    await runGit(repository, "commit", "-m", "test: fixture");
+    await withProjectStorage(
+      repository,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        await storage.tasksStore.write(JSON.parse(TASKS));
+        await storage.stateStore.write(JSON.parse(SYNC_STATE));
+      },
+    );
+
+    vi.spyOn(process, "cwd").mockReturnValue(repository);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await pullCommand.parseAsync(["pull", "--dry-run", "--with-comments", "--json"], {
+      from: "user",
+    });
+
+    expect(fetchAllComments).not.toHaveBeenCalled();
+    await expect(access(join(repository, ".gantt-sync", "comments.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });

--- a/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
@@ -115,8 +115,36 @@ const CONFIG_OTHER_PROJECT = `${JSON.stringify(
 
 type SharedStorageSlot = "tasks" | "sync-state" | "comments";
 
+function gitCommandEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  for (const name of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  ]) {
+    delete environment[name];
+  }
+  return environment;
+}
+
 async function runGit(root: string, ...args: string[]): Promise<string> {
-  const result = await execFileAsync("git", ["-C", root, ...args]);
+  const result = await execFileAsync("git", ["-C", root, ...args], {
+    env: gitCommandEnvironment(),
+  });
   return result.stdout.trim();
 }
 
@@ -130,7 +158,9 @@ async function makeRepositoryWithLinkedWorktree(): Promise<{
   const repository = join(parent, "repository");
   const linked = join(parent, "linked");
   await mkdir(repository);
-  await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+  await execFileAsync("git", ["init", "--initial-branch=main", repository], {
+    env: gitCommandEnvironment(),
+  });
   await runGit(repository, "config", "user.email", "issue-299@example.invalid");
   await runGit(repository, "config", "user.name", "Issue 299 Test");
   await mkdir(join(repository, ".gantt-sync"), { recursive: true });
@@ -619,6 +649,62 @@ describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspac
     }
   });
 
+  it("[NFR-STABILITY-015-AC9] Git hookのrepository選択envをsubprocessへ継承しない", async () => {
+    const { repository, linked, commonDir } = await makeRepositoryWithLinkedWorktree();
+    const foreignGitDir = await makeStandaloneRoot();
+    await execFileAsync("git", ["init", "--bare", foreignGitDir], {
+      env: gitCommandEnvironment(),
+    });
+    const previousGitDir = process.env.GIT_DIR;
+    const previousWorkTree = process.env.GIT_WORK_TREE;
+    process.env.GIT_DIR = foreignGitDir;
+    process.env.GIT_WORK_TREE = repository;
+
+    try {
+      await publishSharedCache(repository);
+      await expect(readSlot(linked, "tasks")).resolves.toBe(TASKS_V1);
+      await expect(
+        access(join(projectNamespace(commonDir, "fixture/repository#1"), "CURRENT")),
+      ).resolves.toBeUndefined();
+      await expect(access(join(foreignGitDir, "gh-gantt"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      if (previousGitDir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = previousGitDir;
+      if (previousWorkTree === undefined) delete process.env.GIT_WORK_TREE;
+      else process.env.GIT_WORK_TREE = previousWorkTree;
+    }
+  });
+
+  it("[NFR-STABILITY-015-AC9] Git discovery範囲を制限するenvよりprojectRootを優先する", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    const nestedRepository = join(repository, "nested-project");
+    const nestedLinked = join(linked, "nested-project");
+    await Promise.all([
+      mkdir(join(nestedRepository, ".gantt-sync"), { recursive: true }),
+      mkdir(join(nestedLinked, ".gantt-sync"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(nestedRepository, ".gantt-sync", "gantt.config.json"), CONFIG_V1),
+      writeFile(join(nestedLinked, ".gantt-sync", "gantt.config.json"), CONFIG_V1),
+    ]);
+    const previousCeiling = process.env.GIT_CEILING_DIRECTORIES;
+    const previousDiscovery = process.env.GIT_DISCOVERY_ACROSS_FILESYSTEM;
+    process.env.GIT_CEILING_DIRECTORIES = repository;
+    process.env.GIT_DISCOVERY_ACROSS_FILESYSTEM = "0";
+
+    try {
+      await publishSharedCache(nestedRepository);
+      await expect(readSlot(nestedLinked, "tasks")).resolves.toBe(TASKS_V1);
+    } finally {
+      if (previousCeiling === undefined) delete process.env.GIT_CEILING_DIRECTORIES;
+      else process.env.GIT_CEILING_DIRECTORIES = previousCeiling;
+      if (previousDiscovery === undefined) delete process.env.GIT_DISCOVERY_ACROSS_FILESYSTEM;
+      else process.env.GIT_DISCOVERY_ACROSS_FILESYSTEM = previousDiscovery;
+    }
+  });
+
   it("[NFR-STABILITY-015-AC7] 別hostで生死を判定できないownerのleaseは回収しない", async () => {
     const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
     const leaseDir = join(commonDir, "gh-gantt", "locks", "work-graph-cache.lock");
@@ -714,7 +800,11 @@ main().catch((error) => {
     const child = spawn(
       process.execPath,
       ["--import", "tsx", childScript, moduleUrl, repository, barrier, release],
-      { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] },
+      {
+        cwd: process.cwd(),
+        env: gitCommandEnvironment(),
+        stdio: ["ignore", "pipe", "pipe"],
+      },
     );
     let childStderr = "";
     child.stderr?.setEncoding("utf8");

--- a/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
@@ -490,6 +490,44 @@ describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspac
     }
   });
 
+  it("[FR-STORE-004-AC5] nested projectはworktree rootを--fromに指定して移行できる", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    const nestedRepository = join(repository, "nested-project");
+    const nestedLinked = join(linked, "nested-project");
+    await Promise.all([
+      mkdir(join(nestedRepository, ".gantt-sync"), { recursive: true }),
+      mkdir(join(nestedLinked, ".gantt-sync"), { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(nestedRepository, ".gantt-sync", "gantt.config.json"), CONFIG_V1),
+      writeFile(join(nestedLinked, ".gantt-sync", "gantt.config.json"), CONFIG_V1),
+      writeLegacy(nestedRepository, {
+        "tasks.json": TASKS_V1,
+        "sync-state.json": SYNC_STATE_V1,
+      }),
+      writeLegacy(nestedLinked, {
+        "tasks.json": TASKS_V2,
+        "sync-state.json": SYNC_STATE_V2,
+      }),
+    ]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      await createStorageCommand({ projectRoot: () => nestedRepository }).parseAsync(
+        ["migrate", "--from", linked, "--json"],
+        { from: "user" },
+      );
+      expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toEqual({
+        ok: true,
+        source: linked,
+      });
+      await expect(readSlot(nestedRepository, "tasks")).resolves.toBe(TASKS_V2);
+      await expect(readSlot(nestedRepository, "sync-state")).resolves.toBe(SYNC_STATE_V2);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   it("[FR-STORE-004-AC2] 同じgit-common-dirでもGitHub Project identityが異なるworktreeはnamespaceを分離する", async () => {
     const { repository, linked } = await makeRepositoryWithLinkedWorktree();
     await publishSharedCache(repository);

--- a/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
@@ -14,12 +14,19 @@ import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promise
 import { isAbsolute, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createEmptyLoopState,
+  FIXED_DEV_ROLE_GRAPH_CONTRACT,
+  type RunGraphAcceptedEvent,
+} from "@gh-gantt/shared";
 import { createStorageCommand } from "../../commands/storage.js";
 import { pullCommand } from "../../commands/pull.js";
+import { GraphContractStore } from "../../store/graph-contract.js";
 import {
   createProjectStorageDependencies,
   withProjectStorage,
 } from "../../store/project-storage.js";
+import { RunGraphEventStore } from "../../store/run-graph.js";
 
 const execFileAsync = promisify(execFile);
 const createdRoots: string[] = [];
@@ -280,15 +287,94 @@ describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspac
     await expect(access(join(linked, ".gantt-sync", "tasks.json"))).rejects.toMatchObject({
       code: "ENOENT",
     });
-    expect(join(repository, ".gantt-sync", "gantt.config.json")).not.toBe(
-      join(linked, ".gantt-sync", "gantt.config.json"),
-    );
-    expect(join(repository, ".gantt-sync", "loop-state.json")).not.toBe(
-      join(linked, ".gantt-sync", "loop-state.json"),
-    );
-    expect(join(repository, ".gantt-sync", "run-graph.jsonl")).not.toBe(
-      join(linked, ".gantt-sync", "run-graph.jsonl"),
-    );
+
+    const repositoryConfig = {
+      ...JSON.parse(CONFIG_V1),
+      project: { ...JSON.parse(CONFIG_V1).project, name: "repository workspace" },
+    };
+    const linkedConfig = {
+      ...JSON.parse(CONFIG_V1),
+      project: { ...JSON.parse(CONFIG_V1).project, name: "linked workspace" },
+    };
+    const repositoryLoop = createEmptyLoopState();
+    repositoryLoop.iterations.push({
+      id: 1,
+      startedAt: "2026-07-30T00:00:00.000Z",
+      selectedTask: null,
+      decision: "repository workspace",
+    });
+    const linkedLoop = createEmptyLoopState();
+    linkedLoop.iterations.push({
+      id: 1,
+      startedAt: "2026-07-30T00:01:00.000Z",
+      selectedTask: null,
+      decision: "linked workspace",
+    });
+    await withProjectStorage(repository, { mode: "write", scope: "workspace" }, async (storage) => {
+      await storage.configStore.write(repositoryConfig);
+      await storage.loopStore.write(repositoryLoop);
+    });
+    await withProjectStorage(linked, { mode: "write", scope: "workspace" }, async (storage) => {
+      await storage.configStore.write(linkedConfig);
+      await storage.loopStore.write(linkedLoop);
+    });
+
+    const repositoryContract = {
+      ...FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      planId: "repository-contract",
+    };
+    const linkedContract = { ...FIXED_DEV_ROLE_GRAPH_CONTRACT, planId: "linked-contract" };
+    await new GraphContractStore(repository).install(repositoryContract);
+    await new GraphContractStore(linked).install(linkedContract);
+    const makeRunStart = (runId: string, issueNumber: number): RunGraphAcceptedEvent => ({
+      recordType: "accepted",
+      eventId: `${runId}-start`,
+      sequence: 1,
+      runId,
+      acceptedAt: "2026-07-30T00:00:00.000Z",
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      command: {
+        type: "run_started",
+        task: { owner: "fixture", repo: "repository", issueNumber },
+        contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+        firstNodeId: "node-planner-1",
+      },
+      artifactIds: [],
+      evidenceIds: [],
+    });
+    await new RunGraphEventStore(repository).appendAccepted(makeRunStart("repository-run", 299));
+    await new RunGraphEventStore(linked).appendAccepted(makeRunStart("linked-run", 300));
+
+    await withProjectStorage(repository, { mode: "read", scope: "workspace" }, async (storage) => {
+      await expect(storage.configStore.read()).resolves.toMatchObject({
+        project: { name: "repository workspace" },
+      });
+      await expect(storage.loopStore.readOrNull()).resolves.toEqual(repositoryLoop);
+    });
+    await withProjectStorage(linked, { mode: "read", scope: "workspace" }, async (storage) => {
+      await expect(storage.configStore.read()).resolves.toMatchObject({
+        project: { name: "linked workspace" },
+      });
+      await expect(storage.loopStore.readOrNull()).resolves.toEqual(linkedLoop);
+    });
+    await expect(
+      new GraphContractStore(repository).read({
+        planId: "repository-contract",
+        planVersion: "1",
+        schemaVersion: "1",
+      }),
+    ).resolves.toEqual(repositoryContract);
+    await expect(
+      new GraphContractStore(linked).read({
+        planId: "linked-contract",
+        planVersion: "1",
+        schemaVersion: "1",
+      }),
+    ).resolves.toEqual(linkedContract);
+    await expect(new RunGraphEventStore(repository).listRunIds()).resolves.toEqual([
+      "repository-run",
+    ]);
+    await expect(new RunGraphEventStore(linked).listRunIds()).resolves.toEqual(["linked-run"]);
   });
 
   it("[FR-STORE-004-AC4] non-git workspace はrepository scopeも従来の.gantt-sync配下へ縮退する", async () => {
@@ -331,6 +417,18 @@ describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspac
 
     await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
     await expect(readSlot(repository, "sync-state")).resolves.toBe(SYNC_STATE_V1);
+  });
+
+  it("[NFR-STABILITY-015-AC1] CURRENT世代のmember欠損は空cacheではなく不完全snapshotとして拒否する", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    await publishSharedCache(repository);
+    const namespaceRoot = projectNamespace(commonDir, "fixture/repository#1");
+    const generation = (await readFile(join(namespaceRoot, "CURRENT"), "utf8")).trim();
+    await rm(join(namespaceRoot, "snapshots", generation, "tasks.json"));
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "CACHE_SNAPSHOT_INCOMPLETE",
+    });
   });
 
   it("[NFR-STABILITY-015-AC2] [NFR-STABILITY-015-AC5] 別process identityのwriter sessionは先行leaseが解放されるまでcallbackへ入らない", async () => {
@@ -672,6 +770,53 @@ describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspac
     await expect(access(leaseDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("[NFR-STABILITY-015-AC3] 別collectorのatomic recovery claimがある死亡ownerは回収しない", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    const leaseDir = join(commonDir, "gh-gantt", "locks", "work-graph-cache.lock");
+    await mkdir(leaseDir, { recursive: true });
+    await writeFile(
+      join(leaseDir, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        group: "work-graph-cache",
+        pid: 611,
+        hostname: "issue-299-test-host",
+        startedAt: "2026-07-30T00:00:00.000Z",
+        workspace: repository,
+        access: "write",
+        nonce: "dead-owner-with-claim",
+      })}\n`,
+    );
+    await writeFile(
+      join(leaseDir, "recovery-claim.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        expectedOwnerNonce: "dead-owner-with-claim",
+        claimant: {
+          pid: 612,
+          hostname: "issue-299-test-host",
+          nonce: "other-collector",
+          claimedAt: "2026-07-30T00:00:01.000Z",
+        },
+      })}\n`,
+    );
+    const livePids = new Set([612, 613]);
+
+    await expect(
+      withProjectStorage(
+        repository,
+        {
+          mode: "write",
+          scope: "shared-cache",
+          waitTimeoutMs: 20,
+          dependencies: processDependencies(613, livePids),
+        },
+        async (storage) => storage.ensureSharedCache(),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_BUSY" });
+    await expect(access(join(leaseDir, "owner.json"))).resolves.toBeUndefined();
+  });
+
   it("[FR-STORE-004-AC4] Git executableの起動失敗はnon-git扱いにせずGIT_DISCOVERY_FAILEDを返す", async () => {
     const { repository } = await makeRepositoryWithLinkedWorktree();
     const emptyPath = await makeStandaloneRoot();
@@ -844,29 +989,43 @@ main().catch((error) => {
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
+    const childExit = once(child, "exit") as Promise<[number | null]>;
     let childStderr = "";
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
       childStderr += chunk;
     });
-    await waitForFile(barrier, child, () => childStderr);
-
     let secondEntered = false;
-    const second = withProjectStorage(
-      repository,
-      { mode: "write", scope: "shared-cache", waitTimeoutMs: 2_000 },
-      async (storage) => {
-        await storage.ensureSharedCache();
-        secondEntered = true;
-      },
-    );
-    await new Promise<void>((resolveWait) => setTimeout(resolveWait, 100));
-    expect(secondEntered).toBe(false);
+    let released = false;
+    let second: Promise<void> | undefined;
+    try {
+      await waitForFile(barrier, child, () => childStderr);
+      second = withProjectStorage(
+        repository,
+        { mode: "write", scope: "shared-cache", waitTimeoutMs: 2_000 },
+        async (storage) => {
+          await storage.ensureSharedCache();
+          secondEntered = true;
+        },
+      );
+      await new Promise<void>((resolveWait) => setTimeout(resolveWait, 100));
+      expect(secondEntered).toBe(false);
 
-    await writeFile(release, "release\n");
-    const [exitCode] = (await once(child, "exit")) as [number | null];
-    expect(exitCode, childStderr).toBe(0);
-    await second;
-    expect(secondEntered).toBe(true);
+      await writeFile(release, "release\n");
+      released = true;
+      const [exitCode] = await childExit;
+      expect(exitCode, childStderr).toBe(0);
+      await second;
+      expect(secondEntered).toBe(true);
+    } finally {
+      if (!released) {
+        await writeFile(release, "release\n").catch(() => undefined);
+      }
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill();
+        await childExit.catch(() => undefined);
+      }
+      await second?.catch(() => undefined);
+    }
   });
 });

--- a/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Issue #299 の ProjectStorage Interface に対する最初の RED tracer。
+ *
+ * 公開 seam は `withProjectStorage(root, access, callback)` とし、caller は
+ * git-common-dir、legacy migration、generation、lease の実装詳細を扱わない。
+ * process identity / liveness だけは、別 process の競合を決定論的に再現するため
+ * `createProjectStorageDependencies` から注入する。
+ */
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { promisify } from "node:util";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStorageCommand } from "../../commands/storage.js";
+import { pullCommand } from "../../commands/pull.js";
+import {
+  createProjectStorageDependencies,
+  withProjectStorage,
+} from "../../store/project-storage.js";
+
+const execFileAsync = promisify(execFile);
+const createdRoots: string[] = [];
+
+const TASKS_V1 = `${JSON.stringify(
+  { tasks: [], cache: { comments: {}, reactions: {} } },
+  null,
+  2,
+)}\n`;
+
+const TASKS_V2 = `${JSON.stringify(
+  {
+    tasks: [],
+    cache: {
+      comments: {
+        marker: [{ author: "tester", body: "v2", created_at: "2026-01-01" }],
+      },
+      reactions: {},
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+const SYNC_STATE_V1 = `${JSON.stringify(
+  {
+    last_synced_at: "2026-07-30T00:00:00.000Z",
+    project_node_id: "PVT_test",
+    id_map: {},
+    field_ids: {},
+    snapshots: {},
+  },
+  null,
+  2,
+)}\n`;
+
+const SYNC_STATE_V2 = `${JSON.stringify(
+  {
+    last_synced_at: "2026-07-30T01:00:00.000Z",
+    project_node_id: "PVT_test",
+    id_map: {},
+    field_ids: {},
+    snapshots: {},
+  },
+  null,
+  2,
+)}\n`;
+
+const COMMENTS_V1 = `${JSON.stringify({ version: "1", fetched_at: {}, comments: {} }, null, 2)}\n`;
+
+const CONFIG_V1 = `${JSON.stringify(
+  {
+    version: "1",
+    project: {
+      name: "Issue 299 fixture",
+      github: { owner: "fixture", repo: "repository", project_number: 1 },
+    },
+    sync: {
+      auto_create_issues: false,
+      field_mapping: { start_date: "Start", end_date: "End" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000000", github_label: null },
+    },
+    type_hierarchy: { task: [] },
+    statuses: { field_name: "Status", values: { Done: { color: "#00ff00", done: true } } },
+    gantt: {
+      default_view: "month",
+      working_days: [1, 2, 3, 4, 5],
+      colors: {
+        critical_path: "#ff0000",
+        on_track: "#00ff00",
+        at_risk: "#ffff00",
+        overdue: "#ff0000",
+      },
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+const CONFIG_OTHER_PROJECT = `${JSON.stringify(
+  {
+    ...JSON.parse(CONFIG_V1),
+    project: {
+      name: "Issue 299 other fixture",
+      github: { owner: "fixture", repo: "other-repository", project_number: 2 },
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+type SharedStorageSlot = "tasks" | "sync-state" | "comments";
+
+async function runGit(root: string, ...args: string[]): Promise<string> {
+  const result = await execFileAsync("git", ["-C", root, ...args]);
+  return result.stdout.trim();
+}
+
+async function makeRepositoryWithLinkedWorktree(): Promise<{
+  repository: string;
+  linked: string;
+  commonDir: string;
+}> {
+  const parent = await mkdtemp(join(tmpdir(), "gh-gantt-issue-299-git-"));
+  createdRoots.push(parent);
+  const repository = join(parent, "repository");
+  const linked = join(parent, "linked");
+  await mkdir(repository);
+  await execFileAsync("git", ["init", "--initial-branch=main", repository]);
+  await runGit(repository, "config", "user.email", "issue-299@example.invalid");
+  await runGit(repository, "config", "user.name", "Issue 299 Test");
+  await mkdir(join(repository, ".gantt-sync"), { recursive: true });
+  await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG_V1);
+  await writeFile(join(repository, "README.md"), "fixture\n");
+  await runGit(repository, "add", "README.md", ".gantt-sync/gantt.config.json");
+  await runGit(repository, "commit", "-m", "test: fixture");
+  await runGit(repository, "worktree", "add", "-b", "fixture-linked", linked);
+
+  const rawCommonDir = await runGit(linked, "rev-parse", "--git-common-dir");
+  const commonDir = isAbsolute(rawCommonDir) ? rawCommonDir : resolve(linked, rawCommonDir);
+  return { repository, linked, commonDir };
+}
+
+async function makeStandaloneRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "gh-gantt-issue-299-standalone-"));
+  createdRoots.push(root);
+  return root;
+}
+
+async function writeLegacy(
+  root: string,
+  files: Partial<Record<"tasks.json" | "sync-state.json" | "comments.json", string>>,
+): Promise<void> {
+  const directory = join(root, ".gantt-sync");
+  await mkdir(directory, { recursive: true });
+  await Promise.all(
+    Object.entries(files).map(([name, content]) => writeFile(join(directory, name), content)),
+  );
+}
+
+async function readSlot(root: string, slot: SharedStorageSlot): Promise<string> {
+  return withProjectStorage(root, { mode: "read" }, async (storage) => {
+    const value =
+      slot === "tasks"
+        ? await storage.tasksStore.read()
+        : slot === "sync-state"
+          ? await storage.stateStore.read()
+          : await storage.commentsStore.read();
+    return `${JSON.stringify(value, null, 2)}\n`;
+  });
+}
+
+async function publishSharedCache(
+  root: string,
+  tasks = TASKS_V1,
+  syncState = SYNC_STATE_V1,
+  comments = COMMENTS_V1,
+): Promise<void> {
+  await withProjectStorage(root, { mode: "write", scope: "shared-cache" }, async (storage) => {
+    await storage.tasksStore.write(JSON.parse(tasks));
+    await storage.stateStore.write(JSON.parse(syncState));
+    await storage.commentsStore.write(JSON.parse(comments));
+  });
+}
+
+function projectNamespace(commonDir: string, identity: string): string {
+  const key = createHash("sha256").update(JSON.stringify(identity)).digest("hex").slice(0, 32);
+  return join(commonDir, "gh-gantt", "cache", "project-storage", "v1", key);
+}
+
+function processDependencies(
+  pid: number,
+  livePids: Set<number>,
+): ReturnType<typeof createProjectStorageDependencies> {
+  return createProjectStorageDependencies({
+    processIdentity: { pid, hostname: "issue-299-test-host" },
+    isProcessAlive: async (candidate) => livePids.has(candidate),
+  });
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolveTurn) => setTimeout(resolveTurn, 25));
+}
+
+async function waitForFile(
+  path: string,
+  child?: ChildProcess,
+  childError: () => string = () => "",
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(path);
+      return;
+    } catch {
+      if (child?.exitCode !== null) {
+        throw new Error(
+          `子processがbarrier作成前に終了しました: exit=${child?.exitCode} ${childError()}`,
+        );
+      }
+      await nextTurn();
+    }
+  }
+  throw new Error(`barrier fileを待機できませんでした: ${path}`);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("[NFR-STABILITY-015] [Issue #299] worktree 間共有 cache と workspace-local state の配置を保証する", () => {
+  it("[FR-STORE-004-AC1] [NFR-STABILITY-015-AC4] real linked worktree はtasks・sync-state・commentsを共有し、設定・journal・Run Graphを共有しない", async () => {
+    const { repository, linked, commonDir } = await makeRepositoryWithLinkedWorktree();
+    await publishSharedCache(repository);
+    await expect(
+      access(join(commonDir, "gh-gantt", "cache", "project-storage", "v1")),
+    ).resolves.toBe(undefined);
+    await expect(readSlot(linked, "tasks")).resolves.toBe(TASKS_V1);
+    await expect(readSlot(linked, "sync-state")).resolves.toBe(SYNC_STATE_V1);
+    await expect(readSlot(linked, "comments")).resolves.toBe(COMMENTS_V1);
+    await expect(access(join(repository, ".gantt-sync", "tasks.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(access(join(linked, ".gantt-sync", "tasks.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(join(repository, ".gantt-sync", "gantt.config.json")).not.toBe(
+      join(linked, ".gantt-sync", "gantt.config.json"),
+    );
+    expect(join(repository, ".gantt-sync", "loop-state.json")).not.toBe(
+      join(linked, ".gantt-sync", "loop-state.json"),
+    );
+    expect(join(repository, ".gantt-sync", "run-graph.jsonl")).not.toBe(
+      join(linked, ".gantt-sync", "run-graph.jsonl"),
+    );
+  });
+
+  it("[FR-STORE-004-AC4] non-git workspace はrepository scopeも従来の.gantt-sync配下へ縮退する", async () => {
+    const root = await makeStandaloneRoot();
+    await publishSharedCache(root);
+
+    await expect(readFile(join(root, ".gantt-sync", "tasks.json"), "utf8")).resolves.toBe(TASKS_V1);
+    await expect(readFile(join(root, ".gantt-sync", "sync-state.json"), "utf8")).resolves.toBe(
+      SYNC_STATE_V1,
+    );
+    await expect(readFile(join(root, ".gantt-sync", "comments.json"), "utf8")).resolves.toBe(
+      COMMENTS_V1,
+    );
+  });
+
+  it("[FR-STORE-004-AC5] 別worktreeのlegacy cacheが共有世代と異なる場合は後勝ちで上書きしない", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, { "tasks.json": TASKS_V1, "sync-state.json": SYNC_STATE_V1 });
+    await writeLegacy(linked, { "tasks.json": TASKS_V2, "sync-state.json": SYNC_STATE_V2 });
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "LEGACY_CACHE_DIVERGED",
+    });
+    await expect(readSlot(linked, "tasks")).rejects.toMatchObject({
+      code: "LEGACY_CACHE_DIVERGED",
+    });
+  });
+
+  it("[NFR-STABILITY-015-AC1] generation公開前にcallbackが失敗した場合は旧CURRENT世代を維持する", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    await publishSharedCache(repository);
+
+    await expect(
+      withProjectStorage(repository, { mode: "write", scope: "shared-cache" }, async (storage) => {
+        await storage.tasksStore.write(JSON.parse(TASKS_V2));
+        await storage.stateStore.write(JSON.parse(SYNC_STATE_V2));
+        throw new Error("CURRENT 交換前の模擬失敗");
+      }),
+    ).rejects.toThrow("CURRENT 交換前の模擬失敗");
+
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+    await expect(readSlot(repository, "sync-state")).resolves.toBe(SYNC_STATE_V1);
+  });
+
+  it("[NFR-STABILITY-015-AC2] [NFR-STABILITY-015-AC5] 別process identityのwriter sessionは先行leaseが解放されるまでcallbackへ入らない", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    const livePids = new Set([101, 202]);
+    let releaseFirst!: () => void;
+    let firstEntered!: () => void;
+    const entered = new Promise<void>((resolveEntered) => {
+      firstEntered = resolveEntered;
+    });
+    const release = new Promise<void>((resolveRelease) => {
+      releaseFirst = resolveRelease;
+    });
+
+    const first = withProjectStorage(
+      repository,
+      {
+        mode: "write",
+        scope: "shared-cache",
+        dependencies: processDependencies(101, livePids),
+      },
+      async (storage) => {
+        await storage.ensureSharedCache();
+        firstEntered();
+        await release;
+      },
+    );
+    await entered;
+
+    let secondEntered = false;
+    const second = withProjectStorage(
+      repository,
+      {
+        mode: "write",
+        scope: "shared-cache",
+        waitTimeoutMs: 1_000,
+        dependencies: processDependencies(202, livePids),
+      },
+      async (storage) => {
+        await storage.ensureSharedCache();
+        secondEntered = true;
+      },
+    );
+
+    await nextTurn();
+    expect(secondEntered).toBe(false);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(secondEntered).toBe(true);
+  });
+
+  it("[FR-STORE-004-AC3] 同一legacy pairは共有cacheへ一度だけcopyし、移行元fileを保持する", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await Promise.all([
+      writeLegacy(repository, {
+        "tasks.json": TASKS_V1,
+        "sync-state.json": SYNC_STATE_V1,
+        "comments.json": COMMENTS_V1,
+      }),
+      writeLegacy(linked, {
+        "tasks.json": TASKS_V1,
+        "sync-state.json": SYNC_STATE_V1,
+        "comments.json": COMMENTS_V1,
+      }),
+    ]);
+
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+    await publishSharedCache(linked, TASKS_V2, SYNC_STATE_V2);
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V2);
+    await expect(readFile(join(repository, ".gantt-sync", "tasks.json"), "utf8")).resolves.toBe(
+      TASKS_V1,
+    );
+    await expect(readFile(join(linked, ".gantt-sync", "tasks.json"), "utf8")).resolves.toBe(
+      TASKS_V1,
+    );
+  });
+
+  it("[FR-STORE-004-AC3] legacy tasksとsync-stateの片側だけがある場合はfail-closedにする", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, { "tasks.json": TASKS_V1 });
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "LEGACY_CACHE_INCOMPLETE",
+    });
+  });
+
+  it("[FR-STORE-004-AC3] 破損したlegacy JSONは空cacheへfallbackせずfail-closedにする", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, {
+      "tasks.json": "{ broken\n",
+      "sync-state.json": SYNC_STATE_V1,
+    });
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "LEGACY_CACHE_INVALID",
+    });
+  });
+
+  it("[FR-STORE-004-AC3] 破損したlegacy commentsは再構築可能な欠損としてpair migrationを継続する", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, {
+      "tasks.json": TASKS_V1,
+      "sync-state.json": SYNC_STATE_V1,
+      "comments.json": "{ broken\n",
+    });
+
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+    await expect(readSlot(repository, "comments")).resolves.toBe(
+      `${JSON.stringify({ version: "1", fetched_at: {}, comments: {} }, null, 2)}\n`,
+    );
+  });
+
+  it("[FR-STORE-004-AC3] migration後にlegacy fingerprintが変わった場合は共有cacheを上書きせず拒否する", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await Promise.all([
+      writeLegacy(repository, { "tasks.json": TASKS_V1, "sync-state.json": SYNC_STATE_V1 }),
+      writeLegacy(linked, { "tasks.json": TASKS_V1, "sync-state.json": SYNC_STATE_V1 }),
+    ]);
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+    await writeLegacy(linked, { "tasks.json": TASKS_V2, "sync-state.json": SYNC_STATE_V2 });
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "LEGACY_CACHE_DIVERGED",
+    });
+  });
+
+  it("[FR-STORE-004-AC3] 破損したmigration manifestは検証を迂回せずfail-closedにする", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    await publishSharedCache(repository);
+    const namespaceRoot = projectNamespace(commonDir, "fixture/repository#1");
+    await writeFile(join(namespaceRoot, "migration.json"), "{ broken\n");
+
+    await expect(readSlot(repository, "tasks")).rejects.toMatchObject({
+      code: "MIGRATION_MANIFEST_INVALID",
+    });
+  });
+
+  it("[FR-STORE-004-AC5] storage migrate --fromで明示した分岐候補だけを共有generationへpublishする", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, { "tasks.json": TASKS_V1, "sync-state.json": SYNC_STATE_V1 });
+    await writeLegacy(linked, { "tasks.json": TASKS_V2, "sync-state.json": SYNC_STATE_V2 });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      await createStorageCommand({ projectRoot: () => repository }).parseAsync(
+        ["migrate", "--from", linked, "--json"],
+        { from: "user" },
+      );
+      expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toEqual({
+        ok: true,
+        source: linked,
+      });
+      await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V2);
+      await expect(readSlot(repository, "sync-state")).resolves.toBe(SYNC_STATE_V2);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("[FR-STORE-004-AC2] 同じgit-common-dirでもGitHub Project identityが異なるworktreeはnamespaceを分離する", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await publishSharedCache(repository);
+    await writeFile(join(linked, ".gantt-sync", "gantt.config.json"), CONFIG_OTHER_PROJECT);
+    await publishSharedCache(linked, TASKS_V2, SYNC_STATE_V2);
+
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+    await expect(readSlot(linked, "tasks")).resolves.toBe(TASKS_V2);
+  });
+
+  it("[FR-STORE-004-AC2] 別Projectの不完全なlegacy pairは現在Projectのmigrationを停止しない", async () => {
+    const { repository, linked } = await makeRepositoryWithLinkedWorktree();
+    await writeLegacy(repository, { "tasks.json": TASKS_V1, "sync-state.json": SYNC_STATE_V1 });
+    await writeFile(join(linked, ".gantt-sync", "gantt.config.json"), CONFIG_OTHER_PROJECT);
+    await writeLegacy(linked, { "tasks.json": TASKS_V2 });
+
+    await expect(readSlot(repository, "tasks")).resolves.toBe(TASKS_V1);
+  });
+
+  it("[NFR-STABILITY-015-AC5] read modeと異なるwrite scopeからの型付き書き込みを拒否する", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+
+    await expect(
+      withProjectStorage(repository, { mode: "read" }, (storage) =>
+        storage.tasksStore.write(JSON.parse(TASKS_V1)),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_SCOPE_VIOLATION" });
+    await expect(
+      withProjectStorage(repository, { mode: "write", scope: "workspace" }, (storage) =>
+        storage.tasksStore.write(JSON.parse(TASKS_V1)),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_SCOPE_VIOLATION" });
+    await expect(
+      withProjectStorage(repository, { mode: "write", scope: "shared-cache" }, (storage) =>
+        storage.configStore.write(JSON.parse(CONFIG_V1)),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_SCOPE_VIOLATION" });
+  });
+
+  it("[NFR-STABILITY-015-AC3] live ownerのleaseはtimeout後も回収せずSTORAGE_BUSYを返す", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    const livePids = new Set([501, 502]);
+    let releaseFirst!: () => void;
+    let firstEntered!: () => void;
+    const entered = new Promise<void>((resolveEntered) => {
+      firstEntered = resolveEntered;
+    });
+    const release = new Promise<void>((resolveRelease) => {
+      releaseFirst = resolveRelease;
+    });
+    const first = withProjectStorage(
+      repository,
+      {
+        mode: "write",
+        scope: "shared-cache",
+        dependencies: processDependencies(501, livePids),
+      },
+      async (storage) => {
+        await storage.ensureSharedCache();
+        firstEntered();
+        await release;
+      },
+    );
+    await entered;
+
+    await expect(
+      withProjectStorage(
+        repository,
+        {
+          mode: "write",
+          scope: "shared-cache",
+          waitTimeoutMs: 20,
+          dependencies: processDependencies(502, livePids),
+        },
+        async (storage) => storage.ensureSharedCache(),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_BUSY" });
+
+    releaseFirst();
+    await first;
+  });
+
+  it("[NFR-STABILITY-015-AC3] pull guardの失敗でもprocessを即時終了せずleaseを解放する", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    const tasksWithConflicts = `${JSON.stringify(
+      { ...JSON.parse(TASKS_V1), has_conflicts: true },
+      null,
+      2,
+    )}\n`;
+    await writeLegacy(repository, {
+      "tasks.json": tasksWithConflicts,
+      "sync-state.json": SYNC_STATE_V1,
+    });
+    const previousExitCode = process.exitCode;
+    const cwd = vi.spyOn(process, "cwd").mockReturnValue(repository);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await pullCommand.parseAsync(["pull"], { from: "user" });
+      expect(process.exitCode).toBe(1);
+      await expect(
+        access(join(commonDir, "gh-gantt", "locks", "work-graph-cache.lock")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      process.exitCode = previousExitCode;
+      cwd.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("[NFR-STABILITY-015-AC3] 同一hostで死亡を確認できるownerのleaseだけを回収する", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    const leaseDir = join(commonDir, "gh-gantt", "locks", "work-graph-cache.lock");
+    await mkdir(leaseDir, { recursive: true });
+    await writeFile(
+      join(leaseDir, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        group: "work-graph-cache",
+        pid: 601,
+        hostname: "issue-299-test-host",
+        startedAt: "2026-07-30T00:00:00.000Z",
+        workspace: repository,
+        access: "write",
+        nonce: "dead-owner",
+      })}\n`,
+    );
+    const livePids = new Set([602]);
+
+    await expect(
+      withProjectStorage(
+        repository,
+        {
+          mode: "write",
+          scope: "shared-cache",
+          waitTimeoutMs: 100,
+          dependencies: processDependencies(602, livePids),
+        },
+        async (storage) => storage.ensureSharedCache(),
+      ),
+    ).resolves.toBeUndefined();
+    await expect(access(leaseDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("[FR-STORE-004-AC4] Git executableの起動失敗はnon-git扱いにせずGIT_DISCOVERY_FAILEDを返す", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    const emptyPath = await makeStandaloneRoot();
+    const originalPath = process.env.PATH;
+    process.env.PATH = emptyPath;
+    try {
+      await expect(
+        withProjectStorage(repository, { mode: "read" }, (storage) => storage.ensureSharedCache()),
+      ).rejects.toMatchObject({ code: "GIT_DISCOVERY_FAILED" });
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
+  });
+
+  it("[NFR-STABILITY-015-AC7] 別hostで生死を判定できないownerのleaseは回収しない", async () => {
+    const { repository, commonDir } = await makeRepositoryWithLinkedWorktree();
+    const leaseDir = join(commonDir, "gh-gantt", "locks", "work-graph-cache.lock");
+    await mkdir(leaseDir, { recursive: true });
+    await writeFile(
+      join(leaseDir, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        group: "work-graph-cache",
+        pid: 701,
+        hostname: "remote-host",
+        startedAt: "2026-07-30T00:00:00.000Z",
+        workspace: repository,
+        access: "write",
+        nonce: "unknown-owner",
+      })}\n`,
+    );
+    const liveness = vi.fn(async () => false);
+
+    await expect(
+      withProjectStorage(
+        repository,
+        {
+          mode: "read",
+          waitTimeoutMs: 20,
+          dependencies: createProjectStorageDependencies({
+            processIdentity: { pid: 702, hostname: "local-host" },
+            isProcessAlive: liveness,
+          }),
+        },
+        (storage) => storage.ensureSharedCache(),
+      ),
+    ).rejects.toMatchObject({ code: "STORAGE_BUSY" });
+    expect(liveness).not.toHaveBeenCalled();
+  });
+
+  it("[NFR-STABILITY-015-AC5] shared slotに触れないcallbackはGit discoveryもfilesystem初期化も行わない", async () => {
+    const root = await makeStandaloneRoot();
+    const runGitAdapter = vi.fn(async () => {
+      throw new Error("呼び出されてはならない");
+    });
+
+    await expect(
+      withProjectStorage(
+        root,
+        {
+          mode: "read",
+          dependencies: createProjectStorageDependencies({ runGit: runGitAdapter }),
+        },
+        async () => "untouched",
+      ),
+    ).resolves.toBe("untouched");
+    expect(runGitAdapter).not.toHaveBeenCalled();
+    await expect(access(join(root, ".gantt-sync"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("[NFR-STABILITY-015-AC2] 真の別OS processが保持するfile leaseの解放まで後続callbackを待機する", async () => {
+    const { repository } = await makeRepositoryWithLinkedWorktree();
+    const scratch = await makeStandaloneRoot();
+    const childScript = join(scratch, "lease-holder.ts");
+    const barrier = join(scratch, "lease-held");
+    const release = join(scratch, "lease-release");
+    const moduleUrl = new URL("../../store/project-storage.ts", import.meta.url).href;
+    await writeFile(
+      childScript,
+      `
+import { access, writeFile } from "node:fs/promises";
+
+const [moduleUrl, root, barrier, release] = process.argv.slice(2);
+async function main() {
+  const { withProjectStorage } = await import(moduleUrl);
+  await withProjectStorage(root, { mode: "write", scope: "shared-cache" }, async (storage) => {
+    await storage.ensureSharedCache();
+    await writeFile(barrier, "held\\n");
+    while (true) {
+      try {
+        await access(release);
+        break;
+      } catch {
+        await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+      }
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`,
+    );
+
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", childScript, moduleUrl, repository, barrier, release],
+      { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let childStderr = "";
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      childStderr += chunk;
+    });
+    await waitForFile(barrier, child, () => childStderr);
+
+    let secondEntered = false;
+    const second = withProjectStorage(
+      repository,
+      { mode: "write", scope: "shared-cache", waitTimeoutMs: 2_000 },
+      async (storage) => {
+        await storage.ensureSharedCache();
+        secondEntered = true;
+      },
+    );
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, 100));
+    expect(secondEntered).toBe(false);
+
+    await writeFile(release, "release\n");
+    const [exitCode] = (await once(child, "exit")) as [number | null];
+    expect(exitCode, childStderr).toBe(0);
+    await second;
+    expect(secondEntered).toBe(true);
+  });
+});

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -981,6 +981,76 @@ describe("createApiRouter", () => {
     });
   });
 
+  describe("task mutation API はリクエスト全体を保存前に検証する", () => {
+    beforeEach(async () => {
+      await new ConfigStore(dir).write(buildParentTestConfig());
+      await new TasksStore(dir).write({
+        tasks: [makeServerTask("o/r#5", { github_issue: 5 })],
+        cache: { comments: {}, reactions: {} },
+      });
+    });
+
+    it("POSTはbody・日付・未知fieldの不正値を400で拒否しdraftを作成しない", async () => {
+      const handler = findRouteHandler(createApiRouter(dir), "/api/tasks", "post");
+      for (const body of [
+        { title: "不正body", type: "task", body: 42 },
+        { title: "不正日付", type: "task", start_date: { value: "2026-07-30" } },
+        { title: "未知field", type: "task", unexpected: true },
+      ]) {
+        const { res, captured } = makeCapturingRes();
+        await handler({ body }, res);
+        expect(captured.statusCode).toBe(400);
+      }
+      expect((await new TasksStore(dir).read()).tasks).toHaveLength(1);
+    });
+
+    it("PATCHはstate・assignees・custom_fields・日付の不正値を400で拒否しtaskを変更しない", async () => {
+      const handler = findRouteHandler(createApiRouter(dir), "/api/tasks/:id", "patch");
+      for (const body of [
+        { state: "archived" },
+        { assignees: ["alice", 42] },
+        { custom_fields: [] },
+        { start_date: 20260730 },
+      ]) {
+        const { res, captured } = makeCapturingRes();
+        await handler({ params: { id: encodeURIComponent("o/r#5") }, body }, res);
+        expect(captured.statusCode).toBe(400);
+      }
+      await expect(new TasksStore(dir).read()).resolves.toMatchObject({
+        tasks: [{ id: "o/r#5", state: "open", assignees: [], custom_fields: {}, start_date: null }],
+      });
+    });
+
+    it("親を変えないtype-only更新でも実効親のtype_hierarchyに反する変更を拒否する", async () => {
+      const config = buildParentTestConfig();
+      config.task_types.feature = {
+        label: "Feature",
+        display: "bar",
+        color: "#222222",
+        github_label: null,
+      };
+      config.type_hierarchy = { epic: ["feature"], feature: ["task"], task: [] };
+      await new ConfigStore(dir).write(config);
+      await new TasksStore(dir).write({
+        tasks: [
+          makeServerTask("o/r#1", { type: "epic", github_issue: 1, sub_tasks: ["o/r#5"] }),
+          makeServerTask("o/r#5", { type: "feature", github_issue: 5, parent: "o/r#1" }),
+        ],
+        cache: { comments: {}, reactions: {} },
+      });
+      const handler = findRouteHandler(createApiRouter(dir), "/api/tasks/:id", "patch");
+      const { res, captured } = makeCapturingRes();
+
+      await handler({ params: { id: encodeURIComponent("o/r#5") }, body: { type: "task" } }, res);
+
+      expect(captured.statusCode).toBe(400);
+      expect(captured.jsonPayload.error).toBe('Cannot place "task" under "epic"');
+      expect(
+        (await new TasksStore(dir).read()).tasks.find((task) => task.id === "o/r#5")?.type,
+      ).toBe("feature");
+    });
+  });
+
   describe("[FR-API-003-AC3] POST /api/tasks/:id/reparent は newParentId を正規形へ解決する", () => {
     beforeEach(async () => {
       await new ConfigStore(dir).write(buildParentTestConfig());

--- a/packages/cli/src/commands/ac.ts
+++ b/packages/cli/src/commands/ac.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import { normalizeAcceptanceCriteria } from "@gh-gantt/shared";
 import type { AcceptanceCriterion, Config, Task } from "@gh-gantt/shared";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
+import { withProjectStorage } from "../store/project-storage.js";
+import type { TasksStore } from "../store/tasks.js";
 import { resolveTaskId } from "../util/task-id.js";
 
 export interface AcceptanceCriteriaAddOptions {
@@ -90,33 +90,39 @@ export function createAcceptanceCriteriaCommand(): Command {
     .action(async (id: string, description: string, opts) => {
       try {
         const projectRoot = process.cwd();
-        const configStore = new ConfigStore(projectRoot);
-        const tasksStore = new TasksStore(projectRoot);
-        const config = await configStore.read();
-        const { tasksFile, resolvedId, taskIndex } = await readTask(id, config, tasksStore);
+        await withProjectStorage(
+          projectRoot,
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const { tasksFile, resolvedId, taskIndex } = await readTask(id, config, tasksStore);
 
-        if (taskIndex === -1) {
-          console.error(`Task not found: ${resolvedId}`);
-          process.exitCode = 1;
-          return;
-        }
+            if (taskIndex === -1) {
+              console.error(`Task not found: ${resolvedId}`);
+              process.exitCode = 1;
+              return;
+            }
 
-        const result = addAcceptanceCriterion(tasksFile.tasks[taskIndex], { description });
-        if (result.error) {
-          console.error(result.error);
-          process.exitCode = 1;
-          return;
-        }
+            const result = addAcceptanceCriterion(tasksFile.tasks[taskIndex], { description });
+            if (result.error) {
+              console.error(result.error);
+              process.exitCode = 1;
+              return;
+            }
 
-        tasksFile.tasks[taskIndex] = result.task;
-        await tasksStore.write(tasksFile);
+            tasksFile.tasks[taskIndex] = result.task;
+            await tasksStore.write(tasksFile);
+            await storage.flush();
 
-        if (opts.json) {
-          console.log(JSON.stringify(result.task, null, 2));
-        } else {
-          const count = normalizeAcceptanceCriteria(result.task.acceptance_criteria).length;
-          console.log(`Added acceptance criterion #${count} to ${resolvedId}.`);
-        }
+            if (opts.json) {
+              console.log(JSON.stringify(result.task, null, 2));
+            } else {
+              const count = normalizeAcceptanceCriteria(result.task.acceptance_criteria).length;
+              console.log(`Added acceptance criterion #${count} to ${resolvedId}.`);
+            }
+          },
+        );
       } catch (err) {
         console.error(
           "Failed to add acceptance criterion:",
@@ -134,32 +140,40 @@ export function createAcceptanceCriteriaCommand(): Command {
     .action(async (id: string, opts) => {
       try {
         const projectRoot = process.cwd();
-        const configStore = new ConfigStore(projectRoot);
-        const tasksStore = new TasksStore(projectRoot);
-        const config = await configStore.read();
-        const { tasksFile, resolvedId, taskIndex } = await readTask(id, config, tasksStore);
+        await withProjectStorage(
+          projectRoot,
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const { tasksFile, resolvedId, taskIndex } = await readTask(id, config, tasksStore);
 
-        if (taskIndex === -1) {
-          console.error(`Task not found: ${resolvedId}`);
-          process.exitCode = 1;
-          return;
-        }
+            if (taskIndex === -1) {
+              console.error(`Task not found: ${resolvedId}`);
+              process.exitCode = 1;
+              return;
+            }
 
-        const result = checkAcceptanceCriterion(tasksFile.tasks[taskIndex], { index: opts.index });
-        if (result.error) {
-          console.error(result.error);
-          process.exitCode = 1;
-          return;
-        }
+            const result = checkAcceptanceCriterion(tasksFile.tasks[taskIndex], {
+              index: opts.index,
+            });
+            if (result.error) {
+              console.error(result.error);
+              process.exitCode = 1;
+              return;
+            }
 
-        tasksFile.tasks[taskIndex] = result.task;
-        await tasksStore.write(tasksFile);
+            tasksFile.tasks[taskIndex] = result.task;
+            await tasksStore.write(tasksFile);
+            await storage.flush();
 
-        if (opts.json) {
-          console.log(JSON.stringify(result.task, null, 2));
-        } else {
-          console.log(`Checked acceptance criterion #${opts.index} on ${resolvedId}.`);
-        }
+            if (opts.json) {
+              console.log(JSON.stringify(result.task, null, 2));
+            } else {
+              console.log(`Checked acceptance criterion #${opts.index} on ${resolvedId}.`);
+            }
+          },
+        );
       } catch (err) {
         console.error(
           "Failed to check acceptance criterion:",

--- a/packages/cli/src/commands/conflicts.ts
+++ b/packages/cli/src/commands/conflicts.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { detectMarkers } from "../sync/conflict-marker.js";
 import { formatValue } from "../util/format.js";
 import type { SyncState } from "@gh-gantt/shared";
@@ -130,19 +129,22 @@ export const conflictsCommand = new Command("conflicts")
   .option("--json", "Output as JSON")
   .action(async (issue?: number, opts?: { json?: boolean }) => {
     const projectRoot = process.cwd();
-    const tasksStore = new TasksStore(projectRoot);
-    const stateStore = new SyncStateStore(projectRoot);
+    return withProjectStorage(
+      projectRoot,
+      { mode: "read", scope: "shared-cache" },
+      async ({ tasksStore, stateStore }) => {
+        const tasksFile = await tasksStore.read();
+        const syncState = await stateStore.read();
 
-    const tasksFile = await tasksStore.read();
-    const syncState = await stateStore.read();
+        const tasks = tasksFile.tasks as unknown as Record<string, unknown>[];
 
-    const tasks = tasksFile.tasks as unknown as Record<string, unknown>[];
-
-    if (opts?.json) {
-      const json = buildConflictJson(tasks, syncState.snapshots, issue);
-      console.log(JSON.stringify(json, null, 2));
-    } else {
-      const output = formatConflictList(tasks, syncState.snapshots, issue);
-      console.log(output);
-    }
+        if (opts?.json) {
+          const json = buildConflictJson(tasks, syncState.snapshots, issue);
+          console.log(JSON.stringify(json, null, 2));
+        } else {
+          const output = formatConflictList(tasks, syncState.snapshots, issue);
+          console.log(output);
+        }
+      },
+    );
   });

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -2,9 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { Command } from "commander";
 import { z } from "zod";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import type { Config, SyncState, Task } from "@gh-gantt/shared";
 import { isInProgressTask, readStatus } from "../utils/status.js";
 
@@ -205,47 +203,52 @@ export function createContextCommand(deps: ContextCommandDeps = {}): Command {
     )
     .action(async (opts) => {
       const projectRoot = process.cwd();
-      const configStore = new ConfigStore(projectRoot);
-      const tasksStore = new TasksStore(projectRoot);
-      const stateStore = new SyncStateStore(projectRoot);
+      return withProjectStorage(
+        projectRoot,
+        { mode: "read", scope: "shared-cache" },
+        async ({ configStore, tasksStore, stateStore }) => {
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const syncState = await stateStore.read();
+          const warnings: string[] = [];
+          const recentDays = parseRecentDays(opts.recentDays);
+          const prLimit = parsePrLimit(opts.prLimit);
 
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const syncState = await stateStore.read();
-      const warnings: string[] = [];
-      const recentDays = parseRecentDays(opts.recentDays);
-      const prLimit = parsePrLimit(opts.prLimit);
+          let openPullRequests: OpenPullRequestSummary[] = [];
+          if (opts.offline) {
+            warnings.push("open PR の取得を --offline でスキップしました");
+          } else {
+            try {
+              openPullRequests = await (deps.fetchOpenPullRequests ?? fetchOpenPullRequests)(
+                config,
+                {
+                  limit: prLimit,
+                },
+              );
+            } catch (err) {
+              warnings.push(
+                `open PR の取得に失敗しました: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }
 
-      let openPullRequests: OpenPullRequestSummary[] = [];
-      if (opts.offline) {
-        warnings.push("open PR の取得を --offline でスキップしました");
-      } else {
-        try {
-          openPullRequests = await (deps.fetchOpenPullRequests ?? fetchOpenPullRequests)(config, {
-            limit: prLimit,
+          const summary = buildContextSummary({
+            config,
+            tasks: tasksFile.tasks,
+            syncState,
+            openPullRequests,
+            now: deps.now?.() ?? new Date(),
+            recentDays,
+            warnings,
           });
-        } catch (err) {
-          warnings.push(
-            `open PR の取得に失敗しました: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }
 
-      const summary = buildContextSummary({
-        config,
-        tasks: tasksFile.tasks,
-        syncState,
-        openPullRequests,
-        now: deps.now?.() ?? new Date(),
-        recentDays,
-        warnings,
-      });
-
-      if (opts.json) {
-        console.log(JSON.stringify(summary, null, 2));
-      } else {
-        console.log(formatContextSummary(summary));
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(summary, null, 2));
+          } else {
+            console.log(formatContextSummary(summary));
+          }
+        },
+      );
     });
 }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -2,8 +2,7 @@ import { Command } from "commander";
 import { readFile, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
 import { resolveTaskId } from "../util/task-id.js";
 import {
@@ -136,191 +135,196 @@ export function createCreateCommand(): Command {
     .option("--json", "Output as JSON")
     .action(async (opts) => {
       const projectRoot = process.cwd();
-      const configStore = new ConfigStore(projectRoot);
-      const tasksStore = new TasksStore(projectRoot);
+      return withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore } = storage;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
 
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
+          const typeKeys = Object.keys(config.task_types);
+          const { owner, repo } = config.project.github;
+          const repoFullName = `${owner}/${repo}`;
 
-      const typeKeys = Object.keys(config.task_types);
-      const { owner, repo } = config.project.github;
-      const repoFullName = `${owner}/${repo}`;
+          let title = opts.title;
+          let type = opts.type;
+          let body = opts.body ?? null;
+          let startDate = opts.startDate ?? null;
+          let endDate = opts.endDate ?? null;
+          let parent = opts.parent ?? null;
+          const estimateHours =
+            opts.estimateHours === undefined ? null : parseEstimateHours(opts.estimateHours);
 
-      let title = opts.title;
-      let type = opts.type;
-      let body = opts.body ?? null;
-      let startDate = opts.startDate ?? null;
-      let endDate = opts.endDate ?? null;
-      let parent = opts.parent ?? null;
-      const estimateHours =
-        opts.estimateHours === undefined ? null : parseEstimateHours(opts.estimateHours);
+          if (opts.estimateHours !== undefined && estimateHours === null) {
+            console.error(
+              `Invalid estimate hours: "${opts.estimateHours}". Use a non-negative number.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
 
-      if (opts.estimateHours !== undefined && estimateHours === null) {
-        console.error(
-          `Invalid estimate hours: "${opts.estimateHours}". Use a non-negative number.`,
-        );
-        process.exitCode = 1;
-        return;
-      }
+          // Interactive prompt for missing required fields
+          if (!title || !type) {
+            const rl = createInterface({ input: process.stdin, output: process.stdout });
+            try {
+              if (!title) {
+                title = await prompt(rl, "Title");
+                if (!title) {
+                  console.error("Title is required.");
+                  process.exitCode = 1;
+                  return;
+                }
+              }
 
-      // Interactive prompt for missing required fields
-      if (!title || !type) {
-        const rl = createInterface({ input: process.stdin, output: process.stdout });
-        try {
-          if (!title) {
-            title = await prompt(rl, "Title");
-            if (!title) {
-              console.error("Title is required.");
+              if (!type) {
+                console.log(`Available types: ${typeKeys.join(", ")}`);
+                type = await prompt(rl, "Type", "task");
+              }
+
+              if (body === null && !opts.body && !opts.template) {
+                body = (await prompt(rl, "Body (optional)")) || null;
+              }
+
+              if (startDate === null && !opts.startDate) {
+                startDate = (await prompt(rl, "Start date (YYYY-MM-DD, optional)")) || null;
+              }
+
+              if (endDate === null && !opts.endDate) {
+                endDate = (await prompt(rl, "End date (YYYY-MM-DD, optional)")) || null;
+              }
+
+              if (parent === null && !opts.parent) {
+                parent = (await prompt(rl, "Parent task ID (optional)")) || null;
+              }
+            } finally {
+              rl.close();
+            }
+          }
+
+          // Validate type
+          if (!config.task_types[type]) {
+            console.error(`Unknown task type: "${type}". Available: ${typeKeys.join(", ")}`);
+            process.exitCode = 1;
+            return;
+          }
+
+          // parent 参照の正規化と存在検証 (#302)
+          // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
+          // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
+          // link --set-parent と同じく resolveTaskId で正規形へ解決してから保存する
+          if (parent) {
+            parent = resolveTaskId(parent, config);
+            if (!tasksFile.tasks.some((t) => t.id === parent)) {
+              console.error(`Parent task not found: ${parent}`);
               process.exitCode = 1;
               return;
             }
           }
 
-          if (!type) {
-            console.log(`Available types: ${typeKeys.join(", ")}`);
-            type = await prompt(rl, "Type", "task");
+          if (opts.template) {
+            const resolution = await resolveExistingTaskTemplatePath(
+              projectRoot,
+              config.task_templates,
+              opts.template,
+            );
+            if (!resolution.ok) {
+              console.error(resolution.message);
+              process.exitCode = 1;
+              return;
+            }
+
+            let template: string;
+            try {
+              template = await readFile(resolution.templatePath, "utf-8");
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.error(`Failed to read template "${opts.template}": ${message}`);
+              process.exitCode = 1;
+              return;
+            }
+
+            body = renderTaskTemplate(template, { title, type, body });
           }
 
-          if (body === null && !opts.body && !opts.template) {
-            body = (await prompt(rl, "Body (optional)")) || null;
+          // Build draft task
+          const draftNumber = getNextDraftNumber(tasksFile.tasks);
+          const taskId = buildDraftTaskId(repoFullName, draftNumber);
+
+          const labels: string[] = [];
+          const taskType = config.task_types[type];
+          if (taskType.github_label) {
+            labels.push(taskType.github_label);
           }
 
-          if (startDate === null && !opts.startDate) {
-            startDate = (await prompt(rl, "Start date (YYYY-MM-DD, optional)")) || null;
+          const now = new Date().toISOString();
+          const task: Task = {
+            id: taskId,
+            type,
+            github_issue: null,
+            github_repo: repoFullName,
+            parent,
+            sub_tasks: [],
+            title,
+            body,
+            state: "open",
+            state_reason: null,
+            assignees: [],
+            labels,
+            milestone: null,
+            linked_prs: [],
+            created_at: now,
+            updated_at: now,
+            closed_at: null,
+            acceptance_criteria: [],
+            acceptance_criteria_slot: body?.includes(ACCEPTANCE_CRITERIA_START_MARKER) === true,
+            implementer: null,
+            reviewer: null,
+            require_review: opts.requireReview === true,
+            review_approved_by: null,
+            review_approved_at: null,
+            custom_fields:
+              estimateHours === null ? {} : { [getEstimateHoursField(config)]: estimateHours },
+            start_date: startDate,
+            end_date: endDate,
+            date: null,
+            blocked_by: [],
+          };
+
+          const taskSizeExcess = getTaskSizeExcess(task, config);
+          if (taskSizeExcess) {
+            console.warn(
+              `警告: タスク見積もり ${taskSizeExcess.estimate_hours}h は閾値 ${taskSizeExcess.max_task_size_hours}h を超えています。gh-gantt-decompose で分解してください。`,
+            );
           }
 
-          if (endDate === null && !opts.endDate) {
-            endDate = (await prompt(rl, "End date (YYYY-MM-DD, optional)")) || null;
+          // Update parent's sub_tasks if parent specified
+          // (parent の存在は正規化時に検証済み)
+          if (parent) {
+            const parentTask = tasksFile.tasks.find((t) => t.id === parent);
+            if (parentTask && !parentTask.sub_tasks.includes(taskId)) {
+              parentTask.sub_tasks.push(taskId);
+            }
           }
 
-          if (parent === null && !opts.parent) {
-            parent = (await prompt(rl, "Parent task ID (optional)")) || null;
+          tasksFile.tasks.push(task);
+          await tasksStore.write(tasksFile);
+          await storage.flush();
+
+          if (opts.json) {
+            console.log(JSON.stringify({ task }, null, 2));
+          } else {
+            console.log(`Created draft task: ${taskId}`);
+            console.log(`  Title: ${title}`);
+            console.log(`  Type: ${type}`);
+            if (startDate) console.log(`  Start: ${startDate}`);
+            if (endDate) console.log(`  End: ${endDate}`);
+            if (parent) console.log(`  Parent: ${parent}`);
+            console.log();
+            console.log('Run "gh-gantt push" to create the GitHub issue.');
           }
-        } finally {
-          rl.close();
-        }
-      }
-
-      // Validate type
-      if (!config.task_types[type]) {
-        console.error(`Unknown task type: "${type}". Available: ${typeKeys.join(", ")}`);
-        process.exitCode = 1;
-        return;
-      }
-
-      // parent 参照の正規化と存在検証 (#302)
-      // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
-      // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
-      // link --set-parent と同じく resolveTaskId で正規形へ解決してから保存する
-      if (parent) {
-        parent = resolveTaskId(parent, config);
-        if (!tasksFile.tasks.some((t) => t.id === parent)) {
-          console.error(`Parent task not found: ${parent}`);
-          process.exitCode = 1;
-          return;
-        }
-      }
-
-      if (opts.template) {
-        const resolution = await resolveExistingTaskTemplatePath(
-          projectRoot,
-          config.task_templates,
-          opts.template,
-        );
-        if (!resolution.ok) {
-          console.error(resolution.message);
-          process.exitCode = 1;
-          return;
-        }
-
-        let template: string;
-        try {
-          template = await readFile(resolution.templatePath, "utf-8");
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error(`Failed to read template "${opts.template}": ${message}`);
-          process.exitCode = 1;
-          return;
-        }
-
-        body = renderTaskTemplate(template, { title, type, body });
-      }
-
-      // Build draft task
-      const draftNumber = getNextDraftNumber(tasksFile.tasks);
-      const taskId = buildDraftTaskId(repoFullName, draftNumber);
-
-      const labels: string[] = [];
-      const taskType = config.task_types[type];
-      if (taskType.github_label) {
-        labels.push(taskType.github_label);
-      }
-
-      const now = new Date().toISOString();
-      const task: Task = {
-        id: taskId,
-        type,
-        github_issue: null,
-        github_repo: repoFullName,
-        parent,
-        sub_tasks: [],
-        title,
-        body,
-        state: "open",
-        state_reason: null,
-        assignees: [],
-        labels,
-        milestone: null,
-        linked_prs: [],
-        created_at: now,
-        updated_at: now,
-        closed_at: null,
-        acceptance_criteria: [],
-        acceptance_criteria_slot: body?.includes(ACCEPTANCE_CRITERIA_START_MARKER) === true,
-        implementer: null,
-        reviewer: null,
-        require_review: opts.requireReview === true,
-        review_approved_by: null,
-        review_approved_at: null,
-        custom_fields:
-          estimateHours === null ? {} : { [getEstimateHoursField(config)]: estimateHours },
-        start_date: startDate,
-        end_date: endDate,
-        date: null,
-        blocked_by: [],
-      };
-
-      const taskSizeExcess = getTaskSizeExcess(task, config);
-      if (taskSizeExcess) {
-        console.warn(
-          `警告: タスク見積もり ${taskSizeExcess.estimate_hours}h は閾値 ${taskSizeExcess.max_task_size_hours}h を超えています。gh-gantt-decompose で分解してください。`,
-        );
-      }
-
-      // Update parent's sub_tasks if parent specified
-      // (parent の存在は正規化時に検証済み)
-      if (parent) {
-        const parentTask = tasksFile.tasks.find((t) => t.id === parent);
-        if (parentTask && !parentTask.sub_tasks.includes(taskId)) {
-          parentTask.sub_tasks.push(taskId);
-        }
-      }
-
-      tasksFile.tasks.push(task);
-      await tasksStore.write(tasksFile);
-
-      if (opts.json) {
-        console.log(JSON.stringify({ task }, null, 2));
-      } else {
-        console.log(`Created draft task: ${taskId}`);
-        console.log(`  Title: ${title}`);
-        console.log(`  Type: ${type}`);
-        if (startDate) console.log(`  Start: ${startDate}`);
-        if (endDate) console.log(`  End: ${endDate}`);
-        if (parent) console.log(`  Parent: ${parent}`);
-        console.log();
-        console.log('Run "gh-gantt push" to create the GitHub issue.');
-      }
+        },
+      );
     });
 }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { readFile, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
+import { z } from "zod";
 import { withProjectStorage } from "../store/project-storage.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
 import { resolveTaskId } from "../util/task-id.js";
@@ -13,6 +14,8 @@ import {
   parseEstimateHours,
 } from "@gh-gantt/shared";
 import type { Task, TaskTemplates } from "@gh-gantt/shared";
+
+const TaskTemplateContentSchema = z.string();
 
 async function prompt(
   rl: ReturnType<typeof createInterface>,
@@ -164,7 +167,7 @@ export function createCreateCommand(): Command {
             return;
           }
 
-          // Interactive prompt for missing required fields
+          // 必須fieldが不足している場合は対話入力で補う
           if (!title || !type) {
             const rl = createInterface({ input: process.stdin, output: process.stdout });
             try {
@@ -202,7 +205,7 @@ export function createCreateCommand(): Command {
             }
           }
 
-          // Validate type
+          // task typeが設定に存在することを検証する
           if (!config.task_types[type]) {
             console.error(`Unknown task type: "${type}". Available: ${typeKeys.join(", ")}`);
             process.exitCode = 1;
@@ -236,7 +239,9 @@ export function createCreateCommand(): Command {
 
             let template: string;
             try {
-              template = await readFile(resolution.templatePath, "utf-8");
+              template = TaskTemplateContentSchema.parse(
+                await readFile(resolution.templatePath, "utf-8"),
+              );
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               console.error(`Failed to read template "${opts.template}": ${message}`);
@@ -247,7 +252,7 @@ export function createCreateCommand(): Command {
             body = renderTaskTemplate(template, { title, type, body });
           }
 
-          // Build draft task
+          // draft taskを組み立てる
           const draftNumber = getNextDraftNumber(tasksFile.tasks);
           const taskId = buildDraftTaskId(repoFullName, draftNumber);
 
@@ -298,8 +303,8 @@ export function createCreateCommand(): Command {
             );
           }
 
-          // Update parent's sub_tasks if parent specified
-          // (parent の存在は正規化時に検証済み)
+          // parent指定時は親のsub_tasksも更新する
+          // （parentの存在は正規化時に検証済み）
           if (parent) {
             const parentTask = tasksFile.tasks.find((t) => t.id === parent);
             if (parentTask && !parentTask.sub_tasks.includes(taskId)) {

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import type { SyncState, Task, TasksFile } from "@gh-gantt/shared";
 import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { resolveTaskId } from "../util/task-id.js";
 import { createGraphQLClient } from "../github/client.js";
 import { executePull } from "../sync/pull-executor.js";
@@ -266,64 +265,69 @@ export function createDeleteCommand(): Command {
     .action(async (id: string, opts: { yes?: boolean; json?: boolean }) => {
       const projectRoot = process.cwd();
       const configStore = new ConfigStore(projectRoot);
-      const tasksStore = new TasksStore(projectRoot);
-      const stateStore = new SyncStateStore(projectRoot);
-
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const syncState = await stateStore.read();
-      const taskId = resolveTaskId(id, config);
-      const result = await executeTaskDeletion({
-        tasksFile,
-        syncState,
-        taskId,
-        yes: opts.yes === true,
-        deleteGithubIssue: deleteGithubIssueWithGraphQL,
-        forcePull: async ({ tasksFile: cleanedTasksFile, syncState: cleanedSyncState }) => {
-          const gql = await createGraphQLClient();
-          const pulled = await executePull(gql, config, cleanedTasksFile, cleanedSyncState, {
-            force: true,
-            fullFetch: true,
-          });
-          return { tasksFile: pulled.tasksFile, syncState: pulled.syncState };
-        },
-      });
-
-      if (!result.ok) {
-        if (opts.json) {
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          console.error(result.error);
-        }
-        process.exitCode = 1;
-        return;
-      }
-
-      await tasksStore.write(result.tasksFile);
-      await stateStore.write(result.syncState);
-
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            {
-              ok: true,
-              task_id: result.taskId,
-              issue_number: result.issueNumber,
-              repair: result.repair,
+      return withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { tasksStore, stateStore } = storage;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const syncState = await stateStore.read();
+          const taskId = resolveTaskId(id, config);
+          const result = await executeTaskDeletion({
+            tasksFile,
+            syncState,
+            taskId,
+            yes: opts.yes === true,
+            deleteGithubIssue: deleteGithubIssueWithGraphQL,
+            forcePull: async ({ tasksFile: cleanedTasksFile, syncState: cleanedSyncState }) => {
+              const gql = await createGraphQLClient();
+              const pulled = await executePull(gql, config, cleanedTasksFile, cleanedSyncState, {
+                force: true,
+                fullFetch: true,
+              });
+              return { tasksFile: pulled.tasksFile, syncState: pulled.syncState };
             },
-            null,
-            2,
-          ),
-        );
-        return;
-      }
+          });
 
-      console.log(`Deleted GitHub Issue: #${result.issueNumber}`);
-      console.log(`Removed task from mirror: ${result.taskId}`);
-      console.log(
-        `Repaired references: parent=${result.repair.parentCleared.length}, sub_tasks=${result.repair.subTaskRemoved.length}, blocked_by=${result.repair.blockedByRemoved.length}`,
+          if (!result.ok) {
+            if (opts.json) {
+              console.log(JSON.stringify(result, null, 2));
+            } else {
+              console.error(result.error);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          await tasksStore.write(result.tasksFile);
+          await stateStore.write(result.syncState);
+          await storage.flush();
+
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  ok: true,
+                  task_id: result.taskId,
+                  issue_number: result.issueNumber,
+                  repair: result.repair,
+                },
+                null,
+                2,
+              ),
+            );
+            return;
+          }
+
+          console.log(`Deleted GitHub Issue: #${result.issueNumber}`);
+          console.log(`Removed task from mirror: ${result.taskId}`);
+          console.log(
+            `Repaired references: parent=${result.repair.parentCleared.length}, sub_tasks=${result.repair.subTaskRemoved.length}, blocked_by=${result.repair.blockedByRemoved.length}`,
+          );
+          console.log("Force pull verification complete.");
+        },
       );
-      console.log("Force pull verification complete.");
     });
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -4,8 +4,7 @@ import { promisify } from "node:util";
 import type { Config, Task, SyncState, TasksFile } from "@gh-gantt/shared";
 import { detectCycles, getTaskSizeExcess } from "@gh-gantt/shared";
 import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage, type ProjectStorageSession } from "../store/project-storage.js";
 import { hashTask } from "../sync/hash.js";
 import { validateSyncState, type SyncStateFinding } from "../sync/validate-sync-state.js";
 import { isInProgressTask } from "../utils/status.js";
@@ -70,10 +69,10 @@ async function checkConfig(
 
 /** tasks.json の schema 妥当性をチェック */
 async function checkTasksFile(
-  projectRoot: string,
+  tasksStore: ProjectStorageSession["tasksStore"],
 ): Promise<{ result: CheckResult; data: TasksFile | null }> {
   try {
-    const data = await new TasksStore(projectRoot).read();
+    const data = await tasksStore.read();
     return {
       result: { name: "tasks-file", status: "PASS", message: "tasks.json は有効です" },
       data,
@@ -103,10 +102,10 @@ async function checkTasksFile(
 
 /** sync-state.json の schema 妥当性をチェック */
 async function checkSyncStateFile(
-  projectRoot: string,
+  stateStore: ProjectStorageSession["stateStore"],
 ): Promise<{ result: CheckResult; data: SyncState | null }> {
   try {
-    const data = await new SyncStateStore(projectRoot).read();
+    const data = await stateStore.read();
     return {
       result: { name: "sync-state-file", status: "PASS", message: "sync-state.json は有効です" },
       data,
@@ -525,7 +524,11 @@ interface DoctorOptions {
   offline: boolean;
 }
 
-async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<DoctorResult> {
+async function runDoctor(
+  projectRoot: string,
+  storage: Pick<ProjectStorageSession, "tasksStore" | "stateStore">,
+  opts: DoctorOptions,
+): Promise<DoctorResult> {
   const checks: CheckResult[] = [];
 
   // 1. config チェック
@@ -533,11 +536,11 @@ async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<Doct
   checks.push(configResult);
 
   // 2. tasks.json チェック
-  const { result: tasksResult, data: tasksFile } = await checkTasksFile(projectRoot);
+  const { result: tasksResult, data: tasksFile } = await checkTasksFile(storage.tasksStore);
   checks.push(tasksResult);
 
   // 3. sync-state.json チェック
-  const { result: stateResult, data: syncState } = await checkSyncStateFile(projectRoot);
+  const { result: stateResult, data: syncState } = await checkSyncStateFile(storage.stateStore);
   checks.push(stateResult);
 
   // tasks と syncState が両方読めた場合のみ整合性チェックを実行
@@ -552,7 +555,7 @@ async function runDoctor(projectRoot: string, opts: DoctorOptions): Promise<Doct
 
     // --fix で修復した場合、書き戻し
     if (fixedSyncState && opts.fix) {
-      await new SyncStateStore(projectRoot).write(fixedSyncState);
+      await storage.stateStore.write(fixedSyncState);
     }
 
     // 5. hash 整合性 (修復後の syncState があればそちらを使用)
@@ -595,40 +598,47 @@ export const doctorCommand = new Command("doctor")
   .option("--json", "JSON 形式で出力")
   .action(async (opts) => {
     const projectRoot = process.cwd();
-    const result = await runDoctor(projectRoot, {
-      fix: !!opts.fix,
-      offline: !!opts.offline,
-    });
+    return withProjectStorage(
+      projectRoot,
+      { mode: opts.fix ? "write" : "read", scope: "shared-cache" },
+      async (storage) => {
+        const result = await runDoctor(projectRoot, storage, {
+          fix: !!opts.fix,
+          offline: !!opts.offline,
+        });
+        await storage.flush();
 
-    if (opts.json) {
-      console.log(JSON.stringify(result, null, 2));
-      process.exitCode = result.summary.fail > 0 ? 1 : 0;
-      return;
-    }
-
-    // テキスト出力
-    const statusIcon = (s: CheckStatus) => (s === "PASS" ? "✓" : s === "WARN" ? "⚠" : "✗");
-    const statusLabel = (s: CheckStatus) =>
-      s === "PASS" ? "[PASS]" : s === "WARN" ? "[WARN]" : "[FAIL]";
-
-    for (const check of result.checks) {
-      const fixedTag = check.fixed ? " (修復済み)" : "";
-      console.log(
-        `${statusIcon(check.status)} ${statusLabel(check.status)} ${check.message}${fixedTag}`,
-      );
-      if (check.details) {
-        for (const detail of check.details) {
-          console.log(`    ${detail}`);
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          process.exitCode = result.summary.fail > 0 ? 1 : 0;
+          return;
         }
-      }
-    }
 
-    console.log();
-    console.log(
-      `結果: ${result.summary.pass} passed, ${result.summary.warn} warnings, ${result.summary.fail} failures`,
+        // テキスト出力
+        const statusIcon = (s: CheckStatus) => (s === "PASS" ? "✓" : s === "WARN" ? "⚠" : "✗");
+        const statusLabel = (s: CheckStatus) =>
+          s === "PASS" ? "[PASS]" : s === "WARN" ? "[WARN]" : "[FAIL]";
+
+        for (const check of result.checks) {
+          const fixedTag = check.fixed ? " (修復済み)" : "";
+          console.log(
+            `${statusIcon(check.status)} ${statusLabel(check.status)} ${check.message}${fixedTag}`,
+          );
+          if (check.details) {
+            for (const detail of check.details) {
+              console.log(`    ${detail}`);
+            }
+          }
+        }
+
+        console.log();
+        console.log(
+          `結果: ${result.summary.pass} passed, ${result.summary.warn} warnings, ${result.summary.fail} failures`,
+        );
+
+        if (result.summary.fail > 0) {
+          process.exitCode = 1;
+        }
+      },
     );
-
-    if (result.summary.fail > 0) {
-      process.exitCode = 1;
-    }
   });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -8,8 +8,7 @@ import {
   type GanttExportScope,
   type ViewScale,
 } from "@gh-gantt/shared";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
+import { withProjectStorage } from "../store/project-storage.js";
 
 export interface PngRenderInput {
   svg: string;
@@ -97,34 +96,40 @@ export async function runExportCommand(
   options: ExportCommandOptions,
   deps: ExportCommandDeps = {},
 ): Promise<void> {
-  const config = await new ConfigStore(projectRoot).read();
-  const tasksFile = await new TasksStore(projectRoot).read();
-  const format = normalizeFormat(options.format);
-  const scope = normalizeScope(options.scope);
-  const viewScale = normalizeScale(options.scale, config.gantt.default_view);
-  const outputPath = resolve(projectRoot, options.output ?? `gh-gantt-export.${format}`);
-  const rendered = renderGanttExportSvg({
-    nodes: buildExportTaskNodes(tasksFile.tasks),
-    config,
-    scope,
-    viewScale,
-  });
+  return withProjectStorage(
+    projectRoot,
+    { mode: "read", scope: "shared-cache" },
+    async ({ configStore, tasksStore }) => {
+      const config = await configStore.read();
+      const tasksFile = await tasksStore.read();
+      const format = normalizeFormat(options.format);
+      const scope = normalizeScope(options.scope);
+      const viewScale = normalizeScale(options.scale, config.gantt.default_view);
+      const outputPath = resolve(projectRoot, options.output ?? `gh-gantt-export.${format}`);
+      const rendered = renderGanttExportSvg({
+        nodes: buildExportTaskNodes(tasksFile.tasks),
+        config,
+        scope,
+        viewScale,
+      });
 
-  await mkdir(dirname(outputPath), { recursive: true });
-  if (format === "svg") {
-    await writeFile(outputPath, rendered.svg);
-  } else {
-    const pngRenderer = deps.pngRenderer ?? renderPngWithPlaywright;
-    const png = await pngRenderer({
-      svg: rendered.svg,
-      width: rendered.width,
-      height: rendered.height,
-      scaleFactor: options.highResolution ? 2 : 1,
-    });
-    await writeFile(outputPath, png);
-  }
+      await mkdir(dirname(outputPath), { recursive: true });
+      if (format === "svg") {
+        await writeFile(outputPath, rendered.svg);
+      } else {
+        const pngRenderer = deps.pngRenderer ?? renderPngWithPlaywright;
+        const png = await pngRenderer({
+          svg: rendered.svg,
+          width: rendered.width,
+          height: rendered.height,
+          scaleFactor: options.highResolution ? 2 : 1,
+        });
+        await writeFile(outputPath, png);
+      }
 
-  console.log(`Exported ${format.toUpperCase()} to ${outputPath}`);
+      console.log(`Exported ${format.toUpperCase()} to ${outputPath}`);
+    },
+  );
 }
 
 export function createExportCommand(): Command {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -101,7 +101,7 @@ export const initCommand = new Command("init")
 
     const gql = await createGraphQLClient();
 
-    // Detect owner type first, then fetch project + org issue types in parallel
+    // owner種別を先に判定し、projectとorganizationのIssue Typeを並列取得する
     const ownerType = await detectOwnerType(gql, opts.owner);
     const [projectData, orgIssueTypes] = await Promise.all([
       fetchProject(gql, opts.owner, opts.project, ownerType),
@@ -165,7 +165,7 @@ export const initCommand = new Command("init")
       }
     }
 
-    // Build task types from sources (priority: issue types > custom field > labels)
+    // 情報源の優先順（Issue Type > custom field > label）でtask typeを組み立てる
     const taskTypes: Config["task_types"] = {
       task: { label: "Task", display: "bar", color: "#27AE60", github_label: null },
     };
@@ -237,7 +237,7 @@ export const initCommand = new Command("init")
       if (task) tasks.push(task);
     }
 
-    // Fetch native GitHub Milestones and create synthetic milestone tasks
+    // GitHub native milestoneを取得し、synthetic milestone taskを作る
     const repoFullName = `${opts.owner}/${opts.repo}`;
     const repoMetadata = await fetchRepositoryMetadata(gql, opts.owner, opts.repo);
     const milestonesWithDueDate = repoMetadata.milestones.filter((m) => m.dueOn);
@@ -254,7 +254,7 @@ export const initCommand = new Command("init")
       console.log(`Added ${milestonesWithDueDate.length} milestone(s) from GitHub`);
     }
 
-    // Fetch sub-issue relationships
+    // sub-issue関係を取得する
     console.log("Fetching sub-issue relationships...");
     const issueItems = projectData.items
       .filter((i) => i.content)
@@ -266,7 +266,7 @@ export const initCommand = new Command("init")
     applySubIssueLinks(tasks, subIssueLinks);
     console.log(`Found ${subIssueLinks.length} sub-issue relationships`);
 
-    // Build sync state
+    // sync stateを組み立てる
     const idMap: SyncState["id_map"] = {};
     for (const item of projectData.items) {
       if (!item.content) continue;
@@ -285,7 +285,7 @@ export const initCommand = new Command("init")
       }
     }
 
-    // Build option_ids map from fields with options
+    // optionを持つfieldからoption_ids mapを組み立てる
     const optionIds: Record<string, Record<string, string>> = {};
     for (const field of projectData.fields) {
       if (field.options && field.options.length > 0) {
@@ -320,5 +320,5 @@ export const initCommand = new Command("init")
 
     console.log(`Initialized gh-gantt with ${tasks.length} tasks`);
     console.log("Workspace config: .gantt-sync/gantt.config.json");
-    console.log("Work Graph Cache: git-common-dir/gh-gantt/cache/project-storage/");
+    console.log("Work Graph Cache を初期化しました。");
   });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,8 +10,7 @@ import { fetchAllSubIssueLinks } from "../github/sub-issues.js";
 import { mapProjectItemToTask, applySubIssueLinks, milestoneToTask } from "../github/issues.js";
 import { resolveTaskType } from "../sync/type-resolver.js";
 import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { DEFAULT_CONFLICT_POLICY } from "@gh-gantt/shared";
 import type { Config, TaskType, TaskDisplay, Task, SyncState } from "@gh-gantt/shared";
 
@@ -94,7 +93,8 @@ export const initCommand = new Command("init")
       console.error(".gantt-sync/gantt.config.json が既に存在します。");
       console.error("  同期データの再構成だけなら gh-gantt pull を使ってください。");
       console.error("  設定ごと作り直す場合は --force を指定してください。");
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     console.log(`Initializing gh-gantt for ${opts.owner}/${opts.repo} project #${opts.project}...`);
@@ -308,16 +308,17 @@ export const initCommand = new Command("init")
 
     // Write files
     const configStore = new ConfigStore(projectRoot);
-    const tasksStore = new TasksStore(projectRoot);
-    const stateStore = new SyncStateStore(projectRoot);
-
     await configStore.write(config);
-    await tasksStore.write({ tasks, cache: { comments: {}, reactions: {} } });
-    await stateStore.write(syncState);
+    await withProjectStorage(
+      projectRoot,
+      { mode: "write", scope: "shared-cache" },
+      async ({ tasksStore, stateStore }) => {
+        await tasksStore.write({ tasks, cache: { comments: {}, reactions: {} } });
+        await stateStore.write(syncState);
+      },
+    );
 
     console.log(`Initialized gh-gantt with ${tasks.length} tasks`);
-    console.log("Files created in .gantt-sync/:");
-    console.log("  - gantt.config.json");
-    console.log("  - tasks.json");
-    console.log("  - sync-state.json");
+    console.log("Workspace config: .gantt-sync/gantt.config.json");
+    console.log("Work Graph Cache: git-common-dir/gh-gantt/cache/project-storage/");
   });

--- a/packages/cli/src/commands/loop.ts
+++ b/packages/cli/src/commands/loop.ts
@@ -28,10 +28,7 @@ import type {
   Task,
   TasksFile,
 } from "@gh-gantt/shared";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
-import { LoopStateStore } from "../store/loop-state.js";
+import { withProjectStorage, type ProjectStorageSession } from "../store/project-storage.js";
 import {
   detectMissingTaskRejection,
   evaluatePrEvidence,
@@ -641,14 +638,13 @@ function reportCommandError(context: string, err: unknown): void {
   process.exitCode = 1;
 }
 
-async function loadStores(projectRoot: string) {
-  const config = await new ConfigStore(projectRoot).read();
-  const tasksStore = new TasksStore(projectRoot);
+async function loadStores(storage: ProjectStorageSession) {
+  const { configStore, tasksStore, stateStore, loopStore } = storage;
+  const config = await configStore.read();
   // 新品クローン等で tasks.json 不在でも例外にせず空状態で開始する。
   // last_synced_at が空のままなので loop next は sync_required で pull を要求する
   const tasksFile = await tasksStore.readOrDefault();
-  const syncState = await new SyncStateStore(projectRoot).readOrDefault();
-  const loopStore = new LoopStateStore(projectRoot);
+  const syncState = await stateStore.readOrDefault();
   const state = await loopStore.readOrNull();
   return { config, tasksStore, tasksFile, syncState, loopStore, state };
 }
@@ -663,14 +659,20 @@ export const loopCommand = new Command("loop")
       .option("--json", "Output as JSON")
       .action(async (opts: { json?: boolean }) => {
         try {
-          const { config, tasksFile, state } = await loadStores(process.cwd());
-          const report = buildLoopStatusReport(
-            state,
-            config,
-            tasksFile.tasks,
-            tasksFile.has_conflicts === true,
+          await withProjectStorage(
+            process.cwd(),
+            { mode: "read", scope: "shared-cache" },
+            async (storage) => {
+              const { config, tasksFile, state } = await loadStores(storage);
+              const report = buildLoopStatusReport(
+                state,
+                config,
+                tasksFile.tasks,
+                tasksFile.has_conflicts === true,
+              );
+              console.log(opts.json ? JSON.stringify(report, null, 2) : formatLoopStatus(report));
+            },
           );
-          console.log(opts.json ? JSON.stringify(report, null, 2) : formatLoopStatus(report));
         } catch (err) {
           reportCommandError("loop status", err);
         }
@@ -683,39 +685,45 @@ export const loopCommand = new Command("loop")
       .option("--decision <text>", "このイテレーションでやることの要約を上書きする")
       .action(async (opts: { json?: boolean; decision?: string }) => {
         try {
-          const { config, tasksFile, syncState, loopStore, state } = await loadStores(
+          await withProjectStorage(
             process.cwd(),
+            { mode: "write", scope: "workspace" },
+            async (storage) => {
+              const { config, tasksFile, syncState, loopStore, state } = await loadStores(storage);
+              const now = new Date().toISOString();
+              // observe: 同期の鮮度確認（stale なら警告して続行、never は選定を拒否）
+              if (assessSyncFreshness(syncState.last_synced_at, now) === "stale") {
+                console.warn(
+                  `⚠ 最終同期から ${SYNC_STALE_THRESHOLD_HOURS} 時間を超えて経過しています。gh-gantt pull の実行を推奨します。`,
+                );
+              }
+              const current = state ?? createEmptyLoopState();
+              const result = decideNextIteration({
+                state: current,
+                config,
+                tasks: tasksFile.tasks,
+                hasConflicts: tasksFile.has_conflicts === true,
+                now,
+                lastSyncedAt: syncState.last_synced_at,
+                decision: opts.decision,
+              });
+
+              if (result.kind === "selected") {
+                current.iterations.push(result.iteration);
+                await loopStore.write(current);
+                await storage.flush();
+              } else if (result.kind === "stopped" && result.iteration) {
+                current.iterations.push(result.iteration);
+                await loopStore.write(current);
+                await storage.flush();
+              }
+
+              console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopNext(result));
+              if (result.kind === "open_iteration" || result.kind === "sync_required") {
+                process.exitCode = 1;
+              }
+            },
           );
-          const now = new Date().toISOString();
-          // observe: 同期の鮮度確認（stale なら警告して続行、never は選定を拒否）
-          if (assessSyncFreshness(syncState.last_synced_at, now) === "stale") {
-            console.warn(
-              `⚠ 最終同期から ${SYNC_STALE_THRESHOLD_HOURS} 時間を超えて経過しています。gh-gantt pull の実行を推奨します。`,
-            );
-          }
-          const current = state ?? createEmptyLoopState();
-          const result = decideNextIteration({
-            state: current,
-            config,
-            tasks: tasksFile.tasks,
-            hasConflicts: tasksFile.has_conflicts === true,
-            now,
-            lastSyncedAt: syncState.last_synced_at,
-            decision: opts.decision,
-          });
-
-          if (result.kind === "selected") {
-            current.iterations.push(result.iteration);
-            await loopStore.write(current);
-          } else if (result.kind === "stopped" && result.iteration) {
-            current.iterations.push(result.iteration);
-            await loopStore.write(current);
-          }
-
-          console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopNext(result));
-          if (result.kind === "open_iteration" || result.kind === "sync_required") {
-            process.exitCode = 1;
-          }
         } catch (err) {
           reportCommandError("loop next", err);
         }
@@ -768,103 +776,117 @@ export const loopCommand = new Command("loop")
             }
             const overrideReason = overrideCheck.reason;
             const verify = parseVerifySpecs(opts.verify);
-            const { config, tasksStore, tasksFile, loopStore, state } = await loadStores(
+            await withProjectStorage(
               process.cwd(),
-            );
-            const now = new Date().toISOString();
+              { mode: "write", scope: "all" },
+              async (storage) => {
+                const { config, tasksStore, tasksFile, loopStore, state } =
+                  await loadStores(storage);
+                const now = new Date().toISOString();
 
-            // state 未初期化でも --json の出力形式は state ありの場合と揃える
-            let result: LoopCompleteResult;
-            if (!state) {
-              result = { kind: "no_open_iteration" };
-            } else {
-              const open = findOpenIteration(state);
-              const task = open
-                ? tasksFile.tasks.find((t) => t.id === open.selectedTask)
-                : undefined;
-              // ローカルの linked_prs からは PR の所在（リポジトリ + 番号）のみ列挙する
-              // （state は live で判定: ADR-019。cross-repo の closing reference に対応）
-              const targets = task
-                ? extractLinkedPrTargets(
-                    task.linked_prs,
-                    parseRepoFullName(task.github_repo, config.project.github),
-                  )
-                : [];
-              const resolved = resolveLoopConfig(config.loop);
-
-              let prEvidence: LoopPrEvidence[] | undefined;
-              let rejection: PrGateRejection | null = null;
-              if (
-                task &&
-                shouldApplyPrGate({
-                  outcome,
-                  requirePrEvidence: resolved.requirePrEvidence,
-                  prNumbers: targets.map((t) => t.number),
-                })
-              ) {
-                let fetched: PrGateState[] | null = null;
-                let fetchError: string | undefined;
-                try {
-                  fetched = await fetchPrGateStates({ targets });
-                } catch (err) {
-                  // fail-closed: 取得失敗は evaluatePrEvidence で拒否として扱う
-                  fetchError = err instanceof Error ? err.message : String(err);
-                }
-                const evaluation = evaluatePrEvidence({
-                  targets,
-                  fetched,
-                  fetchError,
-                  checkedAt: now,
-                  overrideReason,
-                });
-                if (evaluation.kind === "accepted") {
-                  prEvidence = evaluation.evidence;
+                // state 未初期化でも --json の出力形式は state ありの場合と揃える
+                let result: LoopCompleteResult;
+                if (!state) {
+                  result = { kind: "no_open_iteration" };
                 } else {
-                  rejection = evaluation;
-                }
-              } else if (open?.selectedTask && task === undefined) {
-                // タスク不在だと linked PR を列挙できず、ゲートが黙って
-                // スキップされる fail-open になるため completed を拒否する
-                rejection = detectMissingTaskRejection({
-                  outcome,
-                  requirePrEvidence: resolved.requirePrEvidence,
-                  selectedTask: open.selectedTask,
-                  taskFound: false,
-                  overrideReason,
-                });
-              }
+                  const open = findOpenIteration(state);
+                  const task = open
+                    ? tasksFile.tasks.find((t) => t.id === open.selectedTask)
+                    : undefined;
+                  // ローカルの linked_prs からは PR の所在（リポジトリ + 番号）のみ列挙する
+                  // （state は live で判定: ADR-019。cross-repo の closing reference に対応）
+                  const targets = task
+                    ? extractLinkedPrTargets(
+                        task.linked_prs,
+                        parseRepoFullName(task.github_repo, config.project.github),
+                      )
+                    : [];
+                  const resolved = resolveLoopConfig(config.loop);
 
-              result = rejection
-                ? { kind: "pr_gate_rejected", rejection }
-                : completeIteration({
-                    state,
-                    config,
-                    tasks: tasksFile.tasks,
-                    now,
-                    outcome,
-                    reviewOutcome: opts.review,
-                    verify,
-                    prEvidence,
-                  });
-            }
-            if (result.kind === "completed" && state) {
-              // journal 記録と status 更新は別ファイルへの書き込みでありトランザクションではない。
-              // 先に tasks.json を書き込むことで、途中失敗時は「イテレーション未完了」のまま残り、
-              // loop complete の再実行で復旧できる（逆順だと journal だけ完了して status が失われる）
-              if (opts.taskStatus && result.iteration.selectedTask) {
-                applyTaskStatus(tasksFile, result.iteration.selectedTask, opts.taskStatus, config);
-                await tasksStore.write(tasksFile);
-              }
-              await loopStore.write(state);
-            } else {
-              process.exitCode = 1;
-            }
-            console.log(opts.json ? JSON.stringify(result, null, 2) : formatLoopComplete(result));
-            if (result.kind === "completed" && opts.taskStatus) {
-              console.log(
-                `task status を "${opts.taskStatus}" に更新しました。gh-gantt push で GitHub に反映してください。`,
-              );
-            }
+                  let prEvidence: LoopPrEvidence[] | undefined;
+                  let rejection: PrGateRejection | null = null;
+                  if (
+                    task &&
+                    shouldApplyPrGate({
+                      outcome,
+                      requirePrEvidence: resolved.requirePrEvidence,
+                      prNumbers: targets.map((t) => t.number),
+                    })
+                  ) {
+                    let fetched: PrGateState[] | null = null;
+                    let fetchError: string | undefined;
+                    try {
+                      fetched = await fetchPrGateStates({ targets });
+                    } catch (err) {
+                      // fail-closed: 取得失敗は evaluatePrEvidence で拒否として扱う
+                      fetchError = err instanceof Error ? err.message : String(err);
+                    }
+                    const evaluation = evaluatePrEvidence({
+                      targets,
+                      fetched,
+                      fetchError,
+                      checkedAt: now,
+                      overrideReason,
+                    });
+                    if (evaluation.kind === "accepted") {
+                      prEvidence = evaluation.evidence;
+                    } else {
+                      rejection = evaluation;
+                    }
+                  } else if (open?.selectedTask && task === undefined) {
+                    // タスク不在だと linked PR を列挙できず、ゲートが黙って
+                    // スキップされる fail-open になるため completed を拒否する
+                    rejection = detectMissingTaskRejection({
+                      outcome,
+                      requirePrEvidence: resolved.requirePrEvidence,
+                      selectedTask: open.selectedTask,
+                      taskFound: false,
+                      overrideReason,
+                    });
+                  }
+
+                  result = rejection
+                    ? { kind: "pr_gate_rejected", rejection }
+                    : completeIteration({
+                        state,
+                        config,
+                        tasks: tasksFile.tasks,
+                        now,
+                        outcome,
+                        reviewOutcome: opts.review,
+                        verify,
+                        prEvidence,
+                      });
+                }
+                if (result.kind === "completed" && state) {
+                  // journal 記録と status 更新は別ファイルへの書き込みでありトランザクションではない。
+                  // 先に tasks.json を書き込むことで、途中失敗時は「イテレーション未完了」のまま残り、
+                  // loop complete の再実行で復旧できる（逆順だと journal だけ完了して status が失われる）
+                  if (opts.taskStatus && result.iteration.selectedTask) {
+                    applyTaskStatus(
+                      tasksFile,
+                      result.iteration.selectedTask,
+                      opts.taskStatus,
+                      config,
+                    );
+                    await tasksStore.write(tasksFile);
+                    await storage.flush();
+                  }
+                  await loopStore.write(state);
+                  await storage.flush();
+                } else {
+                  process.exitCode = 1;
+                }
+                console.log(
+                  opts.json ? JSON.stringify(result, null, 2) : formatLoopComplete(result),
+                );
+                if (result.kind === "completed" && opts.taskStatus) {
+                  console.log(
+                    `task status を "${opts.taskStatus}" に更新しました。gh-gantt push で GitHub に反映してください。`,
+                  );
+                }
+              },
+            );
           } catch (err) {
             reportCommandError("loop complete", err);
           }

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -49,7 +49,7 @@ export const pullCommand = new Command("pull")
         const tasksFile = await tasksStore.readOrDefault();
         const syncState = await stateStore.readOrDefault();
 
-        // Guard: Unresolved conflicts must be resolved before next pull
+        // 未解決conflictがある場合は次のpullを拒否する
         if (tasksFile.has_conflicts) {
           console.error("未解決のコンフリクトがあります。先に resolve してください");
           process.exitCode = 1;
@@ -81,7 +81,7 @@ export const pullCommand = new Command("pull")
 
         if (result.skipped) {
           if (!opts.dryRun) {
-            // Save updated field/option metadata even when no task changes
+            // task変更がなくても更新済みfield・option metadataを保存する
             await stateStore.write(newSyncState);
             // bootstrap（tasks.json 不在）では空プロジェクトでも quick-skip され得るため、
             // 後続の status / list が ENOENT にならないよう初期ファイルを永続化する
@@ -91,7 +91,7 @@ export const pullCommand = new Command("pull")
             await storage.flush();
           }
 
-          if (!opts.withComments && !opts.forceComments) {
+          if (opts.dryRun || (!opts.withComments && !opts.forceComments)) {
             if (opts.json) {
               console.log(
                 JSON.stringify(
@@ -169,7 +169,7 @@ export const pullCommand = new Command("pull")
 
         console.log(`Fetched items from GitHub`);
 
-        // Dry-run reporting
+        // dry-run結果を表示する
         if (opts.dryRun) {
           for (const d of result.details) {
             switch (d.type) {
@@ -261,7 +261,7 @@ async function fetchAndSaveComments(
       { force: !!opts.forceComments },
     );
 
-    // Clean up comments for deleted tasks
+    // 削除済みtaskのコメントを除去する
     const taskIds = new Set(tasks.map((t) => t.id));
     for (const key of Object.keys(updatedComments.fetched_at)) {
       if (!taskIds.has(key)) {

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,11 +1,9 @@
 import { Command } from "commander";
+import type { CommentsFile } from "@gh-gantt/shared";
 import { createGraphQLClient } from "../github/client.js";
 import { isDraftTask, isMilestoneSyntheticTask } from "../github/issues.js";
 import { fetchAllComments } from "../github/comments.js";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
-import { CommentsStore } from "../store/comments.js";
+import { withProjectStorage, type ProjectStorageSession } from "../store/project-storage.js";
 import { executePull } from "../sync/pull-executor.js";
 import { formatValue } from "../util/format.js";
 
@@ -22,207 +20,226 @@ export const pullCommand = new Command("pull")
   .option("--full-fetch", "Skip pre-check and always fetch all project data")
   .action(async (opts) => {
     const projectRoot = process.cwd();
-    const configStore = new ConfigStore(projectRoot);
-    const tasksStore = new TasksStore(projectRoot);
-    const stateStore = new SyncStateStore(projectRoot);
+    return withProjectStorage(
+      projectRoot,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        const { configStore, tasksStore, stateStore } = storage;
+        const config = await (async () => {
+          try {
+            return await configStore.read();
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+              console.error(".gantt-sync/gantt.config.json がありません。");
+              console.error(
+                "  設定をコミットしてあるリポジトリなら checkout 漏れを確認してください。",
+              );
+              console.error(
+                "  未初期化なら gh-gantt init --owner <owner> --repo <repo> --project <N> を実行してください。",
+              );
+              process.exitCode = 1;
+              return null;
+            }
+            throw err;
+          }
+        })();
+        if (config === null) return;
+        // tasks.json / sync-state.json は不在なら空から開始し、GitHub だけから再構成する
+        const bootstrapping = !(await tasksStore.exists());
+        const tasksFile = await tasksStore.readOrDefault();
+        const syncState = await stateStore.readOrDefault();
 
-    const config = await (async () => {
-      try {
-        return await configStore.read();
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-          console.error(".gantt-sync/gantt.config.json がありません。");
-          console.error("  設定をコミットしてあるリポジトリなら checkout 漏れを確認してください。");
-          console.error(
-            "  未初期化なら gh-gantt init --owner <owner> --repo <repo> --project <N> を実行してください。",
-          );
-          process.exit(1);
+        // Guard: Unresolved conflicts must be resolved before next pull
+        if (tasksFile.has_conflicts) {
+          console.error("未解決のコンフリクトがあります。先に resolve してください");
+          process.exitCode = 1;
+          return;
         }
-        throw err;
-      }
-    })();
-    // tasks.json / sync-state.json は不在なら空から開始し、GitHub だけから再構成する
-    const bootstrapping = !(await tasksStore.exists());
-    const tasksFile = await tasksStore.readOrDefault();
-    const syncState = await stateStore.readOrDefault();
 
-    // Guard: Unresolved conflicts must be resolved before next pull
-    if (tasksFile.has_conflicts) {
-      console.error("未解決のコンフリクトがあります。先に resolve してください");
-      process.exit(1);
-    }
+        const gql = await createGraphQLClient();
+        const {
+          result,
+          tasksFile: newTasksFile,
+          syncState: newSyncState,
+        } = await executePull(gql, config, tasksFile, syncState, {
+          force: opts.force,
+          fullFetch: opts.fullFetch,
+        });
 
-    const gql = await createGraphQLClient();
-    const {
-      result,
-      tasksFile: newTasksFile,
-      syncState: newSyncState,
-    } = await executePull(gql, config, tasksFile, syncState, {
-      force: opts.force,
-      fullFetch: opts.fullFetch,
-    });
+        // sync-state 整合性検証の findings を表示 (自動修復 ↻ / 情報 ℹ / 警告 ⚠)
+        if (!opts.json) {
+          for (const finding of result.syncStateFindings) {
+            const prefix = finding.autoFixed
+              ? "  ↻ 自動修復"
+              : finding.level === "info"
+                ? "  ℹ"
+                : "  ⚠";
+            const log = finding.level === "info" ? console.log : console.warn;
+            log(`${prefix}: ${finding.message}`);
+          }
+        }
 
-    // sync-state 整合性検証の findings を表示 (自動修復 ↻ / 情報 ℹ / 警告 ⚠)
-    if (!opts.json) {
-      for (const finding of result.syncStateFindings) {
-        const prefix = finding.autoFixed
-          ? "  ↻ 自動修復"
-          : finding.level === "info"
-            ? "  ℹ"
-            : "  ⚠";
-        const log = finding.level === "info" ? console.log : console.warn;
-        log(`${prefix}: ${finding.message}`);
-      }
-    }
+        if (result.skipped) {
+          if (!opts.dryRun) {
+            // Save updated field/option metadata even when no task changes
+            await stateStore.write(newSyncState);
+            // bootstrap（tasks.json 不在）では空プロジェクトでも quick-skip され得るため、
+            // 後続の status / list が ENOENT にならないよう初期ファイルを永続化する
+            if (bootstrapping) {
+              await tasksStore.write(newTasksFile);
+            }
+            await storage.flush();
+          }
 
-    if (result.skipped) {
-      // Save updated field/option metadata even when no task changes
-      await stateStore.write(newSyncState);
-      // bootstrap（tasks.json 不在）では空プロジェクトでも quick-skip され得るため、
-      // 後続の status / list が ENOENT にならないよう初期ファイルを永続化する
-      if (bootstrapping && !opts.dryRun) {
-        await tasksStore.write(newTasksFile);
-      }
+          if (!opts.withComments && !opts.forceComments) {
+            if (opts.json) {
+              console.log(
+                JSON.stringify(
+                  {
+                    skipped: true,
+                    dry_run: !!opts.dryRun,
+                    summary: { added: 0, updated: 0, conflicts: 0, removed: 0 },
+                    details: [],
+                    sync_state_findings: result.syncStateFindings,
+                  },
+                  null,
+                  2,
+                ),
+              );
+            } else {
+              console.log("No remote changes detected, skipping sub-issues fetch.");
+              console.log(`Pull summary: +0 ~0 !0 -0`);
+              console.log("Pull complete.");
+            }
+            return;
+          }
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  skipped: true,
+                  dry_run: !!opts.dryRun,
+                  summary: { added: 0, updated: 0, conflicts: 0, removed: 0 },
+                  details: [],
+                  sync_state_findings: result.syncStateFindings,
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log("No remote changes detected, but fetching comments as requested.");
+            console.log(`Pull summary: +0 ~0 !0 -0`);
+            console.log("Pull complete.");
+          }
+          await fetchAndSaveComments(gql, tasksFile.tasks, storage, opts);
+          return;
+        }
 
-      if (!opts.withComments && !opts.forceComments) {
         if (opts.json) {
+          if (!opts.dryRun) {
+            await tasksStore.write(newTasksFile);
+            await stateStore.write(newSyncState);
+            await storage.flush();
+            await fetchAndSaveComments(gql, newTasksFile.tasks, storage, opts);
+          }
+
+          // JSON 出力（dry-run 含む）。永続化が必要な場合はcommit成功後だけ出力する。
           console.log(
             JSON.stringify(
               {
-                skipped: true,
+                skipped: false,
                 dry_run: !!opts.dryRun,
-                summary: { added: 0, updated: 0, conflicts: 0, removed: 0 },
-                details: [],
+                summary: {
+                  added: result.added,
+                  updated: result.updated,
+                  conflicts: result.conflicts,
+                  removed: result.removed,
+                },
+                details: result.details,
                 sync_state_findings: result.syncStateFindings,
               },
               null,
               2,
             ),
           );
-        } else {
-          console.log("No remote changes detected, skipping sub-issues fetch.");
-          console.log(`Pull summary: +0 ~0 !0 -0`);
-          console.log("Pull complete.");
+
+          return;
         }
-        return;
-      }
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            {
-              skipped: true,
-              dry_run: !!opts.dryRun,
-              summary: { added: 0, updated: 0, conflicts: 0, removed: 0 },
-              details: [],
-              sync_state_findings: result.syncStateFindings,
-            },
-            null,
-            2,
-          ),
-        );
-      } else {
-        console.log("No remote changes detected, but fetching comments as requested.");
-        console.log(`Pull summary: +0 ~0 !0 -0`);
-        console.log("Pull complete.");
-      }
-      await fetchAndSaveComments(gql, tasksFile.tasks, projectRoot, opts);
-      return;
-    }
 
-    if (opts.json) {
-      // JSON 出力（dry-run 含む）
-      console.log(
-        JSON.stringify(
-          {
-            skipped: false,
-            dry_run: !!opts.dryRun,
-            summary: {
-              added: result.added,
-              updated: result.updated,
-              conflicts: result.conflicts,
-              removed: result.removed,
-            },
-            details: result.details,
-            sync_state_findings: result.syncStateFindings,
-          },
-          null,
-          2,
-        ),
-      );
+        console.log(`Fetched items from GitHub`);
 
-      if (!opts.dryRun) {
+        // Dry-run reporting
+        if (opts.dryRun) {
+          for (const d of result.details) {
+            switch (d.type) {
+              case "added":
+                console.log(`  + ${d.id}: ${d.title}`);
+                break;
+              case "updated":
+                console.log(`  ~ ${d.id}: ${d.title}`);
+                break;
+              case "removed":
+                console.log(`  - ${d.id}: ${d.title}`);
+                break;
+              case "conflict":
+                console.log(
+                  `  ! ${d.id}: ${d.title} (${d.conflictFields?.length ?? 0} conflict(s))`,
+                );
+                for (const c of d.conflictFields ?? []) {
+                  console.log(
+                    `      ${c.field}: local=${formatValue(c.local)} remote=${formatValue(c.remote)}`,
+                  );
+                }
+                break;
+              case "kept-local":
+                console.warn(
+                  `  ⚠ ${d.id}: ${d.title} (locally modified but changed remotely — keeping local)`,
+                );
+                break;
+            }
+          }
+        }
+
+        if (opts.dryRun) {
+          console.log(
+            `Pull summary: +${result.added} ~${result.updated} !${result.conflicts} -${result.removed}`,
+          );
+          console.log("Dry run — no changes applied.");
+          return;
+        }
+
         await tasksStore.write(newTasksFile);
         await stateStore.write(newSyncState);
-        await fetchAndSaveComments(gql, newTasksFile.tasks, projectRoot, opts);
-      }
-      return;
-    }
+        await storage.flush();
 
-    console.log(`Fetched items from GitHub`);
+        console.log(
+          `Pull summary: +${result.added} ~${result.updated} !${result.conflicts} -${result.removed}`,
+        );
 
-    // Dry-run reporting
-    if (opts.dryRun) {
-      for (const d of result.details) {
-        switch (d.type) {
-          case "added":
-            console.log(`  + ${d.id}: ${d.title}`);
-            break;
-          case "updated":
-            console.log(`  ~ ${d.id}: ${d.title}`);
-            break;
-          case "removed":
-            console.log(`  - ${d.id}: ${d.title}`);
-            break;
-          case "conflict":
-            console.log(`  ! ${d.id}: ${d.title} (${d.conflictFields?.length ?? 0} conflict(s))`);
-            for (const c of d.conflictFields ?? []) {
-              console.log(
-                `      ${c.field}: local=${formatValue(c.local)} remote=${formatValue(c.remote)}`,
-              );
-            }
-            break;
-          case "kept-local":
-            console.warn(
-              `  ⚠ ${d.id}: ${d.title} (locally modified but changed remotely — keeping local)`,
-            );
-            break;
+        if (result.hasConflicts) {
+          console.warn(
+            `\n${result.conflicts} task(s) have conflicts. Run 'gh-gantt resolve' to resolve them.`,
+          );
         }
-      }
-    }
 
-    console.log(
-      `Pull summary: +${result.added} ~${result.updated} !${result.conflicts} -${result.removed}`,
+        console.log("Pull complete.");
+
+        await fetchAndSaveComments(gql, newTasksFile.tasks, storage, opts);
+      },
     );
-
-    if (opts.dryRun) {
-      console.log("Dry run — no changes applied.");
-      return;
-    }
-
-    await tasksStore.write(newTasksFile);
-    await stateStore.write(newSyncState);
-
-    if (result.hasConflicts) {
-      console.warn(
-        `\n${result.conflicts} task(s) have conflicts. Run 'gh-gantt resolve' to resolve them.`,
-      );
-    }
-
-    console.log("Pull complete.");
-
-    await fetchAndSaveComments(gql, newTasksFile.tasks, projectRoot, opts);
   });
 
 async function fetchAndSaveComments(
   gql: Awaited<ReturnType<typeof createGraphQLClient>>,
   tasks: import("@gh-gantt/shared").Task[],
-  projectRoot: string,
+  storage: Pick<ProjectStorageSession, "commentsStore" | "flush">,
   opts: { withComments?: boolean; forceComments?: boolean },
 ): Promise<void> {
   if (!opts.withComments && !opts.forceComments) return;
 
   try {
-    const commentsStore = new CommentsStore(projectRoot);
+    const { commentsStore } = storage;
     const commentsFile = await commentsStore.read();
 
     const commentItems = tasks
@@ -238,7 +255,9 @@ async function fetchAndSaveComments(
       gql,
       commentItems,
       commentsFile,
-      (data) => commentsStore.write(data),
+      async (data) => {
+        await saveCommentsCheckpoint(storage, data);
+      },
       { force: !!opts.forceComments },
     );
 
@@ -251,10 +270,22 @@ async function fetchAndSaveComments(
       }
     }
 
-    await commentsStore.write(updatedComments);
+    await saveCommentsCheckpoint(storage, updatedComments);
   } catch (err) {
     console.warn(
       `Warning: failed to fetch comments: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+/** remote取得の各batchを再開可能なdurable checkpointとしてpublishする。 */
+export async function saveCommentsCheckpoint(
+  storage: {
+    commentsStore: { write(data: CommentsFile): Promise<void> };
+    flush(): Promise<void>;
+  },
+  data: CommentsFile,
+): Promise<void> {
+  await storage.commentsStore.write(data);
+  await storage.flush();
 }

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -34,7 +34,7 @@ export const pushCommand = new Command("push")
         const tasksFile = await tasksStore.read();
         const syncState = await stateStore.read();
 
-        // Guard: unresolved conflicts (not skippable with --force)
+        // 未解決conflictは--forceでも迂回させない
         if (tasksFile.has_conflicts) {
           console.error("未解決のコンフリクトがあります。先に resolve してください");
           process.exitCode = 1;
@@ -63,7 +63,7 @@ export const pushCommand = new Command("push")
           return;
         }
 
-        // Exclude synthetic milestone tasks (read-only)
+        // 読み取り専用のsynthetic milestone taskを除外する
         const pushableDiffs = diffs.filter((d) => !isMilestoneSyntheticTask(d.id));
 
         if (pushableDiffs.length === 0) {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,9 +1,7 @@
 import { createInterface } from "node:readline";
 import { Command } from "commander";
 import { createGraphQLClient } from "../github/client.js";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { computeLocalDiff, estimateApiCalls } from "../sync/diff.js";
 import { executePush } from "../sync/push-executor.js";
 import { isDraftTask, isMilestoneDraftTask, isMilestoneSyntheticTask } from "../github/issues.js";
@@ -26,186 +24,193 @@ export const pushCommand = new Command("push")
   .option("--json", "Output as JSON (implies non-interactive: skips confirmation prompt)")
   .action(async (opts) => {
     const projectRoot = process.cwd();
-    const configStore = new ConfigStore(projectRoot);
-    const tasksStore = new TasksStore(projectRoot);
-    const stateStore = new SyncStateStore(projectRoot);
+    return withProjectStorage(
+      projectRoot,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        const { configStore, tasksStore, stateStore } = storage;
 
-    const config = await configStore.read();
-    const tasksFile = await tasksStore.read();
-    const syncState = await stateStore.read();
+        const config = await configStore.read();
+        const tasksFile = await tasksStore.read();
+        const syncState = await stateStore.read();
 
-    // Guard: unresolved conflicts (not skippable with --force)
-    if (tasksFile.has_conflicts) {
-      console.error("未解決のコンフリクトがあります。先に resolve してください");
-      process.exit(1);
-    }
+        // Guard: unresolved conflicts (not skippable with --force)
+        if (tasksFile.has_conflicts) {
+          console.error("未解決のコンフリクトがあります。先に resolve してください");
+          process.exitCode = 1;
+          return;
+        }
 
-    const diffs = computeLocalDiff(tasksFile.tasks, syncState);
+        const diffs = computeLocalDiff(tasksFile.tasks, syncState);
 
-    if (diffs.length === 0) {
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            {
-              changes: [],
-              dry_run: !!opts.dryRun,
-              estimated_api_calls: 0,
-              summary: { created: 0, updated: 0, skipped: 0 },
-            },
-            null,
-            2,
-          ),
-        );
-      } else {
-        console.log("No local changes to push.");
-      }
-      return;
-    }
+        if (diffs.length === 0) {
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  changes: [],
+                  dry_run: !!opts.dryRun,
+                  estimated_api_calls: 0,
+                  summary: { created: 0, updated: 0, skipped: 0 },
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log("No local changes to push.");
+          }
+          return;
+        }
 
-    // Exclude synthetic milestone tasks (read-only)
-    const pushableDiffs = diffs.filter((d) => !isMilestoneSyntheticTask(d.id));
+        // Exclude synthetic milestone tasks (read-only)
+        const pushableDiffs = diffs.filter((d) => !isMilestoneSyntheticTask(d.id));
 
-    if (pushableDiffs.length === 0) {
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            {
-              changes: [],
-              dry_run: !!opts.dryRun,
-              estimated_api_calls: 0,
-              summary: { created: 0, updated: 0, skipped: 0 },
-            },
-            null,
-            2,
-          ),
-        );
-      } else {
-        console.log("No local changes to push.");
-      }
-      return;
-    }
+        if (pushableDiffs.length === 0) {
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  changes: [],
+                  dry_run: !!opts.dryRun,
+                  estimated_api_calls: 0,
+                  summary: { created: 0, updated: 0, skipped: 0 },
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log("No local changes to push.");
+          }
+          return;
+        }
 
-    const milestoneCount = pushableDiffs.filter(
-      (d) => d.type !== "deleted" && isMilestoneDraftTask(d.task),
-    ).length;
-    const draftCount = pushableDiffs.filter(
-      (d) => d.type !== "deleted" && isDraftTask(d.id) && !isMilestoneDraftTask(d.task),
-    ).length;
-    const deletedCount = pushableDiffs.filter((d) => d.type === "deleted").length;
-    const existingCount = pushableDiffs.length - draftCount - milestoneCount - deletedCount;
+        const milestoneCount = pushableDiffs.filter(
+          (d) => d.type !== "deleted" && isMilestoneDraftTask(d.task),
+        ).length;
+        const draftCount = pushableDiffs.filter(
+          (d) => d.type !== "deleted" && isDraftTask(d.id) && !isMilestoneDraftTask(d.task),
+        ).length;
+        const deletedCount = pushableDiffs.filter((d) => d.type === "deleted").length;
+        const existingCount = pushableDiffs.length - draftCount - milestoneCount - deletedCount;
 
-    if (!opts.json) {
-      console.log(`Found ${pushableDiffs.length} local change(s):`);
-      if (milestoneCount > 0) console.log(`  ${milestoneCount} milestone(s) to create`);
-      if (draftCount > 0) console.log(`  ${draftCount} draft task(s) to create`);
-      if (existingCount > 0) console.log(`  ${existingCount} existing task(s) to update`);
-      if (deletedCount > 0) console.log(`  ${deletedCount} deleted task(s)`);
+        if (!opts.json) {
+          console.log(`Found ${pushableDiffs.length} local change(s):`);
+          if (milestoneCount > 0) console.log(`  ${milestoneCount} milestone(s) to create`);
+          if (draftCount > 0) console.log(`  ${draftCount} draft task(s) to create`);
+          if (existingCount > 0) console.log(`  ${existingCount} existing task(s) to update`);
+          if (deletedCount > 0) console.log(`  ${deletedCount} deleted task(s)`);
 
-      for (const diff of pushableDiffs) {
-        const isMilestone = diff.type !== "deleted" && isMilestoneDraftTask(diff.task);
-        const symbol = isMilestone
-          ? "*"
-          : diff.type === "added"
-            ? "+"
-            : diff.type === "modified"
-              ? "~"
-              : "-";
-        const tag = isMilestone
-          ? ` [milestone${diff.task.date ? `, due: ${diff.task.date}` : ""}]`
-          : isDraftTask(diff.id)
-            ? " [draft]"
-            : "";
-        const fields = diff.changedFields?.length ? ` [${diff.changedFields.join(", ")}]` : "";
-        console.log(`  ${symbol} ${diff.id}: ${diff.task.title ?? "(deleted)"}${tag}${fields}`);
-      }
+          for (const diff of pushableDiffs) {
+            const isMilestone = diff.type !== "deleted" && isMilestoneDraftTask(diff.task);
+            const symbol = isMilestone
+              ? "*"
+              : diff.type === "added"
+                ? "+"
+                : diff.type === "modified"
+                  ? "~"
+                  : "-";
+            const tag = isMilestone
+              ? ` [milestone${diff.task.date ? `, due: ${diff.task.date}` : ""}]`
+              : isDraftTask(diff.id)
+                ? " [draft]"
+                : "";
+            const fields = diff.changedFields?.length ? ` [${diff.changedFields.join(", ")}]` : "";
+            console.log(`  ${symbol} ${diff.id}: ${diff.task.title ?? "(deleted)"}${tag}${fields}`);
+          }
 
-      const estimated = estimateApiCalls(pushableDiffs);
-      console.log(`\nEstimated GitHub API calls: ~${estimated}`);
-    }
+          const estimated = estimateApiCalls(pushableDiffs);
+          console.log(`\nEstimated GitHub API calls: ~${estimated}`);
+        }
 
-    if (opts.dryRun) {
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            {
-              changes: pushableDiffs.map((d) => ({
-                type: d.type,
-                id: d.id,
-                title: d.task.title ?? null,
-                changed_fields: d.changedFields ?? [],
-              })),
-              dry_run: true,
-              estimated_api_calls: estimateApiCalls(pushableDiffs),
-              summary: {
-                created: draftCount + milestoneCount,
-                updated: existingCount,
-                skipped: deletedCount,
-              },
-            },
-            null,
-            2,
-          ),
-        );
-      } else {
-        console.log("\nDry run — no changes pushed.");
-      }
-      return;
-    }
+        if (opts.dryRun) {
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  changes: pushableDiffs.map((d) => ({
+                    type: d.type,
+                    id: d.id,
+                    title: d.task.title ?? null,
+                    changed_fields: d.changedFields ?? [],
+                  })),
+                  dry_run: true,
+                  estimated_api_calls: estimateApiCalls(pushableDiffs),
+                  summary: {
+                    created: draftCount + milestoneCount,
+                    updated: existingCount,
+                    skipped: deletedCount,
+                  },
+                },
+                null,
+                2,
+              ),
+            );
+          } else {
+            console.log("\nDry run — no changes pushed.");
+          }
+          return;
+        }
 
-    if (!opts.yes && !opts.json) {
-      if (!process.stdin.isTTY) {
-        console.error("Non-interactive environment detected. Use --yes to confirm push.");
-        process.exitCode = 1;
-        return;
-      }
-      const confirmed = await confirm("\nProceed with push?");
-      if (!confirmed) {
-        console.log("Push cancelled.");
-        return;
-      }
-    }
+        if (!opts.yes && !opts.json) {
+          if (!process.stdin.isTTY) {
+            console.error("Non-interactive environment detected. Use --yes to confirm push.");
+            process.exitCode = 1;
+            return;
+          }
+          const confirmed = await confirm("\nProceed with push?");
+          if (!confirmed) {
+            console.log("Push cancelled.");
+            return;
+          }
+        }
 
-    const gql = await createGraphQLClient();
-    const {
-      result,
-      tasksFile: updatedTasksFile,
-      syncState: updatedSyncState,
-    } = await executePush(gql, config, tasksFile, syncState, {
-      force: opts.force,
-      saveProgress: async (tf, ss) => {
-        await tasksStore.write(tf);
-        await stateStore.write(ss);
-      },
-    });
-
-    await tasksStore.write(updatedTasksFile);
-    await stateStore.write(updatedSyncState);
-
-    if (opts.json) {
-      console.log(
-        JSON.stringify(
-          {
-            changes: pushableDiffs.map((d) => ({
-              type: d.type,
-              id: d.id,
-              title: d.task.title ?? null,
-              changed_fields: d.changedFields ?? [],
-            })),
-            dry_run: false,
-            estimated_api_calls: estimateApiCalls(pushableDiffs),
-            summary: {
-              created: result.created,
-              updated: result.updated,
-              skipped: result.skipped,
-            },
+        const gql = await createGraphQLClient();
+        const {
+          result,
+          tasksFile: updatedTasksFile,
+          syncState: updatedSyncState,
+        } = await executePush(gql, config, tasksFile, syncState, {
+          force: opts.force,
+          saveProgress: async (tf, ss) => {
+            await tasksStore.write(tf);
+            await stateStore.write(ss);
+            await storage.flush();
           },
-          null,
-          2,
-        ),
-      );
-    } else {
-      console.log(
-        `Push complete: ${result.created} created, ${result.updated} updated, ${result.skipped} skipped.`,
-      );
-    }
+        });
+
+        await tasksStore.write(updatedTasksFile);
+        await stateStore.write(updatedSyncState);
+        await storage.flush();
+
+        if (opts.json) {
+          console.log(
+            JSON.stringify(
+              {
+                changes: pushableDiffs.map((d) => ({
+                  type: d.type,
+                  id: d.id,
+                  title: d.task.title ?? null,
+                  changed_fields: d.changedFields ?? [],
+                })),
+                dry_run: false,
+                estimated_api_calls: estimateApiCalls(pushableDiffs),
+                summary: {
+                  created: result.created,
+                  updated: result.updated,
+                  skipped: result.skipped,
+                },
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.log(
+            `Push complete: ${result.created} created, ${result.updated} updated, ${result.skipped} skipped.`,
+          );
+        }
+      },
+    );
   });

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -40,7 +40,7 @@ export function resolveAll(
   for (const task of tasks) {
     const id = task.id as string;
 
-    // Filter by issue number if specified
+    // 指定された場合はIssue番号で絞り込む
     if (filterIssue !== undefined) {
       const issueNum = extractIssueNumber(id);
       if (issueNum !== filterIssue) continue;
@@ -50,11 +50,11 @@ export function resolveAll(
     if (markers.length === 0) continue;
 
     for (const marker of markers) {
-      // Filter by field if specified
+      // 指定された場合はfieldで絞り込む
       if (filterField !== undefined && marker.field !== filterField) continue;
       resolveMarker(task, marker.field, choice);
 
-      // Track fields resolved with "theirs"
+      // "theirs"で解決したfieldを記録する
       if (choice === "theirs") {
         if (!theirsResolutions.has(id)) {
           theirsResolutions.set(id, new Set());
@@ -172,7 +172,7 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
               theirsResolutionFields.set(id, resolution.theirs);
             }
           } else if (opts?.ours || opts?.theirs) {
-            // Batch mode
+            // 一括解決mode
             const choice = opts.ours ? "ours" : "theirs";
             const batchResolutions = resolveAll(tasks, choice, issue, opts.field);
 
@@ -181,7 +181,7 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
               theirsResolutionFields.set(id, fields);
             }
           } else {
-            // Interactive mode
+            // 対話解決mode
             const rl = readline.createInterface({ input, output });
 
             try {
@@ -215,7 +215,7 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
                   const choice = answer === "o" ? "ours" : "theirs";
                   resolveMarker(task, marker.field, choice);
 
-                  // Track fields resolved with "theirs"
+                  // "theirs"で解決したfieldを記録する
                   if (choice === "theirs") {
                     const fields = theirsResolutionFields.get(id) ?? new Set<string>();
                     fields.add(marker.field);
@@ -228,13 +228,13 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
             }
           }
 
-          // Update snapshots for fully resolved tasks
+          // 完全に解決済みのtaskについてsnapshotを更新する
           for (const task of tasks) {
             const id = task.id as string;
             if (!snapshotTargetTaskIds.has(id)) continue;
             if (hasUnresolvedMarkers(task)) continue;
 
-            // Skip draft tasks (no issue number)
+            // Issue番号を持たないdraft taskは除外する
             if (!id.includes("#")) continue;
 
             try {
@@ -269,12 +269,12 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
                 };
               }
             } catch {
-              // If task can't be hashed (e.g. missing fields after conflict resolution),
-              // skip snapshot update
+              // conflict解決後のfield欠損などでhashを計算できないtaskは
+              // snapshot更新を行わない
             }
           }
 
-          // Update global has_conflicts flag
+          // 全体のhas_conflicts flagを更新する
           const anyConflicts = tasks.some((t) => hasUnresolvedMarkers(t));
           if (anyConflicts) {
             (tasksFile as unknown as Record<string, unknown>).has_conflicts = true;
@@ -286,7 +286,7 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
           await stateStore.write(syncState);
           await storage.flush();
 
-          // Print remaining conflicts or success
+          // 残りのconflictまたは成功結果を出力する
           if (opts?.json) {
             const json = buildConflictJson(tasks, syncState.snapshots, issue);
             console.log(JSON.stringify(json, null, 2));

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -1,9 +1,8 @@
 import { Command } from "commander";
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
 import { ConfigStore } from "../store/config.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import {
   applyConflictPolicy,
   detectMarkers,
@@ -130,168 +129,173 @@ export function createResolveCommand(dependencies: ResolveCommandDependencies = 
       }
 
       const projectRoot = dependencies.projectRoot?.() ?? process.cwd();
-      const tasksStore = new TasksStore(projectRoot);
-      const stateStore = new SyncStateStore(projectRoot);
+      return withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { tasksStore, stateStore } = storage;
+          const tasksFile = await tasksStore.read();
+          const syncState = await stateStore.read();
 
-      const tasksFile = await tasksStore.read();
-      const syncState = await stateStore.read();
+          const tasks = tasksFile.tasks as unknown as Record<string, unknown>[];
 
-      const tasks = tasksFile.tasks as unknown as Record<string, unknown>[];
+          const theirsResolutionFields = new Map<string, Set<string>>();
+          const snapshotTargetTaskIds = new Set<string>();
 
-      const theirsResolutionFields = new Map<string, Set<string>>();
-      const snapshotTargetTaskIds = new Set<string>();
-
-      // 開始時に marker を持ち、Issue filter に一致する task だけを更新対象として固定する。
-      for (const task of tasks) {
-        const id = task.id as string;
-        const markers = detectMarkers(task);
-        const matchesIssue = issue === undefined || extractIssueNumber(id) === issue;
-        if (markers.length > 0 && matchesIssue) {
-          snapshotTargetTaskIds.add(id);
-        }
-      }
-
-      if (opts?.auto) {
-        const config = await new ConfigStore(projectRoot).read();
-        const legacyStrategy = (config.sync as unknown as Record<string, unknown>)[
-          "conflict_strategy"
-        ];
-        if (legacyStrategy !== undefined) {
-          console.warn(
-            "WARNING: sync.conflict_strategy は deprecated であり resolve --auto では無視されます。sync.conflict_policy にフィールド単位の ours / theirs / manual を設定してください。",
-          );
-        }
-        const policyResolutions = resolveAllByPolicy(
-          tasks,
-          config.sync.conflict_policy ?? {},
-          issue,
-          opts.field,
-        );
-        for (const [id, resolution] of policyResolutions) {
-          theirsResolutionFields.set(id, resolution.theirs);
-        }
-      } else if (opts?.ours || opts?.theirs) {
-        // Batch mode
-        const choice = opts.ours ? "ours" : "theirs";
-        const batchResolutions = resolveAll(tasks, choice, issue, opts.field);
-
-        // snapshot baseline を進める theirs フィールドを記録する
-        for (const [id, fields] of batchResolutions) {
-          theirsResolutionFields.set(id, fields);
-        }
-      } else {
-        // Interactive mode
-        const rl = readline.createInterface({ input, output });
-
-        try {
+          // 開始時に marker を持ち、Issue filter に一致する task だけを更新対象として固定する。
           for (const task of tasks) {
             const id = task.id as string;
-
-            if (issue !== undefined) {
-              const issueNum = extractIssueNumber(id);
-              if (issueNum !== issue) continue;
-            }
-
             const markers = detectMarkers(task);
-            if (markers.length === 0) continue;
-
-            const title = task.title as string;
-            const issueNum = extractIssueNumber(id);
-            console.log(`\n#${issueNum}: ${title}`);
-
-            for (const marker of markers) {
-              if (opts?.field !== undefined && marker.field !== opts.field) continue;
-
-              console.log(`  ${marker.field}:`);
-              console.log(`    [o]urs   = ${formatValue(marker.current)}`);
-              console.log(`    [t]heirs = ${formatValue(marker.incoming)}`);
-
-              let answer = "";
-              while (answer !== "o" && answer !== "t") {
-                answer = (await rl.question("  Choose [o/t]: ")).trim().toLowerCase();
-              }
-
-              const choice = answer === "o" ? "ours" : "theirs";
-              resolveMarker(task, marker.field, choice);
-
-              // Track fields resolved with "theirs"
-              if (choice === "theirs") {
-                const fields = theirsResolutionFields.get(id) ?? new Set<string>();
-                fields.add(marker.field);
-                theirsResolutionFields.set(id, fields);
-              }
+            const matchesIssue = issue === undefined || extractIssueNumber(id) === issue;
+            if (markers.length > 0 && matchesIssue) {
+              snapshotTargetTaskIds.add(id);
             }
           }
-        } finally {
-          rl.close();
-        }
-      }
 
-      // Update snapshots for fully resolved tasks
-      for (const task of tasks) {
-        const id = task.id as string;
-        if (!snapshotTargetTaskIds.has(id)) continue;
-        if (hasUnresolvedMarkers(task)) continue;
+          if (opts?.auto) {
+            const config = await new ConfigStore(projectRoot).read();
+            const legacyStrategy = (config.sync as unknown as Record<string, unknown>)[
+              "conflict_strategy"
+            ];
+            if (legacyStrategy !== undefined) {
+              console.warn(
+                "WARNING: sync.conflict_strategy は deprecated であり resolve --auto では無視されます。sync.conflict_policy にフィールド単位の ours / theirs / manual を設定してください。",
+              );
+            }
+            const policyResolutions = resolveAllByPolicy(
+              tasks,
+              config.sync.conflict_policy ?? {},
+              issue,
+              opts.field,
+            );
+            for (const [id, resolution] of policyResolutions) {
+              theirsResolutionFields.set(id, resolution.theirs);
+            }
+          } else if (opts?.ours || opts?.theirs) {
+            // Batch mode
+            const choice = opts.ours ? "ours" : "theirs";
+            const batchResolutions = resolveAll(tasks, choice, issue, opts.field);
 
-        // Skip draft tasks (no issue number)
-        if (!id.includes("#")) continue;
+            // snapshot baseline を進める theirs フィールドを記録する
+            for (const [id, fields] of batchResolutions) {
+              theirsResolutionFields.set(id, fields);
+            }
+          } else {
+            // Interactive mode
+            const rl = readline.createInterface({ input, output });
 
-        try {
-          const existing = syncState.snapshots[id];
-          if (!existing) continue;
+            try {
+              for (const task of tasks) {
+                const id = task.id as string;
 
-          const taskTyped = task as unknown as Task;
-          const resolvedTaskSyncFields = extractSyncFields(taskTyped);
-          const resolvedTaskHash = hashTask(taskTyped);
+                if (issue !== undefined) {
+                  const issueNum = extractIssueNumber(id);
+                  if (issueNum !== issue) continue;
+                }
 
-          if (existing.remoteHash && resolvedTaskHash === existing.remoteHash) {
-            // task 全体が remote と一致するときだけ snapshot 全体を remote へ進める。
-            syncState.snapshots[id] = {
-              ...existing,
-              hash: existing.remoteHash,
-              syncFields: resolvedTaskSyncFields,
-            };
-            continue;
+                const markers = detectMarkers(task);
+                if (markers.length === 0) continue;
+
+                const title = task.title as string;
+                const issueNum = extractIssueNumber(id);
+                console.log(`\n#${issueNum}: ${title}`);
+
+                for (const marker of markers) {
+                  if (opts?.field !== undefined && marker.field !== opts.field) continue;
+
+                  console.log(`  ${marker.field}:`);
+                  console.log(`    [o]urs   = ${formatValue(marker.current)}`);
+                  console.log(`    [t]heirs = ${formatValue(marker.incoming)}`);
+
+                  let answer = "";
+                  while (answer !== "o" && answer !== "t") {
+                    answer = (await rl.question("  Choose [o/t]: ")).trim().toLowerCase();
+                  }
+
+                  const choice = answer === "o" ? "ours" : "theirs";
+                  resolveMarker(task, marker.field, choice);
+
+                  // Track fields resolved with "theirs"
+                  if (choice === "theirs") {
+                    const fields = theirsResolutionFields.get(id) ?? new Set<string>();
+                    fields.add(marker.field);
+                    theirsResolutionFields.set(id, fields);
+                  }
+                }
+              }
+            } finally {
+              rl.close();
+            }
           }
 
-          const conservativeSyncFields = advanceSnapshotBaseline(
-            existing.syncFields,
-            resolvedTaskSyncFields,
-            theirsResolutionFields.get(id) ?? new Set(),
-          );
-          if (conservativeSyncFields) {
-            // baseline を進める場合は hash と syncFields を必ず同じ内容に揃える。
-            syncState.snapshots[id] = {
-              ...existing,
-              hash: hashSyncFields(conservativeSyncFields),
-              syncFields: conservativeSyncFields,
-            };
+          // Update snapshots for fully resolved tasks
+          for (const task of tasks) {
+            const id = task.id as string;
+            if (!snapshotTargetTaskIds.has(id)) continue;
+            if (hasUnresolvedMarkers(task)) continue;
+
+            // Skip draft tasks (no issue number)
+            if (!id.includes("#")) continue;
+
+            try {
+              const existing = syncState.snapshots[id];
+              if (!existing) continue;
+
+              const taskTyped = task as unknown as Task;
+              const resolvedTaskSyncFields = extractSyncFields(taskTyped);
+              const resolvedTaskHash = hashTask(taskTyped);
+
+              if (existing.remoteHash && resolvedTaskHash === existing.remoteHash) {
+                // task 全体が remote と一致するときだけ snapshot 全体を remote へ進める。
+                syncState.snapshots[id] = {
+                  ...existing,
+                  hash: existing.remoteHash,
+                  syncFields: resolvedTaskSyncFields,
+                };
+                continue;
+              }
+
+              const conservativeSyncFields = advanceSnapshotBaseline(
+                existing.syncFields,
+                resolvedTaskSyncFields,
+                theirsResolutionFields.get(id) ?? new Set(),
+              );
+              if (conservativeSyncFields) {
+                // baseline を進める場合は hash と syncFields を必ず同じ内容に揃える。
+                syncState.snapshots[id] = {
+                  ...existing,
+                  hash: hashSyncFields(conservativeSyncFields),
+                  syncFields: conservativeSyncFields,
+                };
+              }
+            } catch {
+              // If task can't be hashed (e.g. missing fields after conflict resolution),
+              // skip snapshot update
+            }
           }
-        } catch {
-          // If task can't be hashed (e.g. missing fields after conflict resolution),
-          // skip snapshot update
-        }
-      }
 
-      // Update global has_conflicts flag
-      const anyConflicts = tasks.some((t) => hasUnresolvedMarkers(t));
-      if (anyConflicts) {
-        (tasksFile as unknown as Record<string, unknown>).has_conflicts = true;
-      } else {
-        delete (tasksFile as unknown as Record<string, unknown>).has_conflicts;
-      }
+          // Update global has_conflicts flag
+          const anyConflicts = tasks.some((t) => hasUnresolvedMarkers(t));
+          if (anyConflicts) {
+            (tasksFile as unknown as Record<string, unknown>).has_conflicts = true;
+          } else {
+            delete (tasksFile as unknown as Record<string, unknown>).has_conflicts;
+          }
 
-      await tasksStore.write(tasksFile);
-      await stateStore.write(syncState);
+          await tasksStore.write(tasksFile);
+          await stateStore.write(syncState);
+          await storage.flush();
 
-      // Print remaining conflicts or success
-      if (opts?.json) {
-        const json = buildConflictJson(tasks, syncState.snapshots, issue);
-        console.log(JSON.stringify(json, null, 2));
-      } else {
-        const remaining = formatConflictList(tasks, syncState.snapshots, issue);
-        console.log(remaining);
-      }
+          // Print remaining conflicts or success
+          if (opts?.json) {
+            const json = buildConflictJson(tasks, syncState.snapshots, issue);
+            console.log(JSON.stringify(json, null, 2));
+          } else {
+            const remaining = formatConflictList(tasks, syncState.snapshots, issue);
+            console.log(remaining);
+          }
+        },
+      );
     });
 }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,9 +13,8 @@ import {
   type RunGraphPrObservation,
 } from "../loop/pr-evidence.js";
 import { RunGraphControlPlane, type RunGraphCommandResult } from "../run-graph/control-plane.js";
-import { ConfigStore } from "../store/config.js";
 import { GraphContractStore } from "../store/graph-contract.js";
-import { TasksStore } from "../store/tasks.js";
+import { withProjectStorage } from "../store/project-storage.js";
 
 const SIDE_EFFECT_STATES = ["not_started", "committed", "reconciled", "unknown"] as const;
 const HUMAN_DECISIONS = ["approved", "rejected", "override"] as const;
@@ -163,66 +162,72 @@ async function startRun(
   projectRoot: string,
   options: { issue: string; eventId: string; actor: string },
 ): Promise<RunGraphCommandResult> {
-  const issueNumber = parsePositiveInteger(options.issue, "--issue");
-  const eventId = parseRequiredText(options.eventId, "--event-id");
-  const actorId = parseRequiredText(options.actor, "--actor");
-  const config = await new ConfigStore(projectRoot).read();
-  const binding = config.run_graph;
-  if (!binding) {
-    throw new RunCommandError(
-      "unsupported_contract_binding",
-      "repository config に run_graph binding がありません",
-    );
-  }
-  const expected = {
-    plan_id: FIXED_DEV_ROLE_GRAPH_CONTRACT.planId,
-    plan_version: FIXED_DEV_ROLE_GRAPH_CONTRACT.planVersion,
-    schema_version: FIXED_DEV_ROLE_GRAPH_CONTRACT.schemaVersion,
-  };
-  if (
-    binding.plan_id !== expected.plan_id ||
-    binding.plan_version !== expected.plan_version ||
-    binding.schema_version !== expected.schema_version
-  ) {
-    throw new RunCommandError(
-      "unsupported_contract_binding",
-      "repository config は fixed dev-role Graph Contract と exact binding していません",
-    );
-  }
+  return withProjectStorage(
+    projectRoot,
+    { mode: "read", scope: "shared-cache" },
+    async ({ configStore, tasksStore }) => {
+      const issueNumber = parsePositiveInteger(options.issue, "--issue");
+      const eventId = parseRequiredText(options.eventId, "--event-id");
+      const actorId = parseRequiredText(options.actor, "--actor");
+      const config = await configStore.read();
+      const binding = config.run_graph;
+      if (!binding) {
+        throw new RunCommandError(
+          "unsupported_contract_binding",
+          "repository config に run_graph binding がありません",
+        );
+      }
+      const expected = {
+        plan_id: FIXED_DEV_ROLE_GRAPH_CONTRACT.planId,
+        plan_version: FIXED_DEV_ROLE_GRAPH_CONTRACT.planVersion,
+        schema_version: FIXED_DEV_ROLE_GRAPH_CONTRACT.schemaVersion,
+      };
+      if (
+        binding.plan_id !== expected.plan_id ||
+        binding.plan_version !== expected.plan_version ||
+        binding.schema_version !== expected.schema_version
+      ) {
+        throw new RunCommandError(
+          "unsupported_contract_binding",
+          "repository config は fixed dev-role Graph Contract と exact binding していません",
+        );
+      }
 
-  const tasks = await new TasksStore(projectRoot).read();
-  const repository = `${config.project.github.owner}/${config.project.github.repo}`;
-  const task = tasks.tasks.find(
-    (candidate) =>
-      candidate.github_issue === issueNumber &&
-      candidate.github_repo.toLowerCase() === repository.toLowerCase(),
+      const tasks = await tasksStore.read();
+      const repository = `${config.project.github.owner}/${config.project.github.repo}`;
+      const task = tasks.tasks.find(
+        (candidate) =>
+          candidate.github_issue === issueNumber &&
+          candidate.github_repo.toLowerCase() === repository.toLowerCase(),
+      );
+      if (!task) {
+        throw new RunCommandError(
+          "issue_not_found",
+          `repository の同期済み task に Issue #${issueNumber} がありません`,
+        );
+      }
+      if (task.state !== "open") {
+        throw new RunCommandError("issue_not_open", `Issue #${issueNumber} は OPEN ではありません`);
+      }
+
+      await new GraphContractStore(projectRoot).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+      return new RunGraphControlPlane(projectRoot).start({
+        schemaVersion: "1",
+        eventId,
+        actor: { id: actorId, role: "orchestrator" },
+        task: {
+          owner: config.project.github.owner,
+          repo: config.project.github.repo,
+          issueNumber,
+        },
+        contract: {
+          planId: binding.plan_id,
+          planVersion: binding.plan_version,
+          schemaVersion: binding.schema_version,
+        },
+      });
+    },
   );
-  if (!task) {
-    throw new RunCommandError(
-      "issue_not_found",
-      `repository の同期済み task に Issue #${issueNumber} がありません`,
-    );
-  }
-  if (task.state !== "open") {
-    throw new RunCommandError("issue_not_open", `Issue #${issueNumber} は OPEN ではありません`);
-  }
-
-  await new GraphContractStore(projectRoot).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
-  return new RunGraphControlPlane(projectRoot).start({
-    schemaVersion: "1",
-    eventId,
-    actor: { id: actorId, role: "orchestrator" },
-    task: {
-      owner: config.project.github.owner,
-      repo: config.project.github.repo,
-      issueNumber,
-    },
-    contract: {
-      planId: binding.plan_id,
-      planVersion: binding.plan_version,
-      schemaVersion: binding.schema_version,
-    },
-  });
 }
 
 export function createRunCommand(dependencies: RunCommandDependencies = {}): Command {

--- a/packages/cli/src/commands/sprint.ts
+++ b/packages/cli/src/commands/sprint.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import Table from "cli-table3";
 import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { resolveTaskId } from "../util/task-id.js";
-import type { Config, SprintConfig, Task, TasksFile } from "@gh-gantt/shared";
+import type { Config, SprintConfig, Task } from "@gh-gantt/shared";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
@@ -251,18 +251,6 @@ async function readConfig(): Promise<{ store: ConfigStore; config: Config }> {
   return { store, config };
 }
 
-async function readProject(): Promise<{
-  config: Config;
-  tasksStore: TasksStore;
-  tasksFile: TasksFile;
-}> {
-  const projectRoot = process.cwd();
-  const config = await new ConfigStore(projectRoot).read();
-  const tasksStore = new TasksStore(projectRoot);
-  const tasksFile = await tasksStore.read();
-  return { config, tasksStore, tasksFile };
-}
-
 function shortTaskId(task: Task): string {
   return task.id.includes("#") ? task.id.split("#")[1]! : task.id;
 }
@@ -399,22 +387,40 @@ export function createSprintCommand(): Command {
     .option("--json", "Output updated tasks as JSON")
     .action(async (sprintName: string, taskIds: string[], opts) => {
       try {
-        const { config, tasksStore, tasksFile } = await readProject();
-        const resolvedTaskIds = taskIds.map((id) => resolveTaskId(id, config));
-        const result = assignTasksToSprint(config, tasksFile.tasks, sprintName, resolvedTaskIds);
-        if (result.error || !result.sprint || !result.updated) {
-          fail(result.error ?? "Failed to assign tasks to sprint.");
-          return;
-        }
-        await tasksStore.write({ ...tasksFile, tasks: result.tasks });
-        if (opts.json) {
-          console.log(JSON.stringify({ sprint: result.sprint, updated: result.updated }, null, 2));
-        } else {
-          console.log(`Assigned ${result.updated.length} task(s) to sprint: ${result.sprint.name}`);
-          for (const task of result.updated) {
-            console.log(`  ${shortTaskId(task)}: ${task.title}`);
-          }
-        }
+        await withProjectStorage(
+          process.cwd(),
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
+            const resolvedTaskIds = taskIds.map((id) => resolveTaskId(id, config));
+            const result = assignTasksToSprint(
+              config,
+              tasksFile.tasks,
+              sprintName,
+              resolvedTaskIds,
+            );
+            if (result.error || !result.sprint || !result.updated) {
+              fail(result.error ?? "Failed to assign tasks to sprint.");
+              return;
+            }
+            await tasksStore.write({ ...tasksFile, tasks: result.tasks });
+            await storage.flush();
+            if (opts.json) {
+              console.log(
+                JSON.stringify({ sprint: result.sprint, updated: result.updated }, null, 2),
+              );
+            } else {
+              console.log(
+                `Assigned ${result.updated.length} task(s) to sprint: ${result.sprint.name}`,
+              );
+              for (const task of result.updated) {
+                console.log(`  ${shortTaskId(task)}: ${task.title}`);
+              }
+            }
+          },
+        );
       } catch (err) {
         fail(`Failed to assign sprint: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -428,27 +434,40 @@ export function createSprintCommand(): Command {
     .option("--json", "Output carried-over tasks as JSON")
     .action(async (fromName: string, toName: string, opts) => {
       try {
-        const { config, tasksStore, tasksFile } = await readProject();
-        const result = carryOverSprintTasks(config, tasksFile.tasks, fromName, toName);
-        if (result.error || !result.from || !result.to || !result.updated) {
-          fail(result.error ?? "Failed to carry over sprint tasks.");
-          return;
-        }
-        await tasksStore.write({ ...tasksFile, tasks: result.tasks });
-        if (opts.json) {
-          console.log(
-            JSON.stringify({ from: result.from, to: result.to, updated: result.updated }, null, 2),
-          );
-        } else if (result.updated.length === 0) {
-          console.log(`No unfinished tasks found in sprint: ${result.from.name}`);
-        } else {
-          console.log(
-            `Carried over ${result.updated.length} task(s): ${result.from.name} → ${result.to.name}`,
-          );
-          for (const task of result.updated) {
-            console.log(`  ${shortTaskId(task)}: ${task.title}`);
-          }
-        }
+        await withProjectStorage(
+          process.cwd(),
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
+            const result = carryOverSprintTasks(config, tasksFile.tasks, fromName, toName);
+            if (result.error || !result.from || !result.to || !result.updated) {
+              fail(result.error ?? "Failed to carry over sprint tasks.");
+              return;
+            }
+            await tasksStore.write({ ...tasksFile, tasks: result.tasks });
+            await storage.flush();
+            if (opts.json) {
+              console.log(
+                JSON.stringify(
+                  { from: result.from, to: result.to, updated: result.updated },
+                  null,
+                  2,
+                ),
+              );
+            } else if (result.updated.length === 0) {
+              console.log(`No unfinished tasks found in sprint: ${result.from.name}`);
+            } else {
+              console.log(
+                `Carried over ${result.updated.length} task(s): ${result.from.name} → ${result.to.name}`,
+              );
+              for (const task of result.updated) {
+                console.log(`  ${shortTaskId(task)}: ${task.title}`);
+              }
+            }
+          },
+        );
       } catch (err) {
         fail(`Failed to carry over sprint: ${err instanceof Error ? err.message : String(err)}`);
       }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -2,9 +2,7 @@ import { Command } from "commander";
 import { createGraphQLClient } from "../github/client.js";
 import { fetchProject } from "../github/projects.js";
 import { isDraftTask } from "../github/issues.js";
-import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { computeLocalDiff } from "../sync/diff.js";
 import { threeWayMerge, type FieldConflict } from "../sync/three-way-merge.js";
 import { formatValue } from "../util/format.js";
@@ -60,147 +58,149 @@ export const statusCommand = new Command("status")
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const projectRoot = process.cwd();
-    const configStore = new ConfigStore(projectRoot);
-    const tasksStore = new TasksStore(projectRoot);
-    const stateStore = new SyncStateStore(projectRoot);
+    return withProjectStorage(
+      projectRoot,
+      { mode: "read", scope: "shared-cache" },
+      async ({ configStore, tasksStore, stateStore }) => {
+        const config = await configStore.read();
+        const tasksFile = await tasksStore.read();
+        const syncState = await stateStore.read();
 
-    const config = await configStore.read();
-    const tasksFile = await tasksStore.read();
-    const syncState = await stateStore.read();
+        // Compute local diff
+        const localDiffs = computeLocalDiff(tasksFile.tasks, syncState);
 
-    // Compute local diff
-    const localDiffs = computeLocalDiff(tasksFile.tasks, syncState);
+        // Fetch remote and compute remote diff
+        const gql = await createGraphQLClient();
+        const { owner, project_number } = config.project.github;
+        const projectData = await fetchProject(gql, owner, project_number);
 
-    // Fetch remote and compute remote diff
-    const gql = await createGraphQLClient();
-    const { owner, project_number } = config.project.github;
-    const projectData = await fetchProject(gql, owner, project_number);
-
-    const remoteTasks: Task[] = [];
-    for (const item of projectData.items) {
-      const task = mapRemoteItemToTask(item, config);
-      if (task) remoteTasks.push(task);
-    }
-
-    // Compute remote changes (aligned with pull's quick check)
-    const remoteChanged = countRemoteChanges(remoteTasks, syncState);
-
-    // Detect conflicts via 3-way merge
-    interface StatusConflict {
-      taskId: string;
-      title: string;
-      fieldConflicts: FieldConflict[];
-    }
-    const conflicts: StatusConflict[] = [];
-    const remoteTaskMap = new Map(remoteTasks.map((t) => [t.id, t]));
-    for (const local of tasksFile.tasks) {
-      const remote = remoteTaskMap.get(local.id);
-      if (!remote) continue;
-      const snapshot = syncState.snapshots[local.id];
-      if (!snapshot?.syncFields) continue;
-      const localHash = hashTask(local);
-      const remoteHash = hashTask(remote);
-      if (localHash !== snapshot.hash && remoteHash !== snapshot.hash) {
-        const localFields = extractSyncFields(local);
-        const remoteFields = extractSyncFields(remote);
-        const { conflicts: fieldConflicts } = threeWayMerge(
-          snapshot.syncFields,
-          localFields,
-          remoteFields,
-        );
-        if (fieldConflicts.length > 0) {
-          conflicts.push({ taskId: local.id, title: local.title, fieldConflicts });
+        const remoteTasks: Task[] = [];
+        for (const item of projectData.items) {
+          const task = mapRemoteItemToTask(item, config);
+          if (task) remoteTasks.push(task);
         }
-      }
-    }
 
-    // Draft tasks
-    const draftTasks = tasksFile.tasks.filter((t) => isDraftTask(t.id));
+        // Compute remote changes (aligned with pull's quick check)
+        const remoteChanged = countRemoteChanges(remoteTasks, syncState);
 
-    if (opts.json) {
-      // JSON 出力
-      console.log(
-        JSON.stringify(
-          {
-            last_synced_at: syncState.last_synced_at,
-            local_tasks: tasksFile.tasks.length,
-            remote_tasks: remoteTasks.length,
-            local_changes: localDiffs.map((d) => ({
-              type: d.type,
-              id: d.id,
-              title: d.task.title ?? null,
-            })),
-            remote_changed: remoteChanged,
-            conflicts: conflicts.map((c) => ({
-              id: c.taskId,
-              title: c.title,
-              issue: extractIssueNumber(c.taskId) ?? null,
-              conflicts: c.fieldConflicts.map((fc) => ({
-                field: fc.field,
-                current: fc.current,
-                incoming: fc.incoming,
-                base: fc.base,
-              })),
-            })),
-            draft_tasks: draftTasks.map((t) => ({ id: t.id, title: t.title, type: t.type })),
-            config: { auto_create_issues: config.sync.auto_create_issues },
-          },
-          null,
-          2,
-        ),
-      );
-      return;
-    }
+        // Detect conflicts via 3-way merge
+        interface StatusConflict {
+          taskId: string;
+          title: string;
+          fieldConflicts: FieldConflict[];
+        }
+        const conflicts: StatusConflict[] = [];
+        const remoteTaskMap = new Map(remoteTasks.map((t) => [t.id, t]));
+        for (const local of tasksFile.tasks) {
+          const remote = remoteTaskMap.get(local.id);
+          if (!remote) continue;
+          const snapshot = syncState.snapshots[local.id];
+          if (!snapshot?.syncFields) continue;
+          const localHash = hashTask(local);
+          const remoteHash = hashTask(remote);
+          if (localHash !== snapshot.hash && remoteHash !== snapshot.hash) {
+            const localFields = extractSyncFields(local);
+            const remoteFields = extractSyncFields(remote);
+            const { conflicts: fieldConflicts } = threeWayMerge(
+              snapshot.syncFields,
+              localFields,
+              remoteFields,
+            );
+            if (fieldConflicts.length > 0) {
+              conflicts.push({ taskId: local.id, title: local.title, fieldConflicts });
+            }
+          }
+        }
 
-    // テキスト出力
-    console.log(`Last synced: ${syncState.last_synced_at}`);
-    console.log(`Local tasks: ${tasksFile.tasks.length}`);
-    console.log(`Remote tasks: ${remoteTasks.length}`);
-    console.log();
+        // Draft tasks
+        const draftTasks = tasksFile.tasks.filter((t) => isDraftTask(t.id));
 
-    if (localDiffs.length > 0) {
-      console.log("Local changes:");
-      for (const diff of localDiffs) {
-        const symbol = diff.type === "added" ? "+" : diff.type === "modified" ? "~" : "-";
-        console.log(`  ${symbol} ${diff.id}: ${diff.task.title ?? "(deleted)"}`);
-      }
-    } else {
-      console.log("No local changes.");
-    }
-
-    console.log();
-
-    if (remoteChanged > 0) {
-      console.log(`Remote changes: ${remoteChanged} task(s) modified`);
-    } else {
-      console.log("No remote changes.");
-    }
-
-    if (conflicts.length > 0) {
-      console.log();
-      console.log(`Conflicts (${conflicts.length}):`);
-      for (const c of conflicts) {
-        console.log(`  ! ${c.taskId}: ${c.title}`);
-        for (const fc of c.fieldConflicts) {
+        if (opts.json) {
+          // JSON 出力
           console.log(
-            `      ${fc.field}: local=${formatValue(fc.current)} remote=${formatValue(fc.incoming)} <- ${formatValue(fc.base)}`,
+            JSON.stringify(
+              {
+                last_synced_at: syncState.last_synced_at,
+                local_tasks: tasksFile.tasks.length,
+                remote_tasks: remoteTasks.length,
+                local_changes: localDiffs.map((d) => ({
+                  type: d.type,
+                  id: d.id,
+                  title: d.task.title ?? null,
+                })),
+                remote_changed: remoteChanged,
+                conflicts: conflicts.map((c) => ({
+                  id: c.taskId,
+                  title: c.title,
+                  issue: extractIssueNumber(c.taskId) ?? null,
+                  conflicts: c.fieldConflicts.map((fc) => ({
+                    field: fc.field,
+                    current: fc.current,
+                    incoming: fc.incoming,
+                    base: fc.base,
+                  })),
+                })),
+                draft_tasks: draftTasks.map((t) => ({ id: t.id, title: t.title, type: t.type })),
+                config: { auto_create_issues: config.sync.auto_create_issues },
+              },
+              null,
+              2,
+            ),
           );
+          return;
         }
-      }
-      console.log();
-      console.log(`Sync: auto_create_issues=${config.sync.auto_create_issues}`);
-    }
 
-    if (draftTasks.length > 0) {
-      console.log();
-      console.log(`Draft tasks (${draftTasks.length}):`);
-      for (const t of draftTasks) {
-        console.log(`  * ${t.id}: ${t.title} [${t.type}]`);
-      }
-      if (config.sync.auto_create_issues) {
-        console.log('  Run "gh-gantt push" to create GitHub issues.');
-      } else {
-        console.log('  Set "auto_create_issues: true" in config to enable push.');
-      }
-    }
+        // テキスト出力
+        console.log(`Last synced: ${syncState.last_synced_at}`);
+        console.log(`Local tasks: ${tasksFile.tasks.length}`);
+        console.log(`Remote tasks: ${remoteTasks.length}`);
+        console.log();
+
+        if (localDiffs.length > 0) {
+          console.log("Local changes:");
+          for (const diff of localDiffs) {
+            const symbol = diff.type === "added" ? "+" : diff.type === "modified" ? "~" : "-";
+            console.log(`  ${symbol} ${diff.id}: ${diff.task.title ?? "(deleted)"}`);
+          }
+        } else {
+          console.log("No local changes.");
+        }
+
+        console.log();
+
+        if (remoteChanged > 0) {
+          console.log(`Remote changes: ${remoteChanged} task(s) modified`);
+        } else {
+          console.log("No remote changes.");
+        }
+
+        if (conflicts.length > 0) {
+          console.log();
+          console.log(`Conflicts (${conflicts.length}):`);
+          for (const c of conflicts) {
+            console.log(`  ! ${c.taskId}: ${c.title}`);
+            for (const fc of c.fieldConflicts) {
+              console.log(
+                `      ${fc.field}: local=${formatValue(fc.current)} remote=${formatValue(fc.incoming)} <- ${formatValue(fc.base)}`,
+              );
+            }
+          }
+          console.log();
+          console.log(`Sync: auto_create_issues=${config.sync.auto_create_issues}`);
+        }
+
+        if (draftTasks.length > 0) {
+          console.log();
+          console.log(`Draft tasks (${draftTasks.length}):`);
+          for (const t of draftTasks) {
+            console.log(`  * ${t.id}: ${t.title} [${t.type}]`);
+          }
+          if (config.sync.auto_create_issues) {
+            console.log('  Run "gh-gantt push" to create GitHub issues.');
+          } else {
+            console.log('  Set "auto_create_issues: true" in config to enable push.');
+          }
+        }
+      },
+    );
   });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -66,10 +66,10 @@ export const statusCommand = new Command("status")
         const tasksFile = await tasksStore.read();
         const syncState = await stateStore.read();
 
-        // Compute local diff
+        // local差分を計算する
         const localDiffs = computeLocalDiff(tasksFile.tasks, syncState);
 
-        // Fetch remote and compute remote diff
+        // remoteを取得して差分を計算する
         const gql = await createGraphQLClient();
         const { owner, project_number } = config.project.github;
         const projectData = await fetchProject(gql, owner, project_number);
@@ -80,10 +80,10 @@ export const statusCommand = new Command("status")
           if (task) remoteTasks.push(task);
         }
 
-        // Compute remote changes (aligned with pull's quick check)
+        // pullのquick checkと同じ規則でremote変更を数える
         const remoteChanged = countRemoteChanges(remoteTasks, syncState);
 
-        // Detect conflicts via 3-way merge
+        // 3-way mergeでconflictを検出する
         interface StatusConflict {
           taskId: string;
           title: string;
@@ -112,7 +112,7 @@ export const statusCommand = new Command("status")
           }
         }
 
-        // Draft tasks
+        // draft taskを抽出する
         const draftTasks = tasksFile.tasks.filter((t) => isDraftTask(t.id));
 
         if (opts.json) {

--- a/packages/cli/src/commands/storage.ts
+++ b/packages/cli/src/commands/storage.ts
@@ -1,0 +1,50 @@
+import { Command } from "commander";
+import { ProjectStorageError, withProjectStorage } from "../store/project-storage.js";
+
+export interface StorageCommandDependencies {
+  projectRoot?: () => string;
+}
+
+/** 分岐したlegacy cacheの正本をoperatorが明示して共有snapshotへ移行する。 */
+export function createStorageCommand(dependencies: StorageCommandDependencies = {}): Command {
+  const storage = new Command("storage").description("Project Storage の配置と移行を管理する");
+
+  storage
+    .command("migrate")
+    .description("選択したworktreeのlegacy cacheを共有snapshotへ移行する")
+    .requiredOption("--from <worktree>", "正本として選ぶworktree root")
+    .option("--json", "JSON形式で出力する")
+    .action(async (options: { from: string; json?: boolean }) => {
+      try {
+        await withProjectStorage(
+          dependencies.projectRoot?.() ?? process.cwd(),
+          {
+            mode: "write",
+            scope: "shared-cache",
+            legacySource: options.from,
+          },
+          async (projectStorage) => {
+            await projectStorage.ensureSharedCache();
+          },
+        );
+        if (options.json) {
+          console.log(JSON.stringify({ ok: true, source: options.from }, null, 2));
+        } else {
+          console.log(`legacy cache の移行が完了しました: ${options.from}`);
+        }
+      } catch (error) {
+        const code = error instanceof ProjectStorageError ? error.code : "STORAGE_MIGRATION_FAILED";
+        const message = error instanceof Error ? error.message : String(error);
+        if (options.json) {
+          console.log(JSON.stringify({ ok: false, code, error: message }, null, 2));
+        } else {
+          console.error(`${code}: ${message}`);
+        }
+        process.exitCode = 1;
+      }
+    });
+
+  return storage;
+}
+
+export const storageCommand = createStorageCommand();

--- a/packages/cli/src/commands/task/close.ts
+++ b/packages/cli/src/commands/task/close.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { ConfigStore } from "../../store/config.js";
-import { TasksStore } from "../../store/tasks.js";
+import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import { applyTaskUpdate, type TaskUpdateOptions } from "./update.js";
 
@@ -14,45 +13,50 @@ export function createTaskCloseCommand(): Command {
     .action(async (id: string, opts) => {
       try {
         const projectRoot = process.cwd();
-        const configStore = new ConfigStore(projectRoot);
-        const tasksStore = new TasksStore(projectRoot);
+        await withProjectStorage(
+          projectRoot,
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
+            const resolvedId = resolveTaskId(id, config);
+            const taskIndex = tasksFile.tasks.findIndex((task) => task.id === resolvedId);
 
-        const config = await configStore.read();
-        const tasksFile = await tasksStore.read();
-        const resolvedId = resolveTaskId(id, config);
-        const taskIndex = tasksFile.tasks.findIndex((task) => task.id === resolvedId);
+            if (taskIndex === -1) {
+              console.error(`Task not found: ${resolvedId}`);
+              process.exitCode = 1;
+              return;
+            }
 
-        if (taskIndex === -1) {
-          console.error(`Task not found: ${resolvedId}`);
-          process.exitCode = 1;
-          return;
-        }
+            const updateOpts: TaskUpdateOptions = {
+              state: "closed",
+              approveReview: opts.approveReview,
+              evidence: opts.evidence,
+            };
+            const result = applyTaskUpdate(tasksFile.tasks[taskIndex], updateOpts, config);
+            if (result.error) {
+              console.error(result.error);
+              process.exitCode = 1;
+              return;
+            }
 
-        const updateOpts: TaskUpdateOptions = {
-          state: "closed",
-          approveReview: opts.approveReview,
-          evidence: opts.evidence,
-        };
-        const result = applyTaskUpdate(tasksFile.tasks[taskIndex], updateOpts, config);
-        if (result.error) {
-          console.error(result.error);
-          process.exitCode = 1;
-          return;
-        }
+            tasksFile.tasks[taskIndex] = result.task;
+            await tasksStore.write(tasksFile);
+            await storage.flush();
 
-        tasksFile.tasks[taskIndex] = result.task;
-        await tasksStore.write(tasksFile);
+            const evidence = typeof opts.evidence === "string" ? opts.evidence.trim() : "";
+            if (evidence.length === 0 && config.require_close_evidence !== true) {
+              console.warn('Warning: closing without evidence. Use --evidence "<summary>".');
+            }
 
-        const evidence = typeof opts.evidence === "string" ? opts.evidence.trim() : "";
-        if (evidence.length === 0 && config.require_close_evidence !== true) {
-          console.warn('Warning: closing without evidence. Use --evidence "<summary>".');
-        }
-
-        if (opts.json) {
-          console.log(JSON.stringify(result.task, null, 2));
-        } else {
-          console.log(`Closed task: ${resolvedId}`);
-        }
+            if (opts.json) {
+              console.log(JSON.stringify(result.task, null, 2));
+            } else {
+              console.log(`Closed task: ${resolvedId}`);
+            }
+          },
+        );
       } catch (err) {
         console.error("Failed to close task:", err instanceof Error ? err.message : String(err));
         process.exitCode = 1;

--- a/packages/cli/src/commands/task/link.ts
+++ b/packages/cli/src/commands/task/link.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { ConfigStore } from "../../store/config.js";
-import { TasksStore } from "../../store/tasks.js";
+import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import type { Task } from "@gh-gantt/shared";
 
@@ -101,63 +100,75 @@ export function createTaskLinkCommand(): Command {
     .option("--json", "Output updated task as JSON")
     .action(async (id: string, opts) => {
       const projectRoot = process.cwd();
-      const configStore = new ConfigStore(projectRoot);
-      const tasksStore = new TasksStore(projectRoot);
+      return withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore } = storage;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const messages: string[] = [];
 
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
+          const resolvedId = resolveTaskId(id, config);
+          const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
 
-      const resolvedId = resolveTaskId(id, config);
-      const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
+          if (taskIndex === -1) {
+            console.error(`Task not found: ${resolvedId}`);
+            process.exitCode = 1;
+            return;
+          }
 
-      if (taskIndex === -1) {
-        console.error(`Task not found: ${resolvedId}`);
-        process.exitCode = 1;
-        return;
-      }
+          if (opts.blockedBy) {
+            const blockerId = resolveTaskId(opts.blockedBy, config);
+            const depResult = addDependency(tasksFile.tasks[taskIndex], blockerId);
+            if (depResult.error) {
+              console.error(depResult.error);
+              process.exitCode = 1;
+              return;
+            }
+            tasksFile.tasks[taskIndex] = depResult.task;
+            messages.push(`Added dependency: ${resolvedId} blocked by ${blockerId}`);
+          }
 
-      if (opts.blockedBy) {
-        const blockerId = resolveTaskId(opts.blockedBy, config);
-        const depResult = addDependency(tasksFile.tasks[taskIndex], blockerId);
-        if (depResult.error) {
-          console.error(depResult.error);
-          process.exitCode = 1;
-          return;
-        }
-        tasksFile.tasks[taskIndex] = depResult.task;
-        console.log(`Added dependency: ${resolvedId} blocked by ${blockerId}`);
-      }
+          if (opts.unblock) {
+            const blockerId = resolveTaskId(opts.unblock, config);
+            const unblockResult = removeDependency(
+              tasksFile.tasks[taskIndex],
+              blockerId,
+              opts.unblock,
+            );
+            tasksFile.tasks[taskIndex] = unblockResult.task;
+            messages.push(`Removed dependency: ${resolvedId} no longer blocked by ${blockerId}`);
+          }
 
-      if (opts.unblock) {
-        const blockerId = resolveTaskId(opts.unblock, config);
-        const unblockResult = removeDependency(tasksFile.tasks[taskIndex], blockerId, opts.unblock);
-        tasksFile.tasks[taskIndex] = unblockResult.task;
-        console.log(`Removed dependency: ${resolvedId} no longer blocked by ${blockerId}`);
-      }
+          if (opts.setParent) {
+            const parentId = resolveTaskId(opts.setParent, config);
+            const parentResult = setParent(tasksFile.tasks, resolvedId, parentId);
+            if (parentResult.error) {
+              console.error(parentResult.error);
+              process.exitCode = 1;
+              return;
+            }
+            tasksFile.tasks = parentResult.tasks!;
+            messages.push(`Set parent: ${resolvedId} → ${parentId}`);
+          }
 
-      if (opts.setParent) {
-        const parentId = resolveTaskId(opts.setParent, config);
-        const parentResult = setParent(tasksFile.tasks, resolvedId, parentId);
-        if (parentResult.error) {
-          console.error(parentResult.error);
-          process.exitCode = 1;
-          return;
-        }
-        tasksFile.tasks = parentResult.tasks!;
-        console.log(`Set parent: ${resolvedId} → ${parentId}`);
-      }
+          if (opts.removeParent) {
+            tasksFile.tasks = removeParent(tasksFile.tasks, resolvedId);
+            messages.push(`Removed parent from: ${resolvedId}`);
+          }
 
-      if (opts.removeParent) {
-        tasksFile.tasks = removeParent(tasksFile.tasks, resolvedId);
-        console.log(`Removed parent from: ${resolvedId}`);
-      }
+          await tasksStore.write(tasksFile);
+          await storage.flush();
 
-      await tasksStore.write(tasksFile);
-
-      if (opts.json) {
-        const updated = tasksFile.tasks.find((t) => t.id === resolvedId);
-        console.log(JSON.stringify(updated, null, 2));
-      }
+          if (opts.json) {
+            const updated = tasksFile.tasks.find((t) => t.id === resolvedId);
+            console.log(JSON.stringify(updated, null, 2));
+          } else {
+            for (const message of messages) console.log(message);
+          }
+        },
+      );
     });
 }
 

--- a/packages/cli/src/commands/task/list.ts
+++ b/packages/cli/src/commands/task/list.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
 import Table from "cli-table3";
-import { ConfigStore } from "../../store/config.js";
-import { TasksStore } from "../../store/tasks.js";
+import { withProjectStorage } from "../../store/project-storage.js";
 import { isMilestoneSyntheticTask } from "../../github/issues.js";
 import type { Config, Task } from "@gh-gantt/shared";
 
@@ -341,55 +340,58 @@ export function createTaskListCommand(): Command {
     .option("--json", "Output as JSON")
     .action(async (opts) => {
       const projectRoot = process.cwd();
-      const configStore = new ConfigStore(projectRoot);
-      const tasksStore = new TasksStore(projectRoot);
+      return withProjectStorage(
+        projectRoot,
+        { mode: "read", scope: "shared-cache" },
+        async ({ configStore, tasksStore }) => {
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
 
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
+          if (opts.type && !config.task_types[opts.type] && !isReservedType(opts.type)) {
+            const typeKeys = Object.keys(config.task_types);
+            console.error(`Unknown task type: "${opts.type}". Available: ${typeKeys.join(", ")}`);
+            process.exitCode = 1;
+            return;
+          }
 
-      if (opts.type && !config.task_types[opts.type] && !isReservedType(opts.type)) {
-        const typeKeys = Object.keys(config.task_types);
-        console.error(`Unknown task type: "${opts.type}". Available: ${typeKeys.join(", ")}`);
-        process.exitCode = 1;
-        return;
-      }
+          const updatedSinceTimestamp =
+            opts.updatedSince != null ? parseUpdatedSince(opts.updatedSince) : undefined;
+          if (opts.updatedSince != null && updatedSinceTimestamp == null) {
+            console.error(`Invalid --updated-since date: "${opts.updatedSince}"`);
+            process.exitCode = 1;
+            return;
+          }
 
-      const updatedSinceTimestamp =
-        opts.updatedSince != null ? parseUpdatedSince(opts.updatedSince) : undefined;
-      if (opts.updatedSince != null && updatedSinceTimestamp == null) {
-        console.error(`Invalid --updated-since date: "${opts.updatedSince}"`);
-        process.exitCode = 1;
-        return;
-      }
+          let filtered = filterTasks(tasksFile.tasks, {
+            backlog: opts.backlog,
+            scheduled: opts.scheduled,
+            type: opts.type,
+            state: opts.state,
+            unblocked: opts.unblocked,
+            assignee: opts.assignee,
+            unassigned: opts.unassigned,
+            status: opts.status,
+            statusFieldName: config.statuses.field_name,
+            label: opts.label,
+            search: opts.search,
+            updatedSinceTimestamp: updatedSinceTimestamp ?? undefined,
+          });
 
-      let filtered = filterTasks(tasksFile.tasks, {
-        backlog: opts.backlog,
-        scheduled: opts.scheduled,
-        type: opts.type,
-        state: opts.state,
-        unblocked: opts.unblocked,
-        assignee: opts.assignee,
-        unassigned: opts.unassigned,
-        status: opts.status,
-        statusFieldName: config.statuses.field_name,
-        label: opts.label,
-        search: opts.search,
-        updatedSinceTimestamp: updatedSinceTimestamp ?? undefined,
-      });
+          if (opts.sort) {
+            filtered = sortTasks(filtered, opts.sort, config);
+          }
 
-      if (opts.sort) {
-        filtered = sortTasks(filtered, opts.sort, config);
-      }
-
-      if (opts.json) {
-        console.log(JSON.stringify({ tasks: filtered }, null, 2));
-      } else {
-        if (filtered.length === 0) {
-          console.log("No tasks found.");
-        } else {
-          console.log(formatTable(filtered));
-        }
-      }
+          if (opts.json) {
+            console.log(JSON.stringify({ tasks: filtered }, null, 2));
+          } else {
+            if (filtered.length === 0) {
+              console.log("No tasks found.");
+            } else {
+              console.log(formatTable(filtered));
+            }
+          }
+        },
+      );
     });
 }
 

--- a/packages/cli/src/commands/task/show.ts
+++ b/packages/cli/src/commands/task/show.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { ConfigStore } from "../../store/config.js";
-import { TasksStore } from "../../store/tasks.js";
+import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import { isMilestoneSyntheticTask } from "../../github/issues.js";
 import {
@@ -77,26 +76,29 @@ export function createTaskShowCommand(): Command {
     .action(async (id: string, opts) => {
       try {
         const projectRoot = process.cwd();
-        const configStore = new ConfigStore(projectRoot);
-        const tasksStore = new TasksStore(projectRoot);
+        await withProjectStorage(
+          projectRoot,
+          { mode: "read", scope: "shared-cache" },
+          async ({ configStore, tasksStore }) => {
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
 
-        const config = await configStore.read();
-        const tasksFile = await tasksStore.read();
+            const resolvedId = resolveTaskId(id, config);
+            const task = tasksFile.tasks.find((t) => t.id === resolvedId);
 
-        const resolvedId = resolveTaskId(id, config);
-        const task = tasksFile.tasks.find((t) => t.id === resolvedId);
+            if (!task) {
+              console.error(`Task not found: ${resolvedId}`);
+              process.exitCode = 1;
+              return;
+            }
 
-        if (!task) {
-          console.error(`Task not found: ${resolvedId}`);
-          process.exitCode = 1;
-          return;
-        }
-
-        if (opts.json) {
-          console.log(JSON.stringify(task, null, 2));
-        } else {
-          console.log(formatTask(task));
-        }
+            if (opts.json) {
+              console.log(JSON.stringify(task, null, 2));
+            } else {
+              console.log(formatTask(task));
+            }
+          },
+        );
       } catch (err) {
         console.error("Failed to show task:", err instanceof Error ? err.message : String(err));
         process.exitCode = 1;

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { ConfigStore } from "../../store/config.js";
-import { TasksStore } from "../../store/tasks.js";
+import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import type { Config, Task } from "@gh-gantt/shared";
 import {
@@ -363,117 +362,123 @@ export function createTaskUpdateCommand(): Command {
     .action(async (id: string | undefined, opts) => {
       try {
         const projectRoot = process.cwd();
-        const configStore = new ConfigStore(projectRoot);
-        const tasksStore = new TasksStore(projectRoot);
+        await withProjectStorage(
+          projectRoot,
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
 
-        const config = await configStore.read();
-        const tasksFile = await tasksStore.read();
+            const updateOpts: TaskUpdateOptions = {
+              title: opts.title,
+              body: opts.body,
+              type: opts.type,
+              state: opts.state,
+              status: opts.status,
+              priority: opts.priority,
+              startDate: opts.startDate,
+              endDate: opts.endDate,
+              assignee: opts.assignee,
+              removeAssignee: opts.removeAssignee,
+              assignImplementer: opts.assignImplementer,
+              assignReviewer: opts.assignReviewer,
+              requireReview: opts.requireReview,
+              approveReview: opts.approveReview,
+              clearReviewApproval: opts.clearReviewApproval,
+              evidence: undefined,
+              milestone: opts.milestone,
+              label: opts.label,
+              removeLabel: opts.removeLabel,
+            };
 
-        const updateOpts: TaskUpdateOptions = {
-          title: opts.title,
-          body: opts.body,
-          type: opts.type,
-          state: opts.state,
-          status: opts.status,
-          priority: opts.priority,
-          startDate: opts.startDate,
-          endDate: opts.endDate,
-          assignee: opts.assignee,
-          removeAssignee: opts.removeAssignee,
-          assignImplementer: opts.assignImplementer,
-          assignReviewer: opts.assignReviewer,
-          requireReview: opts.requireReview,
-          approveReview: opts.approveReview,
-          clearReviewApproval: opts.clearReviewApproval,
-          evidence: undefined,
-          milestone: opts.milestone,
-          label: opts.label,
-          removeLabel: opts.removeLabel,
-        };
+            if (id) {
+              // Single task update
+              const resolvedId = resolveTaskId(id, config);
+              const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
 
-        if (id) {
-          // Single task update
-          const resolvedId = resolveTaskId(id, config);
-          const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
+              if (taskIndex === -1) {
+                console.error(`Task not found: ${resolvedId}`);
+                process.exitCode = 1;
+                return;
+              }
 
-          if (taskIndex === -1) {
-            console.error(`Task not found: ${resolvedId}`);
-            process.exitCode = 1;
-            return;
-          }
+              const result = applyTaskUpdate(tasksFile.tasks[taskIndex], updateOpts, config);
 
-          const result = applyTaskUpdate(tasksFile.tasks[taskIndex], updateOpts, config);
+              if (result.error) {
+                console.error(result.error);
+                process.exitCode = 1;
+                return;
+              }
 
-          if (result.error) {
-            console.error(result.error);
-            process.exitCode = 1;
-            return;
-          }
+              tasksFile.tasks[taskIndex] = result.task;
+              await tasksStore.write(tasksFile);
+              await storage.flush();
 
-          tasksFile.tasks[taskIndex] = result.task;
-          await tasksStore.write(tasksFile);
+              if (opts.json) {
+                console.log(JSON.stringify(result.task, null, 2));
+              } else {
+                console.log(`Updated task: ${resolvedId}`);
+              }
+            } else {
+              // Bulk update
+              const filters: BulkFilterOptions = {
+                filterState: opts.filterState,
+                filterType: opts.filterType,
+                filterMilestone: opts.filterMilestone,
+                filterLabel: opts.filterLabel,
+              };
 
-          if (opts.json) {
-            console.log(JSON.stringify(result.task, null, 2));
-          } else {
-            console.log(`Updated task: ${resolvedId}`);
-          }
-        } else {
-          // Bulk update
-          const filters: BulkFilterOptions = {
-            filterState: opts.filterState,
-            filterType: opts.filterType,
-            filterMilestone: opts.filterMilestone,
-            filterLabel: opts.filterLabel,
-          };
+              const hasFilter =
+                filters.filterState ||
+                filters.filterType ||
+                filters.filterMilestone ||
+                filters.filterLabel;
+              if (!hasFilter) {
+                console.error("Bulk update requires at least one --filter-* option.");
+                process.exitCode = 1;
+                return;
+              }
 
-          const hasFilter =
-            filters.filterState ||
-            filters.filterType ||
-            filters.filterMilestone ||
-            filters.filterLabel;
-          if (!hasFilter) {
-            console.error("Bulk update requires at least one --filter-* option.");
-            process.exitCode = 1;
-            return;
-          }
+              const matched = filterTasksForUpdate(tasksFile.tasks, filters);
+              if (matched.length === 0) {
+                console.log("No tasks matched the filters.");
+                return;
+              }
 
-          const matched = filterTasksForUpdate(tasksFile.tasks, filters);
-          if (matched.length === 0) {
-            console.log("No tasks matched the filters.");
-            return;
-          }
+              const updatedTasks: Task[] = [];
+              for (const task of matched) {
+                const idx = tasksFile.tasks.findIndex((t) => t.id === task.id);
+                const result = applyTaskUpdate(tasksFile.tasks[idx], updateOpts, config);
+                if (result.error) {
+                  console.error(`Error updating ${task.id}: ${result.error}`);
+                  continue;
+                }
+                tasksFile.tasks[idx] = result.task;
+                updatedTasks.push(result.task);
+              }
 
-          const updatedTasks: Task[] = [];
-          for (const task of matched) {
-            const idx = tasksFile.tasks.findIndex((t) => t.id === task.id);
-            const result = applyTaskUpdate(tasksFile.tasks[idx], updateOpts, config);
-            if (result.error) {
-              console.error(`Error updating ${task.id}: ${result.error}`);
-              continue;
+              if (updatedTasks.length === 0) {
+                console.error("All matched tasks failed to update.");
+                process.exitCode = 1;
+                return;
+              }
+
+              await tasksStore.write(tasksFile);
+              await storage.flush();
+
+              if (opts.json) {
+                console.log(JSON.stringify({ updated: updatedTasks }, null, 2));
+              } else {
+                console.log(`Updated ${updatedTasks.length} task(s).`);
+                for (const t of updatedTasks) {
+                  const shortId = t.id.includes("#") ? t.id.split("#")[1] : t.id;
+                  console.log(`  ${shortId}: ${t.title}`);
+                }
+              }
             }
-            tasksFile.tasks[idx] = result.task;
-            updatedTasks.push(result.task);
-          }
-
-          if (updatedTasks.length === 0) {
-            console.error("All matched tasks failed to update.");
-            process.exitCode = 1;
-            return;
-          }
-
-          await tasksStore.write(tasksFile);
-
-          if (opts.json) {
-            console.log(JSON.stringify({ updated: updatedTasks }, null, 2));
-          } else {
-            console.log(`Updated ${updatedTasks.length} task(s).`);
-            for (const t of updatedTasks) {
-              const shortId = t.id.includes("#") ? t.id.split("#")[1] : t.id;
-              console.log(`  ${shortId}: ${t.title}`);
-            }
-          }
-        }
+          },
+        );
       } catch (err) {
         console.error("Failed to update task:", err instanceof Error ? err.message : String(err));
         process.exitCode = 1;

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -73,7 +73,7 @@ export function applyTaskUpdate(
   if (opts.title) updated.title = opts.title;
   if (opts.body !== undefined) updated.body = opts.body;
   if (opts.type) {
-    // Remove old type's github_label, add new type's github_label
+    // 旧typeのgithub_labelを除去し、新typeのgithub_labelを追加する
     const oldTypeDef = config.task_types[task.type];
     const newTypeDef = config.task_types[opts.type];
     if (oldTypeDef?.github_label) {
@@ -393,7 +393,7 @@ export function createTaskUpdateCommand(): Command {
             };
 
             if (id) {
-              // Single task update
+              // 単一taskを更新する
               const resolvedId = resolveTaskId(id, config);
               const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
 
@@ -421,7 +421,7 @@ export function createTaskUpdateCommand(): Command {
                 console.log(`Updated task: ${resolvedId}`);
               }
             } else {
-              // Bulk update
+              // 複数taskを一括更新する
               const filters: BulkFilterOptions = {
                 filterState: opts.filterState,
                 filterType: opts.filterType,

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -20,6 +20,7 @@ import { exportCommand } from "./commands/export.js";
 import { loopCommand } from "./commands/loop.js";
 import { deleteCommand } from "./commands/delete.js";
 import { createRunCommand } from "./commands/run.js";
+import { storageCommand } from "./commands/storage.js";
 
 export function buildProgram(): Command {
   const program = new Command();
@@ -42,6 +43,7 @@ export function buildProgram(): Command {
   program.addCommand(loopCommand);
   program.addCommand(deleteCommand);
   program.addCommand(createRunCommand());
+  program.addCommand(storageCommand);
 
   // Flattened task commands (formerly under `task` subcommand)
   program.addCommand(createTaskListCommand());

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -1,8 +1,6 @@
 import { Router, json } from "express";
 import { ConfigStore } from "../store/config.js";
-import { TasksStore } from "../store/tasks.js";
-import { SyncStateStore } from "../store/state.js";
-import { CommentsStore } from "../store/comments.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { setParent, removeParent } from "../commands/task/link.js";
 import { validateTaskCloseReview } from "../commands/task/update.js";
 import { hashTask } from "../sync/hash.js";
@@ -31,9 +29,6 @@ export function createApiRouter(projectRoot: string): Router {
   router.use(json());
 
   const configStore = new ConfigStore(projectRoot);
-  const tasksStore = new TasksStore(projectRoot);
-  const stateStore = new SyncStateStore(projectRoot);
-  const commentsStore = new CommentsStore(projectRoot);
 
   // GET /api/config
   router.get("/api/config", async (_req, res) => {
@@ -48,30 +43,36 @@ export function createApiRouter(projectRoot: string): Router {
   // GET /api/tasks
   router.get("/api/tasks", async (_req, res) => {
     try {
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const commentsFile = await commentsStore.read();
-      const normalizedComments: Record<
-        string,
-        Array<{ author: string; body: string; created_at: string }>
-      > = {};
-      for (const [key, arr] of Object.entries(commentsFile.comments)) {
-        normalizedComments[key] = arr.map((c) => ({
-          author: c.author,
-          body: c.body,
-          created_at: c.created_at,
-        }));
-      }
-      const mergedCache = {
-        ...tasksFile.cache,
-        comments: { ...tasksFile.cache.comments, ...normalizedComments },
-      };
-      const tasksWithProgress = attachProgress(
-        tasksFile.tasks,
-        config.statuses.values,
-        config.statuses.field_name,
+      await withProjectStorage(
+        projectRoot,
+        { mode: "read", scope: "shared-cache" },
+        async ({ configStore, tasksStore, commentsStore }) => {
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const commentsFile = await commentsStore.read();
+          const normalizedComments: Record<
+            string,
+            Array<{ author: string; body: string; created_at: string }>
+          > = {};
+          for (const [key, arr] of Object.entries(commentsFile.comments)) {
+            normalizedComments[key] = arr.map((c) => ({
+              author: c.author,
+              body: c.body,
+              created_at: c.created_at,
+            }));
+          }
+          const mergedCache = {
+            ...tasksFile.cache,
+            comments: { ...tasksFile.cache.comments, ...normalizedComments },
+          };
+          const tasksWithProgress = attachProgress(
+            tasksFile.tasks,
+            config.statuses.values,
+            config.statuses.field_name,
+          );
+          res.json({ tasks: tasksWithProgress, cache: mergedCache });
+        },
       );
-      res.json({ tasks: tasksWithProgress, cache: mergedCache });
     } catch {
       res.status(500).json({ error: "Failed to read tasks" });
     }
@@ -80,96 +81,104 @@ export function createApiRouter(projectRoot: string): Router {
   // POST /api/tasks — create a draft task
   router.post("/api/tasks", async (req, res) => {
     try {
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const { title, type, body, start_date, end_date } = req.body;
+      await withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore } = storage;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const { title, type, body, start_date, end_date } = req.body;
 
-      if (!title || !type) {
-        res.status(400).json({ error: "title and type are required" });
-        return;
-      }
+          if (!title || !type) {
+            res.status(400).json({ error: "title and type are required" });
+            return;
+          }
 
-      if (!config.task_types[type]) {
-        res.status(400).json({ error: `Unknown task type: "${type}"` });
-        return;
-      }
+          if (!config.task_types[type]) {
+            res.status(400).json({ error: `Unknown task type: "${type}"` });
+            return;
+          }
 
-      // parent 参照の正規化と存在検証 (#319)
-      // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
-      // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
-      // CLI の create --parent (#302) と同じく resolveTaskId で正規形へ解決してから保存する
-      let parent: string | null = req.body.parent ?? null;
-      if (parent !== null && typeof parent !== "string") {
-        res.status(400).json({ error: "parent must be a string or null" });
-        return;
-      }
-      // 空文字・空白のみは正規化をすり抜けて参照整合性を壊すため明示的に拒否する
-      if (parent !== null && parent.trim() === "") {
-        res.status(400).json({ error: "parent must be a non-empty string or null" });
-        return;
-      }
-      if (parent) {
-        parent = resolveTaskId(parent, config);
-        if (!tasksFile.tasks.some((t) => t.id === parent)) {
-          res.status(400).json({ error: `Parent task not found: ${parent}` });
-          return;
-        }
-      }
+          // parent 参照の正規化と存在検証 (#319)
+          // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
+          // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
+          // CLI の create --parent (#302) と同じく resolveTaskId で正規形へ解決してから保存する
+          let parent: string | null = req.body.parent ?? null;
+          if (parent !== null && typeof parent !== "string") {
+            res.status(400).json({ error: "parent must be a string or null" });
+            return;
+          }
+          // 空文字・空白のみは正規化をすり抜けて参照整合性を壊すため明示的に拒否する
+          if (parent !== null && parent.trim() === "") {
+            res.status(400).json({ error: "parent must be a non-empty string or null" });
+            return;
+          }
+          if (parent) {
+            parent = resolveTaskId(parent, config);
+            if (!tasksFile.tasks.some((t) => t.id === parent)) {
+              res.status(400).json({ error: `Parent task not found: ${parent}` });
+              return;
+            }
+          }
 
-      const { owner, repo } = config.project.github;
-      const repoFullName = `${owner}/${repo}`;
-      const draftNumber = getNextDraftNumber(tasksFile.tasks);
-      const taskId = buildDraftTaskId(repoFullName, draftNumber);
+          const { owner, repo } = config.project.github;
+          const repoFullName = `${owner}/${repo}`;
+          const draftNumber = getNextDraftNumber(tasksFile.tasks);
+          const taskId = buildDraftTaskId(repoFullName, draftNumber);
 
-      const labels: string[] = [];
-      const taskType = config.task_types[type];
-      if (taskType.github_label) labels.push(taskType.github_label);
+          const labels: string[] = [];
+          const taskType = config.task_types[type];
+          if (taskType.github_label) labels.push(taskType.github_label);
 
-      const now = new Date().toISOString();
-      const task: Task = {
-        id: taskId,
-        type,
-        github_issue: null,
-        github_repo: repoFullName,
-        parent,
-        sub_tasks: [],
-        title,
-        body: body ?? null,
-        state: "open",
-        state_reason: null,
-        assignees: [],
-        labels,
-        milestone: null,
-        linked_prs: [],
-        created_at: now,
-        updated_at: now,
-        closed_at: null,
-        acceptance_criteria: [],
-        acceptance_criteria_slot: false,
-        implementer: null,
-        reviewer: null,
-        require_review: false,
-        review_approved_by: null,
-        review_approved_at: null,
-        custom_fields: {},
-        start_date: start_date ?? null,
-        end_date: end_date ?? null,
-        date: null,
-        blocked_by: [],
-      };
+          const now = new Date().toISOString();
+          const task: Task = {
+            id: taskId,
+            type,
+            github_issue: null,
+            github_repo: repoFullName,
+            parent,
+            sub_tasks: [],
+            title,
+            body: body ?? null,
+            state: "open",
+            state_reason: null,
+            assignees: [],
+            labels,
+            milestone: null,
+            linked_prs: [],
+            created_at: now,
+            updated_at: now,
+            closed_at: null,
+            acceptance_criteria: [],
+            acceptance_criteria_slot: false,
+            implementer: null,
+            reviewer: null,
+            require_review: false,
+            review_approved_by: null,
+            review_approved_at: null,
+            custom_fields: {},
+            start_date: start_date ?? null,
+            end_date: end_date ?? null,
+            date: null,
+            blocked_by: [],
+          };
 
-      // parent の存在は正規化時に検証済み (#319)
-      if (parent) {
-        const parentTask = tasksFile.tasks.find((t) => t.id === parent);
-        if (parentTask && !parentTask.sub_tasks.includes(taskId)) {
-          parentTask.sub_tasks.push(taskId);
-        }
-      }
+          // parent の存在は正規化時に検証済み (#319)
+          if (parent) {
+            const parentTask = tasksFile.tasks.find((t) => t.id === parent);
+            if (parentTask && !parentTask.sub_tasks.includes(taskId)) {
+              parentTask.sub_tasks.push(taskId);
+            }
+          }
 
-      tasksFile.tasks.push(task);
-      await tasksStore.write(tasksFile);
+          tasksFile.tasks.push(task);
+          await tasksStore.write(tasksFile);
+          await storage.flush();
 
-      res.status(201).json(task);
+          res.status(201).json(task);
+        },
+      );
     } catch (err) {
       res.status(500).json({
         error: "Failed to create task: " + (err instanceof Error ? err.message : String(err)),
@@ -180,266 +189,281 @@ export function createApiRouter(projectRoot: string): Router {
   // PATCH /api/tasks/:id
   router.patch("/api/tasks/:id", async (req, res) => {
     try {
-      const taskId = decodeURIComponent(req.params.id);
-      const updates = req.body;
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const idx = tasksFile.tasks.findIndex((t) => t.id === taskId);
+      await withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore } = storage;
+          const taskId = decodeURIComponent(req.params.id);
+          const updates = req.body;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const idx = tasksFile.tasks.findIndex((t) => t.id === taskId);
 
-      if (idx === -1) {
-        res.status(404).json({ error: "Task not found" });
-        return;
-      }
-
-      const UPDATABLE_FIELDS = [
-        "title",
-        "body",
-        "type",
-        "state",
-        "state_reason",
-        "assignees",
-        "implementer",
-        "reviewer",
-        "require_review",
-        "review_approved_by",
-        "review_approved_at",
-        "labels",
-        "milestone",
-        "custom_fields",
-        "start_date",
-        "end_date",
-        "date",
-        "parent",
-        "blocked_by",
-      ] as const;
-
-      const oldTask = tasksFile.tasks[idx];
-      if ("type" in updates) {
-        if (typeof updates.type !== "string" || !config.task_types[updates.type]) {
-          res.status(400).json({ error: `Unknown task type: "${updates.type}"` });
-          return;
-        }
-      }
-      if ("labels" in updates) {
-        if (
-          !Array.isArray(updates.labels) ||
-          updates.labels.some((label: unknown) => typeof label !== "string")
-        ) {
-          res.status(400).json({ error: "labels must be an array of strings" });
-          return;
-        }
-      }
-      for (const roleField of ["implementer", "reviewer"] as const) {
-        if (
-          roleField in updates &&
-          updates[roleField] !== null &&
-          typeof updates[roleField] !== "string"
-        ) {
-          res.status(400).json({ error: `${roleField} must be a string or null` });
-          return;
-        }
-      }
-      if ("require_review" in updates && typeof updates.require_review !== "boolean") {
-        res.status(400).json({ error: "require_review must be a boolean" });
-        return;
-      }
-      // parent 参照の正規化と存在検証 (#319, POST /api/tasks と同じ規律)
-      if ("parent" in updates && updates.parent !== null) {
-        if (typeof updates.parent !== "string") {
-          res.status(400).json({ error: "parent must be a string or null" });
-          return;
-        }
-        // 空文字・空白のみは resolveTaskId の fallback で "o/r#" に化けて
-        // 「存在しない親」と区別できなくなるため明示的に拒否する (POST と同一)
-        if (updates.parent.trim() === "") {
-          res.status(400).json({ error: "parent must be a non-empty string or null" });
-          return;
-        }
-        const resolvedParent = resolveTaskId(updates.parent, config);
-        if (!tasksFile.tasks.some((t) => t.id === resolvedParent)) {
-          res.status(400).json({ error: `Parent task not found: ${resolvedParent}` });
-          return;
-        }
-        updates.parent = resolvedParent;
-      }
-      for (const reviewField of ["review_approved_by", "review_approved_at"] as const) {
-        if (
-          reviewField in updates &&
-          updates[reviewField] !== null &&
-          typeof updates[reviewField] !== "string"
-        ) {
-          res.status(400).json({ error: `${reviewField} must be a string or null` });
-          return;
-        }
-      }
-      // sub_tasks は parent から導出される逆リンクで、setParent / removeParent が
-      // parent と対で維持する。直接書き換えは child.parent と parent.sub_tasks の
-      // 食い違いを作れるため拒否し、parent 更新 / reparent へ誘導する (#321)
-      if ("sub_tasks" in updates) {
-        res.status(400).json({
-          error:
-            "sub_tasks is derived from parent and cannot be updated directly; " +
-            "update the child's parent or use POST /api/tasks/:id/reparent",
-        });
-        return;
-      }
-      // blocked_by 参照の正規化と存在検証 (#321, parent と同じ規律)
-      // TasksStore.write は無検証・read は Zod 検証のため、形状不正なエントリを
-      // 生保存すると以後の全 read が失敗する。保存前に正規形へ解決して検証する
-      if ("blocked_by" in updates) {
-        if (!Array.isArray(updates.blocked_by)) {
-          res.status(400).json({ error: "blocked_by must be an array of dependencies" });
-          return;
-        }
-        const normalizedDeps: Dependency[] = [];
-        const seenBlockers = new Set<string>();
-        for (const entry of updates.blocked_by as unknown[]) {
-          if (typeof entry !== "object" || entry === null) {
-            res.status(400).json({ error: "blocked_by must be an array of dependency objects" });
+          if (idx === -1) {
+            res.status(404).json({ error: "Task not found" });
             return;
           }
-          const { task: blockerRef, type, lag } = entry as Record<string, unknown>;
-          if (typeof blockerRef !== "string") {
-            res.status(400).json({ error: "blocked_by[].task must be a string" });
-            return;
-          }
-          // 空文字・空白のみは resolveTaskId の fallback で "o/r#" に化けて
-          // 「存在しないブロッカー」と区別できなくなるため明示的に拒否する (parent と同一)
-          if (blockerRef.trim() === "") {
-            res.status(400).json({ error: "blocked_by[].task must be a non-empty string" });
-            return;
-          }
-          const resolvedBlocker = resolveTaskId(blockerRef, config);
-          // type / lag は shared の DependencySchema で検証し、未知プロパティは
-          // 正規形 { task, type, lag } へ落として保存する
-          const parsed = DependencySchema.safeParse({ task: resolvedBlocker, type, lag });
-          if (!parsed.success) {
-            res.status(400).json({
-              error: "blocked_by entry is invalid (expected { task, type, lag })",
-            });
-            return;
-          }
-          // 短縮形の自己参照も正規化後に検出する (CLI addDependency と同一文言)
-          if (resolvedBlocker === taskId) {
-            res.status(400).json({ error: "A task cannot be blocked by itself." });
-            return;
-          }
-          if (!tasksFile.tasks.some((t) => t.id === resolvedBlocker)) {
-            res.status(400).json({ error: `Blocker task not found: ${resolvedBlocker}` });
-            return;
-          }
-          // 正規化後に同一ブロッカーへ潰れた重複は最初の 1 件を優先する
-          // (CLI addDependency の重複 skip と同じ挙動)
-          if (seenBlockers.has(resolvedBlocker)) continue;
-          seenBlockers.add(resolvedBlocker);
-          normalizedDeps.push(parsed.data);
-        }
-        updates.blocked_by = normalizedDeps;
-      }
 
-      const safeUpdates: Partial<Task> = {};
-      for (const key of UPDATABLE_FIELDS) {
-        // parent は単純マージすると旧親・新親の sub_tasks 逆リンクが壊れるため、
-        // 書き込み直前に setParent / removeParent で階層ごと更新する
-        if (key === "parent") continue;
-        if (key in updates) {
-          (safeUpdates as Record<string, unknown>)[key] = updates[key];
-        }
-      }
-      const updatedTask = { ...oldTask, ...safeUpdates };
+          const UPDATABLE_FIELDS = [
+            "title",
+            "body",
+            "type",
+            "state",
+            "state_reason",
+            "assignees",
+            "implementer",
+            "reviewer",
+            "require_review",
+            "review_approved_by",
+            "review_approved_at",
+            "labels",
+            "milestone",
+            "custom_fields",
+            "start_date",
+            "end_date",
+            "date",
+            "parent",
+            "blocked_by",
+          ] as const;
 
-      if (
-        updatedTask.implementer &&
-        updatedTask.reviewer &&
-        updatedTask.implementer.toLowerCase() === updatedTask.reviewer.toLowerCase()
-      ) {
-        res.status(400).json({ error: "reviewer must be different from implementer" });
-        return;
-      }
-      if (updates.state === "closed") {
-        const reviewError = validateTaskCloseReview(updatedTask, config);
-        if (reviewError) {
-          res.status(400).json({ error: reviewError });
-          return;
-        }
-      }
-
-      if (safeUpdates.type && safeUpdates.type !== oldTask.type) {
-        const oldTypeDef = config.task_types[oldTask.type];
-        const newTypeDef = config.task_types[safeUpdates.type];
-        if (oldTypeDef?.github_label) {
-          updatedTask.labels = updatedTask.labels.filter(
-            (label) => label !== oldTypeDef.github_label,
-          );
-        }
-        if (newTypeDef?.github_label && !updatedTask.labels.includes(newTypeDef.github_label)) {
-          updatedTask.labels = [...updatedTask.labels, newTypeDef.github_label];
-        }
-      }
-
-      // Auto-update dates on status transition
-      const statusField = config.statuses.field_name;
-      const oldStatus = oldTask.custom_fields[statusField] as string | undefined;
-      const newStatus = updatedTask.custom_fields[statusField] as string | undefined;
-      if (newStatus && oldStatus !== newStatus) {
-        const dateUpdates = computeStatusDateUpdates(oldStatus, newStatus, config.statuses.values, {
-          start_date: updatedTask.start_date,
-          end_date: updatedTask.end_date,
-        });
-        if (dateUpdates.start_date && !safeUpdates.start_date)
-          updatedTask.start_date = dateUpdates.start_date;
-        if (dateUpdates.end_date && !safeUpdates.end_date)
-          updatedTask.end_date = dateUpdates.end_date;
-      }
-
-      // Prevent start > end regardless of how dates were changed
-      if (
-        updatedTask.start_date &&
-        updatedTask.end_date &&
-        updatedTask.start_date > updatedTask.end_date
-      ) {
-        res.status(400).json({
-          error: `start_date (${updatedTask.start_date}) must not be after end_date (${updatedTask.end_date})`,
-        });
-        return;
-      }
-
-      tasksFile.tasks[idx] = updatedTask;
-
-      // parent の変更は /reparent と同一の setParent / removeParent に委譲し、
-      // 自己参照の拒否と旧親・新親の sub_tasks 逆リンク維持を保証する
-      if ("parent" in updates) {
-        if (updates.parent === null) {
-          tasksFile.tasks = removeParent(tasksFile.tasks, taskId);
-        } else {
-          // 循環検出・階層制約は setParent の責務外のため reparent と同じ検査を通す
-          if (wouldCreateCycle(tasksFile.tasks, taskId, updates.parent as string)) {
-            res.status(400).json({ error: "This operation would create a cycle" });
-            return;
-          }
-          const newParentTask = tasksFile.tasks.find((t) => t.id === updates.parent);
-          if (newParentTask) {
-            const allowed = config.type_hierarchy[newParentTask.type];
-            if (allowed && allowed.length > 0 && !allowed.includes(updatedTask.type)) {
-              res.status(400).json({
-                error: `Cannot place "${updatedTask.type}" under "${newParentTask.type}"`,
-              });
+          const oldTask = tasksFile.tasks[idx];
+          if ("type" in updates) {
+            if (typeof updates.type !== "string" || !config.task_types[updates.type]) {
+              res.status(400).json({ error: `Unknown task type: "${updates.type}"` });
               return;
             }
           }
-          const parentResult = setParent(tasksFile.tasks, taskId, updates.parent as string);
-          if (parentResult.error) {
-            res.status(400).json({ error: parentResult.error });
+          if ("labels" in updates) {
+            if (
+              !Array.isArray(updates.labels) ||
+              updates.labels.some((label: unknown) => typeof label !== "string")
+            ) {
+              res.status(400).json({ error: "labels must be an array of strings" });
+              return;
+            }
+          }
+          for (const roleField of ["implementer", "reviewer"] as const) {
+            if (
+              roleField in updates &&
+              updates[roleField] !== null &&
+              typeof updates[roleField] !== "string"
+            ) {
+              res.status(400).json({ error: `${roleField} must be a string or null` });
+              return;
+            }
+          }
+          if ("require_review" in updates && typeof updates.require_review !== "boolean") {
+            res.status(400).json({ error: "require_review must be a boolean" });
             return;
           }
-          tasksFile.tasks = parentResult.tasks!;
-        }
-      }
+          // parent 参照の正規化と存在検証 (#319, POST /api/tasks と同じ規律)
+          if ("parent" in updates && updates.parent !== null) {
+            if (typeof updates.parent !== "string") {
+              res.status(400).json({ error: "parent must be a string or null" });
+              return;
+            }
+            // 空文字・空白のみは resolveTaskId の fallback で "o/r#" に化けて
+            // 「存在しない親」と区別できなくなるため明示的に拒否する (POST と同一)
+            if (updates.parent.trim() === "") {
+              res.status(400).json({ error: "parent must be a non-empty string or null" });
+              return;
+            }
+            const resolvedParent = resolveTaskId(updates.parent, config);
+            if (!tasksFile.tasks.some((t) => t.id === resolvedParent)) {
+              res.status(400).json({ error: `Parent task not found: ${resolvedParent}` });
+              return;
+            }
+            updates.parent = resolvedParent;
+          }
+          for (const reviewField of ["review_approved_by", "review_approved_at"] as const) {
+            if (
+              reviewField in updates &&
+              updates[reviewField] !== null &&
+              typeof updates[reviewField] !== "string"
+            ) {
+              res.status(400).json({ error: `${reviewField} must be a string or null` });
+              return;
+            }
+          }
+          // sub_tasks は parent から導出される逆リンクで、setParent / removeParent が
+          // parent と対で維持する。直接書き換えは child.parent と parent.sub_tasks の
+          // 食い違いを作れるため拒否し、parent 更新 / reparent へ誘導する (#321)
+          if ("sub_tasks" in updates) {
+            res.status(400).json({
+              error:
+                "sub_tasks is derived from parent and cannot be updated directly; " +
+                "update the child's parent or use POST /api/tasks/:id/reparent",
+            });
+            return;
+          }
+          // blocked_by 参照の正規化と存在検証 (#321, parent と同じ規律)
+          // TasksStore.write は無検証・read は Zod 検証のため、形状不正なエントリを
+          // 生保存すると以後の全 read が失敗する。保存前に正規形へ解決して検証する
+          if ("blocked_by" in updates) {
+            if (!Array.isArray(updates.blocked_by)) {
+              res.status(400).json({ error: "blocked_by must be an array of dependencies" });
+              return;
+            }
+            const normalizedDeps: Dependency[] = [];
+            const seenBlockers = new Set<string>();
+            for (const entry of updates.blocked_by as unknown[]) {
+              if (typeof entry !== "object" || entry === null) {
+                res
+                  .status(400)
+                  .json({ error: "blocked_by must be an array of dependency objects" });
+                return;
+              }
+              const { task: blockerRef, type, lag } = entry as Record<string, unknown>;
+              if (typeof blockerRef !== "string") {
+                res.status(400).json({ error: "blocked_by[].task must be a string" });
+                return;
+              }
+              // 空文字・空白のみは resolveTaskId の fallback で "o/r#" に化けて
+              // 「存在しないブロッカー」と区別できなくなるため明示的に拒否する (parent と同一)
+              if (blockerRef.trim() === "") {
+                res.status(400).json({ error: "blocked_by[].task must be a non-empty string" });
+                return;
+              }
+              const resolvedBlocker = resolveTaskId(blockerRef, config);
+              // type / lag は shared の DependencySchema で検証し、未知プロパティは
+              // 正規形 { task, type, lag } へ落として保存する
+              const parsed = DependencySchema.safeParse({ task: resolvedBlocker, type, lag });
+              if (!parsed.success) {
+                res.status(400).json({
+                  error: "blocked_by entry is invalid (expected { task, type, lag })",
+                });
+                return;
+              }
+              // 短縮形の自己参照も正規化後に検出する (CLI addDependency と同一文言)
+              if (resolvedBlocker === taskId) {
+                res.status(400).json({ error: "A task cannot be blocked by itself." });
+                return;
+              }
+              if (!tasksFile.tasks.some((t) => t.id === resolvedBlocker)) {
+                res.status(400).json({ error: `Blocker task not found: ${resolvedBlocker}` });
+                return;
+              }
+              // 正規化後に同一ブロッカーへ潰れた重複は最初の 1 件を優先する
+              // (CLI addDependency の重複 skip と同じ挙動)
+              if (seenBlockers.has(resolvedBlocker)) continue;
+              seenBlockers.add(resolvedBlocker);
+              normalizedDeps.push(parsed.data);
+            }
+            updates.blocked_by = normalizedDeps;
+          }
 
-      await tasksStore.write(tasksFile);
+          const safeUpdates: Partial<Task> = {};
+          for (const key of UPDATABLE_FIELDS) {
+            // parent は単純マージすると旧親・新親の sub_tasks 逆リンクが壊れるため、
+            // 書き込み直前に setParent / removeParent で階層ごと更新する
+            if (key === "parent") continue;
+            if (key in updates) {
+              (safeUpdates as Record<string, unknown>)[key] = updates[key];
+            }
+          }
+          const updatedTask = { ...oldTask, ...safeUpdates };
 
-      const finalTask = tasksFile.tasks.find((t) => t.id === taskId) ?? updatedTask;
-      res.json(finalTask);
+          if (
+            updatedTask.implementer &&
+            updatedTask.reviewer &&
+            updatedTask.implementer.toLowerCase() === updatedTask.reviewer.toLowerCase()
+          ) {
+            res.status(400).json({ error: "reviewer must be different from implementer" });
+            return;
+          }
+          if (updates.state === "closed") {
+            const reviewError = validateTaskCloseReview(updatedTask, config);
+            if (reviewError) {
+              res.status(400).json({ error: reviewError });
+              return;
+            }
+          }
+
+          if (safeUpdates.type && safeUpdates.type !== oldTask.type) {
+            const oldTypeDef = config.task_types[oldTask.type];
+            const newTypeDef = config.task_types[safeUpdates.type];
+            if (oldTypeDef?.github_label) {
+              updatedTask.labels = updatedTask.labels.filter(
+                (label) => label !== oldTypeDef.github_label,
+              );
+            }
+            if (newTypeDef?.github_label && !updatedTask.labels.includes(newTypeDef.github_label)) {
+              updatedTask.labels = [...updatedTask.labels, newTypeDef.github_label];
+            }
+          }
+
+          // Auto-update dates on status transition
+          const statusField = config.statuses.field_name;
+          const oldStatus = oldTask.custom_fields[statusField] as string | undefined;
+          const newStatus = updatedTask.custom_fields[statusField] as string | undefined;
+          if (newStatus && oldStatus !== newStatus) {
+            const dateUpdates = computeStatusDateUpdates(
+              oldStatus,
+              newStatus,
+              config.statuses.values,
+              {
+                start_date: updatedTask.start_date,
+                end_date: updatedTask.end_date,
+              },
+            );
+            if (dateUpdates.start_date && !safeUpdates.start_date)
+              updatedTask.start_date = dateUpdates.start_date;
+            if (dateUpdates.end_date && !safeUpdates.end_date)
+              updatedTask.end_date = dateUpdates.end_date;
+          }
+
+          // Prevent start > end regardless of how dates were changed
+          if (
+            updatedTask.start_date &&
+            updatedTask.end_date &&
+            updatedTask.start_date > updatedTask.end_date
+          ) {
+            res.status(400).json({
+              error: `start_date (${updatedTask.start_date}) must not be after end_date (${updatedTask.end_date})`,
+            });
+            return;
+          }
+
+          tasksFile.tasks[idx] = updatedTask;
+
+          // parent の変更は /reparent と同一の setParent / removeParent に委譲し、
+          // 自己参照の拒否と旧親・新親の sub_tasks 逆リンク維持を保証する
+          if ("parent" in updates) {
+            if (updates.parent === null) {
+              tasksFile.tasks = removeParent(tasksFile.tasks, taskId);
+            } else {
+              // 循環検出・階層制約は setParent の責務外のため reparent と同じ検査を通す
+              if (wouldCreateCycle(tasksFile.tasks, taskId, updates.parent as string)) {
+                res.status(400).json({ error: "This operation would create a cycle" });
+                return;
+              }
+              const newParentTask = tasksFile.tasks.find((t) => t.id === updates.parent);
+              if (newParentTask) {
+                const allowed = config.type_hierarchy[newParentTask.type];
+                if (allowed && allowed.length > 0 && !allowed.includes(updatedTask.type)) {
+                  res.status(400).json({
+                    error: `Cannot place "${updatedTask.type}" under "${newParentTask.type}"`,
+                  });
+                  return;
+                }
+              }
+              const parentResult = setParent(tasksFile.tasks, taskId, updates.parent as string);
+              if (parentResult.error) {
+                res.status(400).json({ error: parentResult.error });
+                return;
+              }
+              tasksFile.tasks = parentResult.tasks!;
+            }
+          }
+
+          await tasksStore.write(tasksFile);
+          await storage.flush();
+
+          const finalTask = tasksFile.tasks.find((t) => t.id === taskId) ?? updatedTask;
+          res.json(finalTask);
+        },
+      );
     } catch {
       res.status(500).json({ error: "Failed to update task" });
     }
@@ -448,87 +472,95 @@ export function createApiRouter(projectRoot: string): Router {
   // POST /api/tasks/:id/reparent
   router.post("/api/tasks/:id/reparent", async (req, res) => {
     try {
-      const taskId = decodeURIComponent(req.params.id);
-      // 親解除の意図は newParentId: null の明示を要求する。キー欠落を null と
-      // 同一視すると、無関係な body での呼び出しが意図しない親解除になる
-      if (!("newParentId" in req.body)) {
-        res.status(400).json({ error: "newParentId is required (use null to remove parent)" });
-        return;
-      }
-      let { newParentId } = req.body;
+      await withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore } = storage;
+          const taskId = decodeURIComponent(req.params.id);
+          // 親解除の意図は newParentId: null の明示を要求する。キー欠落を null と
+          // 同一視すると、無関係な body での呼び出しが意図しない親解除になる
+          if (!("newParentId" in req.body)) {
+            res.status(400).json({ error: "newParentId is required (use null to remove parent)" });
+            return;
+          }
+          let { newParentId } = req.body;
 
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const task = tasksFile.tasks.find((t) => t.id === taskId);
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const task = tasksFile.tasks.find((t) => t.id === taskId);
 
-      if (!task) {
-        res.status(404).json({ error: "Task not found", code: "TASK_NOT_FOUND" });
-        return;
-      }
+          if (!task) {
+            res.status(404).json({ error: "Task not found", code: "TASK_NOT_FOUND" });
+            return;
+          }
 
-      // newParentId を正規形へ解決してから検証する (#319, CLI link --set-parent と同じ規律)
-      if (newParentId != null) {
-        if (typeof newParentId !== "string") {
-          res.status(400).json({ error: "newParentId must be a string or null" });
-          return;
-        }
-        if (newParentId.trim() === "") {
-          res.status(400).json({ error: "newParentId must be a non-empty string or null" });
-          return;
-        }
-        newParentId = resolveTaskId(newParentId, config);
-      }
+          // newParentId を正規形へ解決してから検証する (#319, CLI link --set-parent と同じ規律)
+          if (newParentId != null) {
+            if (typeof newParentId !== "string") {
+              res.status(400).json({ error: "newParentId must be a string or null" });
+              return;
+            }
+            if (newParentId.trim() === "") {
+              res.status(400).json({ error: "newParentId must be a non-empty string or null" });
+              return;
+            }
+            newParentId = resolveTaskId(newParentId, config);
+          }
 
-      if (newParentId === taskId) {
-        res
-          .status(400)
-          .json({ error: "Cannot set a task as its own parent", code: "SELF_REFERENCE" });
-        return;
-      }
+          if (newParentId === taskId) {
+            res
+              .status(400)
+              .json({ error: "Cannot set a task as its own parent", code: "SELF_REFERENCE" });
+            return;
+          }
 
-      if (newParentId != null) {
-        const parent = tasksFile.tasks.find((t) => t.id === newParentId);
-        if (!parent) {
-          res.status(404).json({ error: "Parent task not found", code: "TASK_NOT_FOUND" });
-          return;
-        }
+          if (newParentId != null) {
+            const parent = tasksFile.tasks.find((t) => t.id === newParentId);
+            if (!parent) {
+              res.status(404).json({ error: "Parent task not found", code: "TASK_NOT_FOUND" });
+              return;
+            }
 
-        // Cycle detection: walk up from newParentId, check we don't reach taskId
-        if (wouldCreateCycle(tasksFile.tasks, taskId, newParentId)) {
-          res
-            .status(400)
-            .json({ error: "This operation would create a cycle", code: "CYCLE_DETECTED" });
-          return;
-        }
+            // Cycle detection: walk up from newParentId, check we don't reach taskId
+            if (wouldCreateCycle(tasksFile.tasks, taskId, newParentId)) {
+              res
+                .status(400)
+                .json({ error: "This operation would create a cycle", code: "CYCLE_DETECTED" });
+              return;
+            }
 
-        // Type hierarchy validation
-        const allowed = config.type_hierarchy[parent.type];
-        if (allowed && allowed.length > 0 && !allowed.includes(task.type)) {
-          res.status(400).json({
-            error: `Cannot place "${task.type}" under "${parent.type}"`,
-            code: "TYPE_HIERARCHY_VIOLATION",
-          });
-          return;
-        }
+            // Type hierarchy validation
+            const allowed = config.type_hierarchy[parent.type];
+            if (allowed && allowed.length > 0 && !allowed.includes(task.type)) {
+              res.status(400).json({
+                error: `Cannot place "${task.type}" under "${parent.type}"`,
+                code: "TYPE_HIERARCHY_VIOLATION",
+              });
+              return;
+            }
 
-        const parentResult = setParent(tasksFile.tasks, taskId, newParentId);
-        if (parentResult.error) {
-          res.status(400).json({ error: parentResult.error });
-          return;
-        }
-        tasksFile.tasks = parentResult.tasks!;
-      } else {
-        tasksFile.tasks = removeParent(tasksFile.tasks, taskId);
-      }
+            const parentResult = setParent(tasksFile.tasks, taskId, newParentId);
+            if (parentResult.error) {
+              res.status(400).json({ error: parentResult.error });
+              return;
+            }
+            tasksFile.tasks = parentResult.tasks!;
+          } else {
+            tasksFile.tasks = removeParent(tasksFile.tasks, taskId);
+          }
 
-      await tasksStore.write(tasksFile);
+          await tasksStore.write(tasksFile);
+          await storage.flush();
 
-      const tasksWithProgress = attachProgress(
-        tasksFile.tasks,
-        config.statuses.values,
-        config.statuses.field_name,
+          const tasksWithProgress = attachProgress(
+            tasksFile.tasks,
+            config.statuses.values,
+            config.statuses.field_name,
+          );
+          res.json({ tasks: tasksWithProgress });
+        },
       );
-      res.json({ tasks: tasksWithProgress });
     } catch (err) {
       res.status(500).json({
         error: "Failed to reparent task: " + (err instanceof Error ? err.message : String(err)),
@@ -539,40 +571,49 @@ export function createApiRouter(projectRoot: string): Router {
   // POST /api/sync/pull
   router.post("/api/sync/pull", async (req, res) => {
     try {
-      const config = await configStore.read();
-      const tasksFile = await tasksStore.read();
-      const syncState = await stateStore.read();
+      await withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore, stateStore } = storage;
+          const config = await configStore.read();
+          const tasksFile = await tasksStore.read();
+          const syncState = await stateStore.read();
 
-      // Guard: Unresolved conflicts must be resolved before next pull
-      if (tasksFile.has_conflicts) {
-        res.status(409).json({
-          message: "未解決のコンフリクトがあります。先に resolve してください",
-        });
-        return;
-      }
+          // Guard: Unresolved conflicts must be resolved before next pull
+          if (tasksFile.has_conflicts) {
+            res.status(409).json({
+              message: "未解決のコンフリクトがあります。先に resolve してください",
+            });
+            return;
+          }
 
-      const gql = await createGraphQLClient();
-      const {
-        result,
-        tasksFile: newTasksFile,
-        syncState: newSyncState,
-      } = await executePull(gql, config, tasksFile, syncState);
+          const gql = await createGraphQLClient();
+          const {
+            result,
+            tasksFile: newTasksFile,
+            syncState: newSyncState,
+          } = await executePull(gql, config, tasksFile, syncState);
 
-      if (result.skipped) {
-        await stateStore.write(newSyncState);
-        res.json({ added: 0, updated: 0, removed: 0, conflicts: 0 });
-        return;
-      }
+          if (result.skipped) {
+            await stateStore.write(newSyncState);
+            await storage.flush();
+            res.json({ added: 0, updated: 0, removed: 0, conflicts: 0 });
+            return;
+          }
 
-      await tasksStore.write(newTasksFile);
-      await stateStore.write(newSyncState);
+          await tasksStore.write(newTasksFile);
+          await stateStore.write(newSyncState);
+          await storage.flush();
 
-      res.json({
-        added: result.added,
-        updated: result.updated,
-        removed: result.removed,
-        conflicts: result.conflicts,
-      });
+          res.json({
+            added: result.added,
+            updated: result.updated,
+            removed: result.removed,
+            conflicts: result.conflicts,
+          });
+        },
+      );
     } catch (err) {
       res
         .status(500)
@@ -583,51 +624,62 @@ export function createApiRouter(projectRoot: string): Router {
   // POST /api/sync/push
   router.post("/api/sync/push", async (req, res) => {
     try {
-      const { dry_run, force } = req.body ?? {};
-      const tasksFile = await tasksStore.read();
-      const syncState = await stateStore.read();
+      await withProjectStorage(
+        projectRoot,
+        { mode: "write", scope: "shared-cache" },
+        async (storage) => {
+          const { configStore, tasksStore, stateStore } = storage;
+          const { dry_run, force } = req.body ?? {};
+          const tasksFile = await tasksStore.read();
+          const syncState = await stateStore.read();
 
-      // Guard: unresolved conflicts (not skippable with force)
-      if (tasksFile.has_conflicts) {
-        res.status(409).json({
-          message: "未解決のコンフリクトがあります。先に resolve してください",
-        });
-        return;
-      }
+          // Guard: unresolved conflicts (not skippable with force)
+          if (tasksFile.has_conflicts) {
+            res.status(409).json({
+              message: "未解決のコンフリクトがあります。先に resolve してください",
+            });
+            return;
+          }
 
-      const diffs = computeLocalDiff(tasksFile.tasks, syncState);
-      if (diffs.length === 0) {
-        if (dry_run) {
-          res.json(formatDiffPreview([]));
-          return;
-        }
-        res.json({ created: 0, updated: 0, skipped: 0, message: "No local changes to push" });
-        return;
-      }
+          const diffs = computeLocalDiff(tasksFile.tasks, syncState);
+          if (diffs.length === 0) {
+            if (dry_run) {
+              res.json(formatDiffPreview([]));
+              return;
+            }
+            res.json({ created: 0, updated: 0, skipped: 0, message: "No local changes to push" });
+            return;
+          }
 
-      const config = await configStore.read();
+          const config = await configStore.read();
 
-      if (dry_run) {
-        res.json(formatDiffPreview(diffs, { autoCreateIssues: config.sync.auto_create_issues }));
-        return;
-      }
-      const gql = await createGraphQLClient();
-      const {
-        result,
-        tasksFile: updatedTasksFile,
-        syncState: updatedSyncState,
-      } = await executePush(gql, config, tasksFile, syncState, {
-        force,
-        saveProgress: async (tf, ss) => {
-          await tasksStore.write(tf);
-          await stateStore.write(ss);
+          if (dry_run) {
+            res.json(
+              formatDiffPreview(diffs, { autoCreateIssues: config.sync.auto_create_issues }),
+            );
+            return;
+          }
+          const gql = await createGraphQLClient();
+          const {
+            result,
+            tasksFile: updatedTasksFile,
+            syncState: updatedSyncState,
+          } = await executePush(gql, config, tasksFile, syncState, {
+            force,
+            saveProgress: async (tf, ss) => {
+              await tasksStore.write(tf);
+              await stateStore.write(ss);
+              await storage.flush();
+            },
+          });
+
+          await tasksStore.write(updatedTasksFile);
+          await stateStore.write(updatedSyncState);
+          await storage.flush();
+
+          res.json(result);
         },
-      });
-
-      await tasksStore.write(updatedTasksFile);
-      await stateStore.write(updatedSyncState);
-
-      res.json(result);
+      );
     } catch (err) {
       res
         .status(500)
@@ -638,17 +690,23 @@ export function createApiRouter(projectRoot: string): Router {
   // GET /api/sync/status
   router.get("/api/sync/status", async (_req, res) => {
     try {
-      const syncState = await stateStore.read();
-      const tasksFile = await tasksStore.read();
-      const localChanges = tasksFile.tasks.filter((task) => {
-        const snapshot = syncState.snapshots[task.id];
-        return !snapshot || hashTask(task) !== snapshot.hash;
-      });
-      res.json({
-        last_synced_at: syncState.last_synced_at,
-        local_changes: localChanges.length,
-        total_tasks: tasksFile.tasks.length,
-      });
+      await withProjectStorage(
+        projectRoot,
+        { mode: "read", scope: "shared-cache" },
+        async ({ tasksStore, stateStore }) => {
+          const syncState = await stateStore.read();
+          const tasksFile = await tasksStore.read();
+          const localChanges = tasksFile.tasks.filter((task) => {
+            const snapshot = syncState.snapshots[task.id];
+            return !snapshot || hashTask(task) !== snapshot.hash;
+          });
+          res.json({
+            last_synced_at: syncState.last_synced_at,
+            local_changes: localChanges.length,
+            total_tasks: tasksFile.tasks.length,
+          });
+        },
+      );
     } catch {
       res.status(500).json({ error: "Failed to get sync status" });
     }

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -1,4 +1,5 @@
 import { Router, json } from "express";
+import { z } from "zod";
 import { ConfigStore } from "../store/config.js";
 import { withProjectStorage } from "../store/project-storage.js";
 import { setParent, removeParent } from "../commands/task/link.js";
@@ -11,7 +12,43 @@ import { createGraphQLClient } from "../github/client.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
 import { resolveTaskId } from "../util/task-id.js";
 import type { Task, StatusValue, Dependency } from "@gh-gantt/shared";
-import { computeStatusDateUpdates, DependencySchema } from "@gh-gantt/shared";
+import { computeStatusDateUpdates, DependencySchema, TaskSchema } from "@gh-gantt/shared";
+
+const CreateTaskRequestSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    type: z.string().trim().min(1),
+    body: z.string().nullable().optional(),
+    start_date: z.string().nullable().optional(),
+    end_date: z.string().nullable().optional(),
+    parent: z.string().nullable().optional(),
+  })
+  .strict();
+
+const UpdateTaskRequestSchema = z
+  .object({
+    title: z.string().optional(),
+    body: z.string().nullable().optional(),
+    type: z.string().optional(),
+    state: z.enum(["open", "closed"]).optional(),
+    state_reason: z.string().nullable().optional(),
+    assignees: z.array(z.string()).optional(),
+    implementer: z.string().nullable().optional(),
+    reviewer: z.string().nullable().optional(),
+    require_review: z.boolean().optional(),
+    review_approved_by: z.string().nullable().optional(),
+    review_approved_at: z.string().nullable().optional(),
+    labels: z.array(z.string()).optional(),
+    milestone: z.string().nullable().optional(),
+    custom_fields: z.record(z.string(), z.unknown()).optional(),
+    start_date: z.string().nullable().optional(),
+    end_date: z.string().nullable().optional(),
+    date: z.string().nullable().optional(),
+    parent: z.string().nullable().optional(),
+    blocked_by: z.array(DependencySchema).optional(),
+    sub_tasks: z.unknown().optional(),
+  })
+  .strict();
 
 /** newParentId から親方向へ遡り taskId に到達する場合 true (循環になる)。 */
 function wouldCreateCycle(tasks: Task[], taskId: string, newParentId: string): boolean {
@@ -30,7 +67,7 @@ export function createApiRouter(projectRoot: string): Router {
 
   const configStore = new ConfigStore(projectRoot);
 
-  // GET /api/config
+  // 設定取得: GET /api/config
   router.get("/api/config", async (_req, res) => {
     try {
       const config = await configStore.read();
@@ -40,7 +77,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // GET /api/tasks
+  // task一覧取得: GET /api/tasks
   router.get("/api/tasks", async (_req, res) => {
     try {
       await withProjectStorage(
@@ -78,7 +115,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // POST /api/tasks — create a draft task
+  // draft task作成: POST /api/tasks
   router.post("/api/tasks", async (req, res) => {
     try {
       await withProjectStorage(
@@ -88,15 +125,18 @@ export function createApiRouter(projectRoot: string): Router {
           const { configStore, tasksStore } = storage;
           const config = await configStore.read();
           const tasksFile = await tasksStore.read();
-          const { title, type, body, start_date, end_date } = req.body;
+          const rawBody = req.body as unknown;
 
-          if (!title || !type) {
+          if (
+            typeof rawBody !== "object" ||
+            rawBody === null ||
+            Array.isArray(rawBody) ||
+            !("title" in rawBody) ||
+            !("type" in rawBody) ||
+            !(rawBody as Record<string, unknown>).title ||
+            !(rawBody as Record<string, unknown>).type
+          ) {
             res.status(400).json({ error: "title and type are required" });
-            return;
-          }
-
-          if (!config.task_types[type]) {
-            res.status(400).json({ error: `Unknown task type: "${type}"` });
             return;
           }
 
@@ -104,14 +144,25 @@ export function createApiRouter(projectRoot: string): Router {
           // 生の "draft-1" / "293" のまま保存すると push の replaceTaskIdReferences /
           // id_map 照合 (正規形の完全一致) が効かず sub-issue 関係がスキップされるため、
           // CLI の create --parent (#302) と同じく resolveTaskId で正規形へ解決してから保存する
-          let parent: string | null = req.body.parent ?? null;
-          if (parent !== null && typeof parent !== "string") {
+          const rawParent = (rawBody as Record<string, unknown>).parent ?? null;
+          if (rawParent !== null && typeof rawParent !== "string") {
             res.status(400).json({ error: "parent must be a string or null" });
             return;
           }
+          let parent: string | null = rawParent;
           // 空文字・空白のみは正規化をすり抜けて参照整合性を壊すため明示的に拒否する
           if (parent !== null && parent.trim() === "") {
             res.status(400).json({ error: "parent must be a non-empty string or null" });
+            return;
+          }
+          const parsedBody = CreateTaskRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            res.status(400).json({ error: "Invalid task create request" });
+            return;
+          }
+          const { title, type, body, start_date, end_date } = parsedBody.data;
+          if (!config.task_types[type]) {
+            res.status(400).json({ error: `Unknown task type: "${type}"` });
             return;
           }
           if (parent) {
@@ -132,7 +183,7 @@ export function createApiRouter(projectRoot: string): Router {
           if (taskType.github_label) labels.push(taskType.github_label);
 
           const now = new Date().toISOString();
-          const task: Task = {
+          const task = TaskSchema.parse({
             id: taskId,
             type,
             github_issue: null,
@@ -162,7 +213,7 @@ export function createApiRouter(projectRoot: string): Router {
             end_date: end_date ?? null,
             date: null,
             blocked_by: [],
-          };
+          });
 
           // parent の存在は正規化時に検証済み (#319)
           if (parent) {
@@ -186,7 +237,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // PATCH /api/tasks/:id
+  // task更新: PATCH /api/tasks/:id
   router.patch("/api/tasks/:id", async (req, res) => {
     try {
       await withProjectStorage(
@@ -195,7 +246,11 @@ export function createApiRouter(projectRoot: string): Router {
         async (storage) => {
           const { configStore, tasksStore } = storage;
           const taskId = decodeURIComponent(req.params.id);
-          const updates = req.body;
+          let updates = req.body as Record<string, unknown>;
+          if (typeof updates !== "object" || updates === null || Array.isArray(updates)) {
+            res.status(400).json({ error: "Invalid task update request" });
+            return;
+          }
           const config = await configStore.read();
           const tasksFile = await tasksStore.read();
           const idx = tasksFile.tasks.findIndex((t) => t.id === taskId);
@@ -353,6 +408,13 @@ export function createApiRouter(projectRoot: string): Router {
             updates.blocked_by = normalizedDeps;
           }
 
+          const parsedUpdates = UpdateTaskRequestSchema.safeParse(updates);
+          if (!parsedUpdates.success) {
+            res.status(400).json({ error: "Invalid task update request" });
+            return;
+          }
+          updates = parsedUpdates.data;
+
           const safeUpdates: Partial<Task> = {};
           for (const key of UPDATABLE_FIELDS) {
             // parent は単純マージすると旧親・新親の sub_tasks 逆リンクが壊れるため、
@@ -393,7 +455,7 @@ export function createApiRouter(projectRoot: string): Router {
             }
           }
 
-          // Auto-update dates on status transition
+          // status遷移に応じて日付を自動更新する
           const statusField = config.statuses.field_name;
           const oldStatus = oldTask.custom_fields[statusField] as string | undefined;
           const newStatus = updatedTask.custom_fields[statusField] as string | undefined;
@@ -413,7 +475,7 @@ export function createApiRouter(projectRoot: string): Router {
               updatedTask.end_date = dateUpdates.end_date;
           }
 
-          // Prevent start > end regardless of how dates were changed
+          // 日付の変更経路にかかわらずstart > endを拒否する
           if (
             updatedTask.start_date &&
             updatedTask.end_date &&
@@ -425,7 +487,27 @@ export function createApiRouter(projectRoot: string): Router {
             return;
           }
 
-          tasksFile.tasks[idx] = updatedTask;
+          const effectiveParentId = "parent" in updates ? (updates.parent ?? null) : oldTask.parent;
+          if (("type" in updates || "parent" in updates) && effectiveParentId) {
+            const effectiveParent = tasksFile.tasks.find((task) => task.id === effectiveParentId);
+            if (effectiveParent) {
+              const allowed = config.type_hierarchy[effectiveParent.type];
+              if (allowed && allowed.length > 0 && !allowed.includes(updatedTask.type)) {
+                res.status(400).json({
+                  error: `Cannot place "${updatedTask.type}" under "${effectiveParent.type}"`,
+                });
+                return;
+              }
+            }
+          }
+
+          const parsedTask = TaskSchema.safeParse(updatedTask);
+          if (!parsedTask.success) {
+            res.status(400).json({ error: "Invalid task update request" });
+            return;
+          }
+
+          tasksFile.tasks[idx] = parsedTask.data;
 
           // parent の変更は /reparent と同一の setParent / removeParent に委譲し、
           // 自己参照の拒否と旧親・新親の sub_tasks 逆リンク維持を保証する
@@ -437,16 +519,6 @@ export function createApiRouter(projectRoot: string): Router {
               if (wouldCreateCycle(tasksFile.tasks, taskId, updates.parent as string)) {
                 res.status(400).json({ error: "This operation would create a cycle" });
                 return;
-              }
-              const newParentTask = tasksFile.tasks.find((t) => t.id === updates.parent);
-              if (newParentTask) {
-                const allowed = config.type_hierarchy[newParentTask.type];
-                if (allowed && allowed.length > 0 && !allowed.includes(updatedTask.type)) {
-                  res.status(400).json({
-                    error: `Cannot place "${updatedTask.type}" under "${newParentTask.type}"`,
-                  });
-                  return;
-                }
               }
               const parentResult = setParent(tasksFile.tasks, taskId, updates.parent as string);
               if (parentResult.error) {
@@ -469,7 +541,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // POST /api/tasks/:id/reparent
+  // 親変更: POST /api/tasks/:id/reparent
   router.post("/api/tasks/:id/reparent", async (req, res) => {
     try {
       await withProjectStorage(
@@ -522,7 +594,7 @@ export function createApiRouter(projectRoot: string): Router {
               return;
             }
 
-            // Cycle detection: walk up from newParentId, check we don't reach taskId
+            // newParentIdから親方向へ辿り、taskIdへ到達する循環を検出する
             if (wouldCreateCycle(tasksFile.tasks, taskId, newParentId)) {
               res
                 .status(400)
@@ -530,7 +602,7 @@ export function createApiRouter(projectRoot: string): Router {
               return;
             }
 
-            // Type hierarchy validation
+            // task typeの階層制約を検証する
             const allowed = config.type_hierarchy[parent.type];
             if (allowed && allowed.length > 0 && !allowed.includes(task.type)) {
               res.status(400).json({
@@ -568,7 +640,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // POST /api/sync/pull
+  // pull実行: POST /api/sync/pull
   router.post("/api/sync/pull", async (req, res) => {
     try {
       await withProjectStorage(
@@ -580,7 +652,7 @@ export function createApiRouter(projectRoot: string): Router {
           const tasksFile = await tasksStore.read();
           const syncState = await stateStore.read();
 
-          // Guard: Unresolved conflicts must be resolved before next pull
+          // 未解決conflictがある場合は次のpullを拒否する
           if (tasksFile.has_conflicts) {
             res.status(409).json({
               message: "未解決のコンフリクトがあります。先に resolve してください",
@@ -621,7 +693,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // POST /api/sync/push
+  // push実行: POST /api/sync/push
   router.post("/api/sync/push", async (req, res) => {
     try {
       await withProjectStorage(
@@ -633,7 +705,7 @@ export function createApiRouter(projectRoot: string): Router {
           const tasksFile = await tasksStore.read();
           const syncState = await stateStore.read();
 
-          // Guard: unresolved conflicts (not skippable with force)
+          // 未解決conflictはforceでも迂回させない
           if (tasksFile.has_conflicts) {
             res.status(409).json({
               message: "未解決のコンフリクトがあります。先に resolve してください",
@@ -687,7 +759,7 @@ export function createApiRouter(projectRoot: string): Router {
     }
   });
 
-  // GET /api/sync/status
+  // 同期状態取得: GET /api/sync/status
   router.get("/api/sync/status", async (_req, res) => {
     try {
       await withProjectStorage(

--- a/packages/cli/src/store/comments.ts
+++ b/packages/cli/src/store/comments.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { CommentsFileSchema, GANTT_DIR, COMMENTS_FILE } from "@gh-gantt/shared";
 import type { CommentsFile } from "@gh-gantt/shared";
@@ -6,23 +7,56 @@ import type { CommentsFile } from "@gh-gantt/shared";
 const EMPTY: CommentsFile = { version: "1", fetched_at: {}, comments: {} };
 
 export class CommentsStore {
-  private path: string;
+  private path: string | null;
+  private binding: {
+    readText(slot: "comments"): Promise<string | null>;
+    writeText(slot: "comments", content: string): Promise<void>;
+  } | null;
 
-  constructor(projectRoot: string) {
-    this.path = join(projectRoot, GANTT_DIR, COMMENTS_FILE);
+  constructor(
+    projectRootOrBinding:
+      | string
+      | {
+          readText(slot: "comments"): Promise<string | null>;
+          writeText(slot: "comments", content: string): Promise<void>;
+        },
+  ) {
+    this.path =
+      typeof projectRootOrBinding === "string"
+        ? join(projectRootOrBinding, GANTT_DIR, COMMENTS_FILE)
+        : null;
+    this.binding = typeof projectRootOrBinding === "string" ? null : projectRootOrBinding;
   }
 
   async read(): Promise<CommentsFile> {
     try {
-      const raw = await readFile(this.path, "utf-8");
+      const raw = this.binding
+        ? await this.binding.readText("comments")
+        : await readFile(this.path!, "utf-8");
+      if (raw === null) return { ...EMPTY, fetched_at: {}, comments: {} };
       return CommentsFileSchema.parse(JSON.parse(raw));
-    } catch {
-      return { ...EMPTY, fetched_at: {}, comments: {} };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { ...EMPTY, fetched_at: {}, comments: {} };
+      }
+      throw error;
     }
   }
 
   async write(data: CommentsFile): Promise<void> {
-    await mkdir(join(this.path, ".."), { recursive: true });
-    await writeFile(this.path, JSON.stringify(data, null, 2) + "\n");
+    const content = JSON.stringify(data, null, 2) + "\n";
+    if (this.binding) {
+      await this.binding.writeText("comments", content);
+      return;
+    }
+    await mkdir(join(this.path!, ".."), { recursive: true });
+    const temporary = `${this.path}.${randomUUID()}.tmp`;
+    await writeFile(temporary, content);
+    try {
+      await rename(temporary, this.path!);
+    } catch (error) {
+      await rm(temporary, { force: true }).catch(() => undefined);
+      throw error;
+    }
   }
 }

--- a/packages/cli/src/store/config.ts
+++ b/packages/cli/src/store/config.ts
@@ -6,14 +6,34 @@ import type { Config } from "@gh-gantt/shared";
 const DEFAULT_STARTS_WORK_NAMES = ["in progress", "in review", "active", "working"];
 
 export class ConfigStore {
-  private path: string;
+  private path: string | null;
+  private binding: {
+    readText(slot: "config"): Promise<string | null>;
+    writeText(slot: "config", content: string): Promise<void>;
+  } | null;
 
-  constructor(projectRoot: string) {
-    this.path = join(projectRoot, GANTT_DIR, CONFIG_FILE);
+  constructor(
+    projectRootOrBinding:
+      | string
+      | {
+          readText(slot: "config"): Promise<string | null>;
+          writeText(slot: "config", content: string): Promise<void>;
+        },
+  ) {
+    this.path =
+      typeof projectRootOrBinding === "string"
+        ? join(projectRootOrBinding, GANTT_DIR, CONFIG_FILE)
+        : null;
+    this.binding = typeof projectRootOrBinding === "string" ? null : projectRootOrBinding;
   }
 
   async read(): Promise<Config> {
-    const raw = await readFile(this.path, "utf-8");
+    const raw = this.binding
+      ? await this.binding.readText("config")
+      : await readFile(this.path!, "utf-8");
+    if (raw === null) {
+      throw Object.assign(new Error("gantt.config.json が見つかりません"), { code: "ENOENT" });
+    }
     const config = ConfigSchema.parse(JSON.parse(raw));
     // Auto-migrate: fill in starts_work for known status names
     for (const [name, sv] of Object.entries(config.statuses.values)) {
@@ -35,14 +55,20 @@ export class ConfigStore {
   }
 
   async write(config: Config): Promise<void> {
-    await mkdir(join(this.path, ".."), { recursive: true });
-    await writeFile(this.path, JSON.stringify(config, null, 2) + "\n");
+    const content = JSON.stringify(config, null, 2) + "\n";
+    if (this.binding) {
+      await this.binding.writeText("config", content);
+      return;
+    }
+    await mkdir(join(this.path!, ".."), { recursive: true });
+    await writeFile(this.path!, content);
   }
 
   /** ファイルの存在判定。ENOENT のみ false とし、権限エラー等は再 throw する。 */
   async exists(): Promise<boolean> {
+    if (this.binding) return (await this.binding.readText("config")) !== null;
     try {
-      await readFile(this.path);
+      await readFile(this.path!);
       return true;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;

--- a/packages/cli/src/store/loop-state.ts
+++ b/packages/cli/src/store/loop-state.ts
@@ -22,26 +22,49 @@ async function writeAtomic(filePath: string, content: string): Promise<void> {
  * `gh-gantt loop` コマンド経由でのみ操作する（ADR-016）。
  */
 export class LoopStateStore {
-  private path: string;
+  private path: string | null;
+  private binding: {
+    readText(slot: "loop-state"): Promise<string | null>;
+    writeText(slot: "loop-state", content: string): Promise<void>;
+  } | null;
 
-  constructor(projectRoot: string) {
-    this.path = join(projectRoot, GANTT_DIR, LOOP_STATE_FILE);
+  constructor(
+    projectRootOrBinding:
+      | string
+      | {
+          readText(slot: "loop-state"): Promise<string | null>;
+          writeText(slot: "loop-state", content: string): Promise<void>;
+        },
+  ) {
+    this.path =
+      typeof projectRootOrBinding === "string"
+        ? join(projectRootOrBinding, GANTT_DIR, LOOP_STATE_FILE)
+        : null;
+    this.binding = typeof projectRootOrBinding === "string" ? null : projectRootOrBinding;
   }
 
   /** ファイル不在（未初期化）は null を返す。破損・スキーマ不一致は例外を投げる。 */
   async readOrNull(): Promise<LoopState | null> {
-    let raw: string;
+    let raw: string | null;
     try {
-      raw = await readFile(this.path, "utf-8");
+      raw = this.binding
+        ? await this.binding.readText("loop-state")
+        : await readFile(this.path!, "utf-8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw err;
     }
+    if (raw === null) return null;
     return LoopStateSchema.parse(JSON.parse(raw));
   }
 
   async write(state: LoopState): Promise<void> {
-    await mkdir(join(this.path, ".."), { recursive: true });
-    await writeAtomic(this.path, JSON.stringify(state, null, 2) + "\n");
+    const content = JSON.stringify(state, null, 2) + "\n";
+    if (this.binding) {
+      await this.binding.writeText("loop-state", content);
+      return;
+    }
+    await mkdir(join(this.path!, ".."), { recursive: true });
+    await writeAtomic(this.path!, content);
   }
 }

--- a/packages/cli/src/store/project-storage.ts
+++ b/packages/cli/src/store/project-storage.ts
@@ -583,12 +583,21 @@ async function publishSnapshot(layout: GitLayout, tasks: string, syncState: stri
 }
 
 async function selectLegacyCandidate(
+  layout: GitLayout,
   candidates: LegacyCandidate[],
   source: string,
 ): Promise<LegacyCandidate> {
   const canonicalSource = await realpath(resolve(source));
+  const acceptedSources = new Set([canonicalSource]);
+  if (layout.relativeProjectRoot !== "") {
+    try {
+      acceptedSources.add(await realpath(join(canonicalSource, layout.relativeProjectRoot)));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
   for (const candidate of candidates) {
-    if ((await realpath(candidate.workspace)) === canonicalSource) return candidate;
+    if (acceptedSources.has(await realpath(candidate.workspace))) return candidate;
   }
   throw new ProjectStorageError(
     "LEGACY_SOURCE_NOT_FOUND",
@@ -652,7 +661,7 @@ async function migrateLegacy(layout: GitLayout, legacySource?: string): Promise<
     if (legacySource) {
       await publishLegacyCandidate(
         layout,
-        await selectLegacyCandidate(candidates, legacySource),
+        await selectLegacyCandidate(layout, candidates, legacySource),
         candidates,
       );
       return;
@@ -689,7 +698,7 @@ async function migrateLegacy(layout: GitLayout, legacySource?: string): Promise<
     if (legacySource) {
       await publishLegacyCandidate(
         layout,
-        await selectLegacyCandidate(candidates, legacySource),
+        await selectLegacyCandidate(layout, candidates, legacySource),
         candidates,
       );
       return;

--- a/packages/cli/src/store/project-storage.ts
+++ b/packages/cli/src/store/project-storage.ts
@@ -202,12 +202,41 @@ function isNotGitRepository(error: unknown): boolean {
   return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
 }
 
+function gitCommandEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  // pre-push等のGit hookはrepository選択用envをexportすることがある。
+  // projectRootを正本とするsubprocessへ継承すると、-Cよりenvが優先され別repositoryを操作し得る。
+  for (const name of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  ]) {
+    delete environment[name];
+  }
+  return environment;
+}
+
 async function runGit(projectRoot: string, args: string[]): Promise<string> {
   try {
     const result = await execFileAsync("git", ["-C", projectRoot, ...args], {
       encoding: "utf8",
       timeout: 10_000,
       maxBuffer: 4 * 1024 * 1024,
+      env: gitCommandEnvironment(),
     });
     return result.stdout.trim();
   } catch (error) {

--- a/packages/cli/src/store/project-storage.ts
+++ b/packages/cli/src/store/project-storage.ts
@@ -124,6 +124,19 @@ const LockOwnerSchema = z.object({
 
 type LockOwner = z.infer<typeof LockOwnerSchema>;
 
+const RecoveryClaimSchema = z.object({
+  schemaVersion: z.literal("1"),
+  expectedOwnerNonce: z.string().min(1),
+  claimant: z.object({
+    pid: z.number().int().positive(),
+    hostname: z.string().min(1),
+    nonce: z.string().min(1),
+    claimedAt: z.string().datetime(),
+  }),
+});
+
+type RecoveryClaim = z.infer<typeof RecoveryClaimSchema>;
+
 interface LegacyCandidate {
   workspace: string;
   tasks: string;
@@ -227,6 +240,8 @@ function gitCommandEnvironment(): NodeJS.ProcessEnv {
   ]) {
     delete environment[name];
   }
+  // Git の診断文を安定させ、non-git 判定がprocess localeに依存しないようにする。
+  environment.LC_ALL = "C";
   return environment;
 }
 
@@ -429,20 +444,58 @@ async function acquireLease(
         }
       }
 
-      if (existing && existing.hostname === dependencies.processIdentity.hostname) {
+      let recoveryClaim: RecoveryClaim | null = null;
+      try {
+        const rawClaim = await readOptional(join(layout.lockDir, "recovery-claim.json"));
+        if (rawClaim !== null) {
+          recoveryClaim = RecoveryClaimSchema.parse(JSON.parse(rawClaim));
+        }
+      } catch (claimError) {
+        throw new ProjectStorageError("CACHE_LOCK_INVALID", "lock recovery claim が不正です", {
+          cause: claimError,
+        });
+      }
+
+      if (
+        existing &&
+        recoveryClaim === null &&
+        existing.hostname === dependencies.processIdentity.hostname
+      ) {
         const alive = await dependencies.isProcessAlive(existing.pid);
         if (!alive) {
-          const confirmed = LockOwnerSchema.parse(
-            JSON.parse(await readFile(join(layout.lockDir, "owner.json"), "utf8")),
-          );
-          if (confirmed.nonce === existing.nonce) {
-            const recovered = `${layout.lockDir}.recovered-${existing.nonce}-${randomUUID()}`;
-            try {
+          const claim: RecoveryClaim = {
+            schemaVersion: "1",
+            expectedOwnerNonce: existing.nonce,
+            claimant: {
+              pid: owner.pid,
+              hostname: owner.hostname,
+              nonce: owner.nonce,
+              claimedAt: new Date().toISOString(),
+            },
+          };
+          try {
+            await writeFile(
+              join(layout.lockDir, "recovery-claim.json"),
+              `${JSON.stringify(claim, null, 2)}\n`,
+              { flag: "wx" },
+            );
+            const confirmed = LockOwnerSchema.parse(
+              JSON.parse(await readFile(join(layout.lockDir, "owner.json"), "utf8")),
+            );
+            if (confirmed.nonce === claim.expectedOwnerNonce) {
+              const recovered = `${layout.lockDir}.recovered-${existing.nonce}-${randomUUID()}`;
               await rename(layout.lockDir, recovered);
               await rm(recovered, { recursive: true, force: true });
               continue;
-            } catch (recoveryError) {
-              if ((recoveryError as NodeJS.ErrnoException).code !== "ENOENT") throw recoveryError;
+            }
+          } catch (recoveryError) {
+            const recoveryCode = (recoveryError as NodeJS.ErrnoException).code;
+            if (
+              recoveryCode !== "ENOENT" &&
+              recoveryCode !== "EEXIST" &&
+              recoveryCode !== "ENOTEMPTY"
+            ) {
+              throw recoveryError;
             }
           }
         }
@@ -733,7 +786,14 @@ class BoundStorageSession {
     if (this.layout.kind === "git" && (slot === "tasks" || slot === "sync-state")) {
       const generation = await readCurrentGeneration(this.layout);
       if (generation === null) return null;
-      return readOptional(generationPath(this.layout, generation, slot));
+      const content = await readOptional(generationPath(this.layout, generation, slot));
+      if (content === null) {
+        throw new ProjectStorageError(
+          "CACHE_SNAPSHOT_INCOMPLETE",
+          `CURRENT generation ${generation} に ${slot}.json がありません`,
+        );
+      }
+      return content;
     }
     return readOptional(await this.location(slot));
   }

--- a/packages/cli/src/store/project-storage.ts
+++ b/packages/cli/src/store/project-storage.ts
@@ -1,0 +1,869 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import {
+  CommentsFileSchema,
+  ConfigSchema,
+  GANTT_DIR,
+  SyncStateSchema,
+  TasksFileWithConflictsSchema,
+} from "@gh-gantt/shared";
+import { z } from "zod";
+import { CommentsStore } from "./comments.js";
+import { ConfigStore } from "./config.js";
+import { LoopStateStore } from "./loop-state.js";
+import { SyncStateStore } from "./state.js";
+import { TasksStore } from "./tasks.js";
+
+const execFileAsync = promisify(execFile);
+const LAYOUT_VERSION = "v1";
+const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
+const LOCK_POLL_INTERVAL_MS = 20;
+
+type ProjectStorageSlot =
+  | "config"
+  | "workflow"
+  | "tasks"
+  | "sync-state"
+  | "comments"
+  | "loop-state"
+  | "graph-contracts"
+  | "run-graph";
+
+type SharedSlot = "tasks" | "sync-state" | "comments";
+type StorageScope = "shared-cache" | "workspace" | "all";
+
+export interface ProjectStorageDependencies {
+  processIdentity: { pid: number; hostname: string };
+  isProcessAlive: (pid: number) => Promise<boolean>;
+  runGit: (projectRoot: string, args: string[]) => Promise<string>;
+}
+
+export interface ProjectStorageOptions {
+  mode: "read" | "write";
+  scope?: StorageScope;
+  waitTimeoutMs?: number;
+  dependencies?: ProjectStorageDependencies;
+  /** 分岐したlegacy cacheからoperatorが明示的に選ぶworktree root。 */
+  legacySource?: string;
+}
+
+export interface ProjectStorageSession {
+  readonly configStore: ConfigStore;
+  readonly tasksStore: TasksStore;
+  readonly stateStore: SyncStateStore;
+  readonly commentsStore: CommentsStore;
+  readonly loopStore: LoopStateStore;
+  /** legacy cache migrationを含む共有cacheの初期化を明示的に開始する。 */
+  ensureSharedCache(): Promise<void>;
+  /** 長いremote操作の途中で、整合したsnapshot-setを明示的にpublishする。 */
+  flush(): Promise<void>;
+}
+
+export class ProjectStorageError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ProjectStorageError";
+    this.code = code;
+  }
+}
+
+export function createProjectStorageDependencies(
+  overrides: Partial<ProjectStorageDependencies> = {},
+): ProjectStorageDependencies {
+  return {
+    processIdentity: overrides.processIdentity ?? { pid: process.pid, hostname: hostname() },
+    isProcessAlive:
+      overrides.isProcessAlive ??
+      (async (pid) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch (error) {
+          return (error as NodeJS.ErrnoException).code !== "ESRCH";
+        }
+      }),
+    runGit: overrides.runGit ?? runGit,
+  };
+}
+
+interface GitLayout {
+  kind: "git";
+  projectRoot: string;
+  topLevel: string;
+  commonDir: string;
+  relativeProjectRoot: string;
+  worktrees: string[];
+  projectIdentity: string;
+  namespaceRoot: string;
+  lockDir: string;
+}
+
+interface StandaloneLayout {
+  kind: "standalone";
+  projectRoot: string;
+}
+
+type StorageLayout = GitLayout | StandaloneLayout;
+
+const LockOwnerSchema = z.object({
+  schemaVersion: z.literal("1"),
+  group: z.literal("work-graph-cache"),
+  pid: z.number().int().positive(),
+  hostname: z.string().min(1),
+  startedAt: z.string().datetime(),
+  workspace: z.string().min(1),
+  access: z.enum(["read", "write"]),
+  nonce: z.string().min(1),
+});
+
+type LockOwner = z.infer<typeof LockOwnerSchema>;
+
+interface LegacyCandidate {
+  workspace: string;
+  tasks: string;
+  syncState: string;
+  comments: string | null;
+  fingerprint: string;
+}
+
+const MigrationManifestSchema = z.object({
+  schemaVersion: z.literal("1"),
+  projectIdentity: z.string().min(1),
+  selectedSource: z.string().min(1).nullable(),
+  legacyFingerprints: z.record(z.string(), z.string().regex(/^[0-9a-f]{64}$/)),
+});
+
+type MigrationManifest = z.infer<typeof MigrationManifestSchema>;
+
+const CurrentGenerationSchema = z.string().regex(/^[0-9a-f-]{36}$/);
+
+function isSharedSlot(slot: ProjectStorageSlot): slot is SharedSlot {
+  return slot === "tasks" || slot === "sync-state" || slot === "comments";
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    );
+  }
+  return value;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+async function readOptional(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temporary, content);
+  try {
+    await rename(temporary, path);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function parseWorktreeList(output: string): string[] {
+  return output
+    .split("\0")
+    .filter((entry) => entry.startsWith("worktree "))
+    .map((entry) => entry.slice("worktree ".length));
+}
+
+function isNotGitRepository(error: unknown): boolean {
+  const stderr = String((error as { stderr?: unknown }).stderr ?? "");
+  return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
+}
+
+async function runGit(projectRoot: string, args: string[]): Promise<string> {
+  try {
+    const result = await execFileAsync("git", ["-C", projectRoot, ...args], {
+      encoding: "utf8",
+      timeout: 10_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return result.stdout.trim();
+  } catch (error) {
+    if (isNotGitRepository(error)) {
+      throw new ProjectStorageError("NOT_A_GIT_REPOSITORY", "Git repository ではありません", {
+        cause: error,
+      });
+    }
+    throw new ProjectStorageError(
+      "GIT_DISCOVERY_FAILED",
+      `Git workspace の解決に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+async function readProjectIdentity(projectRoot: string): Promise<string> {
+  const configPath = join(projectRoot, GANTT_DIR, "gantt.config.json");
+  try {
+    const parsed = ConfigSchema.parse(JSON.parse(await readFile(configPath, "utf8")));
+    const github = parsed.project.github;
+    return `${github.owner.trim().toLowerCase()}/${github.repo.trim().toLowerCase()}#${github.project_number}`;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ProjectStorageError(
+        "PROJECT_CONFIG_MISSING",
+        `共有cacheのidentity解決に必要な設定がありません: ${configPath}`,
+        { cause: error },
+      );
+    }
+    throw new ProjectStorageError(
+      "PROJECT_CONFIG_INVALID",
+      `共有cacheのidentity解決に必要な設定が不正です: ${configPath}`,
+      { cause: error },
+    );
+  }
+}
+
+async function resolveLayout(
+  projectRoot: string,
+  dependencies: ProjectStorageDependencies,
+): Promise<StorageLayout> {
+  // standalone fallback は従来の caller 指定 path を維持する。Git 管理下では
+  // rev-parse / common-dir の結果だけを realpath して repository identity を揃える。
+  const absoluteRoot = resolve(projectRoot);
+  let topLevel: string;
+  try {
+    topLevel = await dependencies.runGit(absoluteRoot, ["rev-parse", "--show-toplevel"]);
+  } catch (error) {
+    if (error instanceof ProjectStorageError && error.code === "NOT_A_GIT_REPOSITORY") {
+      return { kind: "standalone", projectRoot: absoluteRoot };
+    }
+    if (error instanceof ProjectStorageError) throw error;
+    throw new ProjectStorageError(
+      "GIT_DISCOVERY_FAILED",
+      `Git workspace の解決に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  let rawCommonDir: string;
+  let worktreeOutput: string;
+  try {
+    rawCommonDir = await dependencies.runGit(absoluteRoot, ["rev-parse", "--git-common-dir"]);
+    worktreeOutput = await dependencies.runGit(absoluteRoot, [
+      "worktree",
+      "list",
+      "--porcelain",
+      "-z",
+    ]);
+  } catch (error) {
+    if (error instanceof ProjectStorageError) throw error;
+    throw new ProjectStorageError(
+      "GIT_DISCOVERY_FAILED",
+      `Git workspace の解決に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  const gitProjectRoot = await realpath(absoluteRoot);
+  const canonicalTopLevel = await realpath(topLevel);
+  const commonDir = await realpath(
+    isAbsolute(rawCommonDir) ? rawCommonDir : resolve(absoluteRoot, rawCommonDir),
+  );
+  const projectIdentity = await readProjectIdentity(gitProjectRoot);
+  const projectKey = fingerprint(projectIdentity).slice(0, 32);
+  const storageRoot = join(commonDir, "gh-gantt");
+  return {
+    kind: "git",
+    projectRoot: gitProjectRoot,
+    topLevel: canonicalTopLevel,
+    commonDir,
+    relativeProjectRoot: relative(canonicalTopLevel, gitProjectRoot),
+    worktrees: parseWorktreeList(worktreeOutput),
+    projectIdentity,
+    namespaceRoot: join(storageRoot, "cache", "project-storage", LAYOUT_VERSION, projectKey),
+    lockDir: join(storageRoot, "locks", "work-graph-cache.lock"),
+  };
+}
+
+function workspacePath(projectRoot: string, slot: ProjectStorageSlot): string {
+  const directory = join(projectRoot, GANTT_DIR);
+  switch (slot) {
+    case "config":
+      return join(directory, "gantt.config.json");
+    case "workflow":
+      return join(directory, "workflow.md");
+    case "tasks":
+      return join(directory, "tasks.json");
+    case "sync-state":
+      return join(directory, "sync-state.json");
+    case "comments":
+      return join(directory, "comments.json");
+    case "loop-state":
+      return join(directory, "loop-state.json");
+    case "graph-contracts":
+      return join(directory, "run-graph", "contracts");
+    case "run-graph":
+      return join(directory, "run-graph", "runs");
+  }
+}
+
+function sharedLocation(layout: GitLayout, slot: SharedSlot): string {
+  if (slot === "comments") return join(layout.namespaceRoot, "comments.json");
+  return join(layout.namespaceRoot, "current", `${slot}.json`);
+}
+
+function migrationPath(layout: GitLayout): string {
+  return join(layout.namespaceRoot, "migration.json");
+}
+
+function currentPath(layout: GitLayout): string {
+  return join(layout.namespaceRoot, "CURRENT");
+}
+
+async function readCurrentGeneration(layout: GitLayout): Promise<string | null> {
+  const raw = await readOptional(currentPath(layout));
+  if (raw === null) return null;
+  const parsed = CurrentGenerationSchema.safeParse(raw.trim());
+  if (!parsed.success) {
+    throw new ProjectStorageError("CACHE_CURRENT_INVALID", "CURRENT generation が不正です");
+  }
+  return parsed.data;
+}
+
+function generationPath(layout: GitLayout, generation: string, slot: "tasks" | "sync-state") {
+  return join(layout.namespaceRoot, "snapshots", generation, `${slot}.json`);
+}
+
+async function acquireLease(
+  layout: GitLayout,
+  options: ProjectStorageOptions,
+  dependencies: ProjectStorageDependencies,
+): Promise<() => Promise<void>> {
+  await mkdir(dirname(layout.lockDir), { recursive: true });
+  const owner: LockOwner = {
+    schemaVersion: "1",
+    group: "work-graph-cache",
+    pid: dependencies.processIdentity.pid,
+    hostname: dependencies.processIdentity.hostname,
+    startedAt: new Date().toISOString(),
+    workspace: layout.projectRoot,
+    access: options.mode,
+    nonce: randomUUID(),
+  };
+  const deadline = Date.now() + (options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+
+  while (true) {
+    const candidate = `${layout.lockDir}.candidate-${owner.nonce}`;
+    try {
+      await mkdir(candidate);
+      await writeFile(join(candidate, "owner.json"), `${JSON.stringify(owner, null, 2)}\n`, {
+        flag: "wx",
+      });
+      await rename(candidate, layout.lockDir);
+      break;
+    } catch (error) {
+      await rm(candidate, { recursive: true, force: true }).catch(() => undefined);
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "ENOTEMPTY") throw error;
+      let existing: LockOwner | null = null;
+      try {
+        existing = LockOwnerSchema.parse(
+          JSON.parse(await readFile(join(layout.lockDir, "owner.json"), "utf8")),
+        );
+      } catch (ownerError) {
+        if ((ownerError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new ProjectStorageError("CACHE_LOCK_INVALID", "lock owner record が不正です", {
+            cause: ownerError,
+          });
+        }
+      }
+
+      if (existing && existing.hostname === dependencies.processIdentity.hostname) {
+        const alive = await dependencies.isProcessAlive(existing.pid);
+        if (!alive) {
+          const confirmed = LockOwnerSchema.parse(
+            JSON.parse(await readFile(join(layout.lockDir, "owner.json"), "utf8")),
+          );
+          if (confirmed.nonce === existing.nonce) {
+            const recovered = `${layout.lockDir}.recovered-${existing.nonce}-${randomUUID()}`;
+            try {
+              await rename(layout.lockDir, recovered);
+              await rm(recovered, { recursive: true, force: true });
+              continue;
+            } catch (recoveryError) {
+              if ((recoveryError as NodeJS.ErrnoException).code !== "ENOENT") throw recoveryError;
+            }
+          }
+        }
+      }
+
+      if (Date.now() >= deadline) {
+        throw new ProjectStorageError(
+          "STORAGE_BUSY",
+          `Work Graph Cache は別processが使用中です${existing ? ` (pid=${existing.pid}, host=${existing.hostname})` : ""}`,
+        );
+      }
+      await sleep(LOCK_POLL_INTERVAL_MS);
+    }
+  }
+
+  return async () => {
+    let current: LockOwner;
+    try {
+      current = LockOwnerSchema.parse(
+        JSON.parse(await readFile(join(layout.lockDir, "owner.json"), "utf8")),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new ProjectStorageError("CACHE_LOCK_LOST", "解放対象のlockが見つかりません", {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    if (current.nonce !== owner.nonce) {
+      throw new ProjectStorageError("CACHE_LOCK_LOST", "解放対象のlock nonceが一致しません");
+    }
+
+    // active path を直接再帰削除すると、空directoryになった瞬間に別processが
+    // 新しいlockへ置換し、そのlockまで削除し得る。nonce固有pathへatomicに退避してから掃除する。
+    const retired = `${layout.lockDir}.retired-${owner.nonce}-${randomUUID()}`;
+    try {
+      await rename(layout.lockDir, retired);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new ProjectStorageError("CACHE_LOCK_LOST", "解放中にlockを失いました", {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    await rm(retired, { recursive: true, force: true }).catch(() => undefined);
+  };
+}
+
+async function readCandidate(
+  layout: GitLayout,
+  workspace: string,
+): Promise<LegacyCandidate | null> {
+  const root = join(workspace, layout.relativeProjectRoot);
+  const directory = join(root, GANTT_DIR);
+  const [tasks, syncState] = await Promise.all([
+    readOptional(join(directory, "tasks.json")),
+    readOptional(join(directory, "sync-state.json")),
+  ]);
+  if (tasks === null && syncState === null) return null;
+
+  let candidateIdentity: string;
+  try {
+    candidateIdentity = await readProjectIdentity(root);
+  } catch (error) {
+    throw new ProjectStorageError(
+      "LEGACY_CACHE_INVALID",
+      `legacy cache の project identity を検証できません: ${root}`,
+      { cause: error },
+    );
+  }
+  if (candidateIdentity !== layout.projectIdentity) return null;
+  if (tasks === null || syncState === null) {
+    throw new ProjectStorageError(
+      "LEGACY_CACHE_INCOMPLETE",
+      `legacy tasks/sync-state の片方だけが存在します: ${root}`,
+    );
+  }
+
+  try {
+    const parsedTasks = TasksFileWithConflictsSchema.parse(JSON.parse(tasks));
+    const parsedState = SyncStateSchema.parse(JSON.parse(syncState));
+    const legacyComments = await readOptional(join(directory, "comments.json"));
+    let comments: string | null = null;
+    if (legacyComments !== null) {
+      // comments はmerge baseではなく再構築可能なcacheなので、legacy破損時は
+      // tasks/sync-state migrationを止めず欠損として扱う。
+      const parsedComments = CommentsFileSchema.safeParse(
+        (() => {
+          try {
+            return JSON.parse(legacyComments);
+          } catch {
+            return undefined;
+          }
+        })(),
+      );
+      if (parsedComments.success) comments = legacyComments;
+    }
+    return {
+      workspace: root,
+      tasks,
+      syncState,
+      comments,
+      fingerprint: fingerprint({ tasks: parsedTasks, syncState: parsedState }),
+    };
+  } catch (error) {
+    throw new ProjectStorageError("LEGACY_CACHE_INVALID", `legacy cache が不正です: ${root}`, {
+      cause: error,
+    });
+  }
+}
+
+async function collectLegacyCandidates(layout: GitLayout): Promise<LegacyCandidate[]> {
+  const candidates = await Promise.all(
+    [...layout.worktrees].sort().map((worktree) => readCandidate(layout, worktree)),
+  );
+  return candidates.filter((candidate): candidate is LegacyCandidate => candidate !== null);
+}
+
+async function publishSnapshot(layout: GitLayout, tasks: string, syncState: string): Promise<void> {
+  try {
+    TasksFileWithConflictsSchema.parse(JSON.parse(tasks));
+    SyncStateSchema.parse(JSON.parse(syncState));
+  } catch (error) {
+    throw new ProjectStorageError("CACHE_SNAPSHOT_INVALID", "snapshot-set が不正です", {
+      cause: error,
+    });
+  }
+  const generation = randomUUID();
+  const directory = join(layout.namespaceRoot, "snapshots", generation);
+  await mkdir(directory, { recursive: true });
+  await Promise.all([
+    writeFile(join(directory, "tasks.json"), tasks, { flag: "wx" }),
+    writeFile(join(directory, "sync-state.json"), syncState, { flag: "wx" }),
+  ]);
+  await writeAtomic(currentPath(layout), `${generation}\n`);
+}
+
+async function selectLegacyCandidate(
+  candidates: LegacyCandidate[],
+  source: string,
+): Promise<LegacyCandidate> {
+  const canonicalSource = await realpath(resolve(source));
+  for (const candidate of candidates) {
+    if ((await realpath(candidate.workspace)) === canonicalSource) return candidate;
+  }
+  throw new ProjectStorageError(
+    "LEGACY_SOURCE_NOT_FOUND",
+    `指定したworktreeにlegacy cacheがありません: ${source}`,
+  );
+}
+
+async function writeMigrationManifest(
+  layout: GitLayout,
+  candidates: LegacyCandidate[],
+  selectedSource: string | null,
+): Promise<void> {
+  const migration: MigrationManifest = {
+    schemaVersion: "1",
+    projectIdentity: layout.projectIdentity,
+    selectedSource,
+    legacyFingerprints: Object.fromEntries(
+      candidates.map((candidate) => [candidate.workspace, candidate.fingerprint]),
+    ),
+  };
+  await writeAtomic(migrationPath(layout), `${JSON.stringify(migration, null, 2)}\n`);
+}
+
+async function publishLegacyCandidate(
+  layout: GitLayout,
+  candidate: LegacyCandidate,
+  candidates: LegacyCandidate[],
+): Promise<void> {
+  await publishSnapshot(layout, candidate.tasks, candidate.syncState);
+  if (candidate.comments !== null) {
+    await writeAtomic(join(layout.namespaceRoot, "comments.json"), candidate.comments);
+  }
+  await writeMigrationManifest(layout, candidates, candidate.workspace);
+}
+
+async function migrateLegacy(layout: GitLayout, legacySource?: string): Promise<void> {
+  const generation = await readCurrentGeneration(layout);
+  const candidates = await collectLegacyCandidates(layout);
+  const manifestRaw = await readOptional(migrationPath(layout));
+  let manifest: MigrationManifest | null = null;
+  if (manifestRaw !== null) {
+    try {
+      manifest = MigrationManifestSchema.parse(JSON.parse(manifestRaw));
+    } catch (error) {
+      throw new ProjectStorageError("MIGRATION_MANIFEST_INVALID", "migration manifest が不正です", {
+        cause: error,
+      });
+    }
+  }
+
+  if (generation !== null) {
+    if (candidates.length === 0) {
+      if (legacySource) {
+        throw new ProjectStorageError(
+          "LEGACY_SOURCE_NOT_FOUND",
+          `指定したworktreeにlegacy cacheがありません: ${legacySource}`,
+        );
+      }
+      return;
+    }
+    if (legacySource) {
+      await publishLegacyCandidate(
+        layout,
+        await selectLegacyCandidate(candidates, legacySource),
+        candidates,
+      );
+      return;
+    }
+    if (!manifest) {
+      throw new ProjectStorageError(
+        "LEGACY_CACHE_DIVERGED",
+        "共有cache作成後に記録のないlegacy cacheが見つかりました",
+      );
+    }
+    for (const candidate of candidates) {
+      if (manifest.legacyFingerprints[candidate.workspace] !== candidate.fingerprint) {
+        throw new ProjectStorageError(
+          "LEGACY_CACHE_DIVERGED",
+          `migration後にlegacy cacheが変更されました: ${candidate.workspace}。` +
+            "gh-gantt storage migrate --from <worktree> で正本を明示してください",
+        );
+      }
+    }
+    return;
+  }
+
+  if (candidates.length === 0) {
+    if (legacySource) {
+      throw new ProjectStorageError(
+        "LEGACY_SOURCE_NOT_FOUND",
+        `指定したworktreeにlegacy cacheがありません: ${legacySource}`,
+      );
+    }
+    return;
+  }
+  const expected = candidates[0].fingerprint;
+  if (candidates.some((candidate) => candidate.fingerprint !== expected)) {
+    if (legacySource) {
+      await publishLegacyCandidate(
+        layout,
+        await selectLegacyCandidate(candidates, legacySource),
+        candidates,
+      );
+      return;
+    }
+    throw new ProjectStorageError(
+      "LEGACY_CACHE_DIVERGED",
+      `worktree間でlegacy cacheが分岐しています: ${candidates.map((item) => item.workspace).join(", ")}。` +
+        "gh-gantt storage migrate --from <worktree> で正本を明示してください",
+    );
+  }
+
+  await publishLegacyCandidate(layout, candidates[0], candidates);
+}
+
+class BoundStorageSession {
+  private readonly staged = new Map<ProjectStorageSlot, string>();
+
+  constructor(
+    private readonly layout: StorageLayout,
+    private readonly options: ProjectStorageOptions,
+  ) {}
+
+  async location(slot: ProjectStorageSlot): Promise<string> {
+    if (this.layout.kind === "git" && isSharedSlot(slot)) {
+      return sharedLocation(this.layout, slot);
+    }
+    return workspacePath(this.layout.projectRoot, slot);
+  }
+
+  async readText(slot: ProjectStorageSlot): Promise<string | null> {
+    if (this.staged.has(slot)) return this.staged.get(slot) ?? null;
+    if (this.layout.kind === "git" && (slot === "tasks" || slot === "sync-state")) {
+      const generation = await readCurrentGeneration(this.layout);
+      if (generation === null) return null;
+      return readOptional(generationPath(this.layout, generation, slot));
+    }
+    return readOptional(await this.location(slot));
+  }
+
+  async writeText(slot: ProjectStorageSlot, content: string): Promise<void> {
+    if (this.options.mode !== "write") {
+      throw new ProjectStorageError("STORAGE_SCOPE_VIOLATION", "read scopeでは書き込めません");
+    }
+    const scope = this.options.scope ?? "workspace";
+    const allowed =
+      scope === "all" || (isSharedSlot(slot) ? scope === "shared-cache" : scope === "workspace");
+    if (!allowed) {
+      throw new ProjectStorageError(
+        "STORAGE_SCOPE_VIOLATION",
+        `${scope} scopeから${slot}へは書き込めません`,
+      );
+    }
+    this.staged.set(slot, content);
+  }
+
+  async commit(): Promise<void> {
+    if (this.options.mode !== "write" || this.staged.size === 0) return;
+    if (this.layout.kind === "standalone") {
+      await Promise.all(
+        [...this.staged].map(([slot, content]) =>
+          writeAtomic(workspacePath(this.layout.projectRoot, slot), content),
+        ),
+      );
+      this.staged.clear();
+      return;
+    }
+
+    const sharedDirty = this.staged.has("tasks") || this.staged.has("sync-state");
+    if (sharedDirty) {
+      const [tasks, syncState] = await Promise.all([
+        this.readText("tasks"),
+        this.readText("sync-state"),
+      ]);
+      if (tasks === null || syncState === null) {
+        throw new ProjectStorageError(
+          "CACHE_SNAPSHOT_INCOMPLETE",
+          "tasksとsync-stateは同じsnapshot-setとして必要です",
+        );
+      }
+      await publishSnapshot(this.layout, tasks, syncState);
+    }
+    if (this.staged.has("comments")) {
+      const comments = this.staged.get("comments")!;
+      try {
+        CommentsFileSchema.parse(JSON.parse(comments));
+      } catch (error) {
+        throw new ProjectStorageError("CACHE_COMMENTS_INVALID", "comments cacheが不正です", {
+          cause: error,
+        });
+      }
+      await writeAtomic(sharedLocation(this.layout, "comments"), comments);
+    }
+    if ((await readOptional(migrationPath(this.layout))) === null) {
+      const manifest: MigrationManifest = {
+        schemaVersion: "1",
+        projectIdentity: this.layout.projectIdentity,
+        selectedSource: null,
+        legacyFingerprints: {},
+      };
+      await writeAtomic(migrationPath(this.layout), `${JSON.stringify(manifest, null, 2)}\n`);
+    }
+    this.staged.clear();
+  }
+
+  async flush(): Promise<void> {
+    await this.commit();
+  }
+}
+
+interface InitializedStorage {
+  bound: BoundStorageSession;
+  release: () => Promise<void>;
+}
+
+class LazyProjectStorageSession implements ProjectStorageSession {
+  readonly configStore: ConfigStore;
+  readonly tasksStore: TasksStore;
+  readonly stateStore: SyncStateStore;
+  readonly commentsStore: CommentsStore;
+  readonly loopStore: LoopStateStore;
+  private initialized: Promise<InitializedStorage> | null = null;
+  private readonly workspace: BoundStorageSession;
+
+  constructor(
+    private readonly projectRoot: string,
+    private readonly options: ProjectStorageOptions,
+    private readonly dependencies: ProjectStorageDependencies,
+  ) {
+    const binding = {
+      readText: (slot: ProjectStorageSlot) => this.readText(slot),
+      writeText: (slot: ProjectStorageSlot, content: string) => this.writeText(slot, content),
+    };
+    this.workspace = new BoundStorageSession(
+      { kind: "standalone", projectRoot: resolve(projectRoot) },
+      options,
+    );
+    this.configStore = new ConfigStore(binding);
+    this.tasksStore = new TasksStore(binding);
+    this.stateStore = new SyncStateStore(binding);
+    this.commentsStore = new CommentsStore(binding);
+    this.loopStore = new LoopStateStore(binding);
+  }
+
+  private async initialize(): Promise<InitializedStorage> {
+    if (this.initialized) return this.initialized;
+    this.initialized = (async () => {
+      const layout = await resolveLayout(this.projectRoot, this.dependencies);
+      const release =
+        layout.kind === "git"
+          ? await acquireLease(layout, this.options, this.dependencies)
+          : async () => undefined;
+      try {
+        if (layout.kind === "git") await migrateLegacy(layout, this.options.legacySource);
+        return { bound: new BoundStorageSession(layout, this.options), release };
+      } catch (error) {
+        await release();
+        throw error;
+      }
+    })();
+    return this.initialized;
+  }
+
+  async ensureSharedCache(): Promise<void> {
+    await this.initialize();
+  }
+
+  private async readText(slot: ProjectStorageSlot): Promise<string | null> {
+    if (!isSharedSlot(slot)) return this.workspace.readText(slot);
+    return (await this.initialize()).bound.readText(slot);
+  }
+
+  private async writeText(slot: ProjectStorageSlot, content: string): Promise<void> {
+    if (!isSharedSlot(slot)) return this.workspace.writeText(slot, content);
+    return (await this.initialize()).bound.writeText(slot, content);
+  }
+
+  async flush(): Promise<void> {
+    await this.workspace.flush();
+    if (this.initialized) await (await this.initialized).bound.flush();
+  }
+
+  async finish(): Promise<void> {
+    await this.workspace.flush();
+    if (this.initialized) await (await this.initialized).bound.flush();
+  }
+
+  async close(): Promise<void> {
+    if (this.initialized) await (await this.initialized).release();
+  }
+}
+
+export async function withProjectStorage<T>(
+  projectRoot: string,
+  options: ProjectStorageOptions,
+  callback: (storage: ProjectStorageSession) => Promise<T>,
+): Promise<T> {
+  const dependencies = options.dependencies ?? createProjectStorageDependencies();
+  const session = new LazyProjectStorageSession(projectRoot, options, dependencies);
+  try {
+    const result = await callback(session);
+    await session.finish();
+    return result;
+  } finally {
+    await session.close();
+  }
+}

--- a/packages/cli/src/store/state.ts
+++ b/packages/cli/src/store/state.ts
@@ -16,14 +16,34 @@ async function writeAtomic(filePath: string, content: string): Promise<void> {
 }
 
 export class SyncStateStore {
-  private path: string;
+  private path: string | null;
+  private binding: {
+    readText(slot: "sync-state"): Promise<string | null>;
+    writeText(slot: "sync-state", content: string): Promise<void>;
+  } | null;
 
-  constructor(projectRoot: string) {
-    this.path = join(projectRoot, GANTT_DIR, SYNC_STATE_FILE);
+  constructor(
+    projectRootOrBinding:
+      | string
+      | {
+          readText(slot: "sync-state"): Promise<string | null>;
+          writeText(slot: "sync-state", content: string): Promise<void>;
+        },
+  ) {
+    this.path =
+      typeof projectRootOrBinding === "string"
+        ? join(projectRootOrBinding, GANTT_DIR, SYNC_STATE_FILE)
+        : null;
+    this.binding = typeof projectRootOrBinding === "string" ? null : projectRootOrBinding;
   }
 
   async read(): Promise<SyncState> {
-    const raw = await readFile(this.path, "utf-8");
+    const raw = this.binding
+      ? await this.binding.readText("sync-state")
+      : await readFile(this.path!, "utf-8");
+    if (raw === null) {
+      throw Object.assign(new Error("sync-state.json が見つかりません"), { code: "ENOENT" });
+    }
     return SyncStateSchema.parse(JSON.parse(raw));
   }
 
@@ -49,7 +69,12 @@ export class SyncStateStore {
   }
 
   async write(data: SyncState): Promise<void> {
-    await mkdir(join(this.path, ".."), { recursive: true });
-    await writeAtomic(this.path, JSON.stringify(data, null, 2) + "\n");
+    const content = JSON.stringify(data, null, 2) + "\n";
+    if (this.binding) {
+      await this.binding.writeText("sync-state", content);
+      return;
+    }
+    await mkdir(join(this.path!, ".."), { recursive: true });
+    await writeAtomic(this.path!, content);
   }
 }

--- a/packages/cli/src/store/tasks.ts
+++ b/packages/cli/src/store/tasks.ts
@@ -16,14 +16,34 @@ async function writeAtomic(filePath: string, content: string): Promise<void> {
 }
 
 export class TasksStore {
-  private path: string;
+  private path: string | null;
+  private binding: {
+    readText(slot: "tasks"): Promise<string | null>;
+    writeText(slot: "tasks", content: string): Promise<void>;
+  } | null;
 
-  constructor(projectRoot: string) {
-    this.path = join(projectRoot, GANTT_DIR, TASKS_FILE);
+  constructor(
+    projectRootOrBinding:
+      | string
+      | {
+          readText(slot: "tasks"): Promise<string | null>;
+          writeText(slot: "tasks", content: string): Promise<void>;
+        },
+  ) {
+    this.path =
+      typeof projectRootOrBinding === "string"
+        ? join(projectRootOrBinding, GANTT_DIR, TASKS_FILE)
+        : null;
+    this.binding = typeof projectRootOrBinding === "string" ? null : projectRootOrBinding;
   }
 
   async read(): Promise<TasksFile> {
-    const raw = await readFile(this.path, "utf-8");
+    const raw = this.binding
+      ? await this.binding.readText("tasks")
+      : await readFile(this.path!, "utf-8");
+    if (raw === null) {
+      throw Object.assign(new Error("tasks.json が見つかりません"), { code: "ENOENT" });
+    }
     return TasksFileWithConflictsSchema.parse(JSON.parse(raw)) as TasksFile;
   }
 
@@ -43,14 +63,20 @@ export class TasksStore {
   }
 
   async write(data: TasksFile): Promise<void> {
-    await mkdir(join(this.path, ".."), { recursive: true });
-    await writeAtomic(this.path, JSON.stringify(data, null, 2) + "\n");
+    const content = JSON.stringify(data, null, 2) + "\n";
+    if (this.binding) {
+      await this.binding.writeText("tasks", content);
+      return;
+    }
+    await mkdir(join(this.path!, ".."), { recursive: true });
+    await writeAtomic(this.path!, content);
   }
 
   /** ファイルの存在判定。ENOENT のみ false とし、権限エラー等は再 throw する。 */
   async exists(): Promise<boolean> {
+    if (this.binding) return (await this.binding.readText("tasks")) !== null;
     try {
-      await readFile(this.path);
+      await readFile(this.path!);
       return true;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;


### PR DESCRIPTION
## Summary

- Work Graph CacheをGit common dir配下のProject identity別namespaceへ移し、linked worktree間でtasks・sync-state・commentsを共有します
- tasks/sync-stateのatomic generation、repository lease、fail-closedなlegacy migrationと`storage migrate --from`を追加します
- CLI/API callerを型付きProject Storage seamへ統合し、Git hook由来のrepository選択envをsubprocessから分離します
- NFR-STABILITY-015-AC9とADR-023にhook環境の安全境界、および実linked worktreeとmock GitHub transportの証拠範囲を記録します

Closes #299

## Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（1,244 tests）
- `pnpm build`
- `pnpm req:trace`（covered 203 / uncovered 20 / failing 0）
- `pnpm req:validate`（既存23 warningsのみ）
- `pnpm docs:gen`
- pre-push hookのCI相当gate完走
- betterleaks native 1.5.0およびpin済みDocker 1.1.2で全branch差分・staged差分をscanし、漏洩0
- 実Git linked worktreeで`status`、GitHub transportをmockした`pull`、`push --dry-run`、別OS process leaseを検証

remote writeを伴うGitHub end-to-end smokeは実施していません。

