### PR TITLE
feat(ui): Project Map に planned-vs-actual Run Graph を表示する (#330)

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -160,10 +160,12 @@ JSON は shared の `ProjectMapRunGraphViewModel` を共用し、別々の状態
 | -------- | ------------------------------------------------------------------------ |
 | `taskId` | canonical task ID。draft task は Run Graph target を持たないため拒否する |
 | `runId`  | opaque run ID。task と一致しない run は 404                              |
-| `nodeId` | opaque node ID。該当しない場合は current node を選択する                 |
+| `nodeId` | opaque node ID。選択 run に存在しない場合は fail-closed で 404           |
 | `limit`  | run/node/attempt/artifact/evidence の上限。1〜50、既定20                 |
 
-レスポンスは `total / limit / truncated / items` を持つ。全 run history や log 本文は既定で返さない。
+レスポンスは run と planned node/edge に `total / limit / truncated / items` を持つ。API は各 run の
+先頭・末尾 event metadata を直列に確認して候補を先に絞り、journal 全文の replay は最大 `limit` 件に
+限定する。全 run history や log 本文は既定で返さない。
 URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時は古い node 選択を除去する。
 
 ### 11.2 状態と差分
@@ -172,7 +174,7 @@ URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時�
   `running / retrying` を加えた表示状態へ正規化する。正準 state 自体は変更しない。
 - actual transition を Graph Contract edge と stable ID で照合し、`unexpected_node`、
   `unexpected_edge`、`skip`、`retry`、`fallback`、`cancel` を差分として表示する。
-- attempt は actor、開始・終了時刻、duration、artifact/evidence の bounded 件数だけを表示する。
+- attempt は node/attempt ID、actor、開始・終了時刻、duration、artifact/evidence の bounded 件数だけを表示する。
 - accepted event timestamp から導出できる duration は既知値とする。現行 runner contract が保持しない
   token / cost / latency は `0` へ丸めず `unknown` とする。
 - Run Graph が存在しない project では空状態を表示し、従来の5パネルと task 編集を維持する。

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -166,7 +166,10 @@ JSON は shared の `ProjectMapRunGraphViewModel` を共用し、別々の状態
 レスポンスは run と planned node/edge に `total / limit / truncated / items` を持つ。accepted event の
 append 時に Zod 検証済みの task locator index を更新し、API request は task 単位の最大50件の summary と
 選択 run の locator だけを読む。既存 journal の index 再構築は server 起動時に request path 外で行い、
-journal 全文の replay は最大 `limit` 件に限定する。全 run history や log 本文は既定で返さない。
+journal 全文の replay は最大 `limit` 件に限定する。append は event 確定前に index を検証して pending
+transaction を永続化し、event 確定後の中断は次の append / 一覧取得 / server 起動時に bounded 修復する。
+locator writer は process 間 lease で直列化し、死亡 owner と死亡・期限切れ recovery claimant を再回収する。
+全 run history や log 本文は既定で返さない。
 URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時は古い node 選択を除去する。
 
 ### 11.2 状態と差分

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -156,16 +156,17 @@ JSON は shared の `ProjectMapRunGraphViewModel` を共用し、別々の状態
 
 ### 11.1 bounded API
 
-| query    | 意味                                                                     |
-| -------- | ------------------------------------------------------------------------ |
-| `taskId` | canonical task ID。draft task は Run Graph target を持たないため拒否する |
-| `runId`  | opaque run ID。task と一致しない run は 404                              |
-| `nodeId` | opaque node ID。選択 run に存在しない場合は fail-closed で 404           |
-| `limit`  | run/node/attempt/artifact/evidence の上限。1〜50、既定20                 |
+| query    | 意味                                                                            |
+| -------- | ------------------------------------------------------------------------------- |
+| `taskId` | 必須の canonical task ID。draft task は Run Graph target を持たないため拒否する |
+| `runId`  | opaque run ID。task と一致しない run は 404                                     |
+| `nodeId` | opaque node ID。選択 run に存在しない場合は fail-closed で 404                  |
+| `limit`  | run/node/attempt/artifact/evidence の上限。1〜50、既定20                        |
 
-レスポンスは run と planned node/edge に `total / limit / truncated / items` を持つ。API は各 run の
-先頭・末尾 event metadata を直列に確認して候補を先に絞り、journal 全文の replay は最大 `limit` 件に
-限定する。全 run history や log 本文は既定で返さない。
+レスポンスは run と planned node/edge に `total / limit / truncated / items` を持つ。accepted event の
+append 時に Zod 検証済みの task locator index を更新し、API request は task 単位の最大50件の summary と
+選択 run の locator だけを読む。既存 journal の index 再構築は server 起動時に request path 外で行い、
+journal 全文の replay は最大 `limit` 件に限定する。全 run history や log 本文は既定で返さない。
 URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時は古い node 選択を除去する。
 
 ### 11.2 状態と差分

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -23,19 +23,22 @@
 │ (左)          │ (中央)                │ (右)           │
 ├───────────────┴───────────┬───────────┴────────────────┤
 │ Next Actions              │ Compact Gantt / Timeline    │
-│ (下左)                    │ (下右)                      │
-└───────────────────────────┴─────────────────────────────┘
+│ (中左)                    │ (中右)                      │
+├───────────────────────────┴─────────────────────────────┤
+│ Planned vs Actual Run Graph                             │
+└────────────────────────────────────────────────────────┘
 ```
 
 UI 上の各パネル見出しは英語表記（括弧内）で表示される。
 
-| パネル                             | 責務                                                                      |
-| ---------------------------------- | ------------------------------------------------------------------------- |
-| システムツリー (System Tree)       | 全体構造を階層表示し、選択した Epic / Feature / Task を他パネルへ伝播する |
-| プロジェクトボード (Project Board) | 選択サブツリーのタスクを実行状態の列で表示する (`Ready Now` 列が要)       |
-| 依存関係マップ (Dependency Map)    | 選択サブツリーの上流 / 下流依存・クリティカルパスをグラフ表示する         |
-| 次のアクション (Next Actions)      | 次に着手すべきタスクをスコア順で理由付きに推薦する                        |
-| コンパクトガント (Compact Gantt)   | 選択サブツリーのスケジュールをミニタイムラインで読み取り専用表示する      |
+| パネル                             | 責務                                                                       |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| システムツリー (System Tree)       | 全体構造を階層表示し、選択した Epic / Feature / Task を他パネルへ伝播する  |
+| プロジェクトボード (Project Board) | 選択サブツリーのタスクを実行状態の列で表示する (`Ready Now` 列が要)        |
+| 依存関係マップ (Dependency Map)    | 選択サブツリーの上流 / 下流依存・クリティカルパスをグラフ表示する          |
+| 次のアクション (Next Actions)      | 次に着手すべきタスクをスコア順で理由付きに推薦する                         |
+| コンパクトガント (Compact Gantt)   | 選択サブツリーのスケジュールをミニタイムラインで読み取り専用表示する       |
+| 実行グラフ (Planned vs Actual)     | Graph Contract の計画と durable Run Graph の実績・差分・待機理由を表示する |
 
 ## 3. MVP / P1 / P2 の境界
 
@@ -142,5 +145,34 @@ score =
 ## 10. Graph Contractとの関係
 
 Project MapはWork Graphの派生viewであり、graph contractの正典はADR-021とする。
-本viewは実行履歴を生成せず、taskを暗黙に変更しない。planned-vs-actual表示は#330まで未実装である。
+本viewは実行履歴を生成せず、taskを暗黙に変更しない。#330 の planned-vs-actual 表示は
+#328 の immutable event store と control plane の bounded view だけを入力にし、runner log 本文を読まない。
 後続拡張は、#329のclaim/lease/joinと#331のapproval proposal/new plan versionをADR-021で確認する。
+
+## 11. Planned vs Actual Run Graph
+
+選択 task に紐づく run を `GET /api/project-map/run-graph` から取得する。operator UI と agent 向け
+JSON は shared の `ProjectMapRunGraphViewModel` を共用し、別々の状態判定を持たない。
+
+### 11.1 bounded API
+
+| query    | 意味                                                                     |
+| -------- | ------------------------------------------------------------------------ |
+| `taskId` | canonical task ID。draft task は Run Graph target を持たないため拒否する |
+| `runId`  | opaque run ID。task と一致しない run は 404                              |
+| `nodeId` | opaque node ID。該当しない場合は current node を選択する                 |
+| `limit`  | run/node/attempt/artifact/evidence の上限。1〜50、既定20                 |
+
+レスポンスは `total / limit / truncated / items` を持つ。全 run history や log 本文は既定で返さない。
+URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時は古い node 選択を除去する。
+
+### 11.2 状態と差分
+
+- run は `active / queued / waiting_human / failed / completed / cancelled`、node はこれに
+  `running / retrying` を加えた表示状態へ正規化する。正準 state 自体は変更しない。
+- actual transition を Graph Contract edge と stable ID で照合し、`unexpected_node`、
+  `unexpected_edge`、`skip`、`retry`、`fallback`、`cancel` を差分として表示する。
+- attempt は actor、開始・終了時刻、duration、artifact/evidence の bounded 件数だけを表示する。
+- accepted event timestamp から導出できる duration は既知値とする。現行 runner contract が保持しない
+  token / cost / latency は `0` へ丸めず `unknown` とする。
+- Run Graph が存在しない project では空状態を表示し、従来の5パネルと task 編集を維持する。

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -146,7 +146,7 @@ score =
 
 Project MapはWork Graphの派生viewであり、graph contractの正典はADR-021とする。
 本viewは実行履歴を生成せず、taskを暗黙に変更しない。#330 の planned-vs-actual 表示は
-#328 の immutable event store と control plane の bounded view だけを入力にし、runner log 本文を読まない。
+`#328` の immutable event store と control plane の bounded view だけを入力にし、runner log 本文を読まない。
 後続拡張は、#329のclaim/lease/joinと#331のapproval proposal/new plan versionをADR-021で確認する。
 
 ## 11. Planned vs Actual Run Graph
@@ -169,6 +169,8 @@ append 時に Zod 検証済みの task locator index を更新し、API request 
 journal 全文の replay は最大 `limit` 件に限定する。append は event 確定前に index を検証して pending
 transaction を永続化し、event 確定後の中断は次の append / 一覧取得 / server 起動時に bounded 修復する。
 locator writer は process 間 lease で直列化し、死亡 owner と死亡・期限切れ recovery claimant を再回収する。
+一覧取得も同じ lease 内で pending 修復・complete state 検証・index 読み取りを行う。live writer が
+100ms 以内に解放しない場合や complete state がない場合は、混在 snapshot を返さず 503 で fail-closed にする。
 全 run history や log 本文は既定で返さない。
 URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時は古い node 選択を除去する。
 
@@ -177,7 +179,8 @@ URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時�
 - run は `active / queued / waiting_human / failed / completed / cancelled`、node はこれに
   `running / retrying` を加えた表示状態へ正規化する。正準 state 自体は変更しない。
 - actual transition を Graph Contract edge と stable ID で照合し、`unexpected_node`、
-  `unexpected_edge`、`skip`、`retry`、`fallback`、`cancel` を差分として表示する。
+  `unexpected_edge`、`skip`、`retry`、`fallback`、`cancel` を差分として表示する。差分は最大200件に制限し、
+  超過時は `deviationsTruncated` で一部表示であることを示す。
 - attempt は node/attempt ID、actor、開始・終了時刻、duration、artifact/evidence の bounded 件数だけを表示する。
 - accepted event timestamp から導出できる duration は既知値とする。現行 runner contract が保持しない
   token / cost / latency は `0` へ丸めず `unknown` とする。

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1518,6 +1518,7 @@ areas:
             tests:
               - packages/cli/src/__tests__/run-command.test.ts
               - packages/cli/src/__tests__/run-graph-store.test.ts
+              - packages/cli/src/__tests__/server-api.test.ts
               - packages/shared/src/__tests__/run-graph.test.ts
               - tests/workflow/project-config.test.ts
           - id: NFR-STABILITY-014-AC2
@@ -1544,6 +1545,7 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/run-graph-store.test.ts
+              - packages/cli/src/__tests__/server-api.test.ts
               - packages/shared/src/__tests__/run-graph.test.ts
           - id: NFR-STABILITY-014-AC5
             description: |

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1029,9 +1029,10 @@ areas:
             tests:
               - packages/shared/src/__tests__/project-map.test.ts
           - id: FR-VIS-026-AC4
-            description: run ID と node ID の deep link、および 1 件以上 50 件以下に制限された bounded detail API を提供する
+            description: run ID と node ID の deep link、および task locator index により request 処理を 1 件以上 50 件以下に制限した bounded detail API を提供する
             status: covered
             tests:
+              - packages/cli/src/__tests__/run-graph-store.test.ts
               - packages/cli/src/__tests__/server-api.test.ts
               - packages/shared/src/__tests__/project-map.test.ts
               - packages/ui/src/__tests__/project-map-run-graph.test.tsx

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1010,6 +1010,42 @@ areas:
             status: covered
             tests:
               - packages/shared/src/__tests__/grouping.test.ts
+      - id: FR-VIS-026
+        summary: Project Map の planned-vs-actual Run Graph 観測
+        acceptance_criteria:
+          - id: FR-VIS-026-AC1
+            description: 選択した task と run の planned node・edge と actual node・transition を同じ ViewModel で識別できる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/project-map.test.ts
+          - id: FR-VIS-026-AC2
+            description: run と node の実行状態、待機理由、attempt の actor・開始終了時刻・duration・artifact/evidence 要約を確認できる
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/project-map.test.ts
+          - id: FR-VIS-026-AC3
+            description: retry・fallback・skip・cancel・planned にない node/edge を差分として表示し、取得できない token・cost・latency は 0 ではなく unknown とする
+            status: covered
+            tests:
+              - packages/shared/src/__tests__/project-map.test.ts
+          - id: FR-VIS-026-AC4
+            description: run ID と node ID の deep link、および 1 件以上 50 件以下に制限された bounded detail API を提供する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/server-api.test.ts
+              - packages/shared/src/__tests__/project-map.test.ts
+              - packages/ui/src/__tests__/project-map-run-graph.test.tsx
+          - id: FR-VIS-026-AC5
+            description: Run Graph が存在しない project でも従来の Project Map が動作し、実行履歴の空状態を表示する
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/server-api.test.ts
+              - packages/shared/src/__tests__/project-map.test.ts
+          - id: FR-VIS-026-AC6
+            description: planned-vs-actual panel をキーボードと支援技術から操作し、run と node を選択できる
+            status: covered
+            tests:
+              - packages/ui/src/__tests__/project-map-run-graph.test.tsx
   - id: STORE
     name: Data Store
     description: ローカルデータの永続化とバリデーション

--- a/packages/cli/src/__tests__/run-graph-control-plane.test.ts
+++ b/packages/cli/src/__tests__/run-graph-control-plane.test.ts
@@ -283,16 +283,66 @@ describe("[NFR-STABILITY-014-AC2] RunGraphControlPlane は start/applyEvent/insp
     expect(result.view).toMatchObject({
       state: "running",
       revision: 1,
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+      createdAt: timestamp,
+      updatedAt: timestamp,
       currentNode: { contractNodeId: "planner", state: "ready", activeAttemptId: null },
       activeAttempt: null,
       waitReason: null,
       allowedNextTransitions: ["attempt_started"],
+      nodes: { total: 1, limit: 20, truncated: false, items: [{ contractNodeId: "planner" }] },
+      attempts: { total: 0, limit: 20, truncated: false, items: [] },
     });
 
     const restored = await new RunGraphControlPlane(root, deterministicDependencies()).inspect(
       result.view.runId,
     );
     expect(restored).toEqual(result.view);
+  });
+
+  it("node と attempt の履歴を指定 limit で bounded view にする", async () => {
+    const { control } = await createControlPlane();
+    const runId = await startRun(control, "start-bounded-project-map-view");
+    await completeCurrentNode({
+      control,
+      runId,
+      role: "planner",
+      outcome: "plan_valid",
+      schemaId: "dev-role.plan",
+      prefix: "bounded-plan",
+    });
+
+    const view = await control.inspect(runId, 1);
+
+    expect(view.nodes).toMatchObject({ total: 2, limit: 1, truncated: true });
+    expect(view.nodes.items).toHaveLength(1);
+    expect(view.nodes.items[0]?.contractNodeId).toBe("implementer");
+    expect(view.attempts).toMatchObject({ total: 1, limit: 1, truncated: false });
+    expect(view.attempts.items[0]?.actor.id).toBe("planner-agent");
+  });
+
+  it("deep link 対象 node が末尾の limit 外でも bounded view に含める", async () => {
+    const { control } = await createControlPlane();
+    const runId = await startRun(control, "start-focused-project-map-view");
+    const started = await control.inspect(runId);
+    const plannerNodeId = started.currentNode?.id;
+    if (!plannerNodeId) throw new Error("planner node がありません");
+    await completeCurrentNode({
+      control,
+      runId,
+      role: "planner",
+      outcome: "plan_valid",
+      schemaId: "dev-role.plan",
+      prefix: "focused-plan",
+    });
+
+    const view = await control.inspect(runId, 1, plannerNodeId);
+
+    expect(view.nodes).toMatchObject({ total: 2, limit: 1, truncated: true });
+    expect(view.nodes.items.map((node) => node.id)).toEqual([plannerNodeId]);
+    expect(view.attempts.items.map((attempt) => attempt.nodeId)).toEqual([plannerNodeId]);
+    expect(view.artifacts.items.map((artifact) => artifact.nodeId)).toEqual([plannerNodeId]);
+    expect(view.evidence.items.map((evidence) => evidence.nodeId)).toEqual([plannerNodeId]);
   });
 
   it("unsupported binding と orchestrator 以外の start を fail-closed で拒否する", async () => {

--- a/packages/cli/src/__tests__/run-graph-store.test.ts
+++ b/packages/cli/src/__tests__/run-graph-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,6 +30,25 @@ const startEvent: RunGraphAcceptedEvent = {
   artifactIds: [],
   evidenceIds: [],
 };
+
+function startEventFor(
+  runId: string,
+  issueNumber: number,
+  acceptedAt: string,
+): RunGraphAcceptedEvent {
+  return {
+    ...startEvent,
+    eventId: `start-${runId}`,
+    runId,
+    acceptedAt,
+    command: {
+      type: "run_started",
+      task: { owner: "stanah", repo: "gh-gantt", issueNumber },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+      firstNodeId: "node-planner-1",
+    },
+  };
+}
 
 describe("[NFR-STABILITY-014-AC1] GraphContractStore は exact version binding を永続化する", () => {
   it("install 後に別 instance から同じ contract を取得できる", async () => {
@@ -78,6 +97,94 @@ describe("[NFR-STABILITY-014-AC4] RunGraphEventStore は immutable sequence segm
     expect(journal.acceptedEvents).toEqual([startEvent]);
     expect(journal.rejections).toEqual([rejection]);
     await expect(new RunGraphEventStore(root).listRunIds()).resolves.toEqual(["run-328"]);
+  });
+
+  it("task locator index から limit 件だけを返し request 時に全 Run を走査しない", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    for (let index = 0; index < 55; index += 1) {
+      await store.appendAccepted(
+        startEventFor(
+          `run-${index}`,
+          330,
+          `2026-07-30T00:${String(index).padStart(2, "0")}:00.000Z`,
+        ),
+      );
+    }
+    await store.appendAccepted(startEventFor("run-other-task", 331, "2026-07-30T00:04:00.000Z"));
+    vi.spyOn(store, "listRunIds").mockRejectedValue(new Error("全 Run 走査は禁止"));
+
+    await expect(
+      store.listRunLocators({
+        task: { owner: "STANAH", repo: "GH-GANTT", issueNumber: 330 },
+        limit: 1,
+        selectedRunId: "run-0",
+      }),
+    ).resolves.toEqual({
+      total: 55,
+      items: [
+        {
+          runId: "run-0",
+          task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+          updatedAt: "2026-07-30T00:00:00.000Z",
+        },
+      ],
+    });
+    const bounded = await store.listRunLocators({
+      task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+      limit: 50,
+    });
+    expect(bounded.total).toBe(55);
+    expect(bounded.items).toHaveLength(50);
+  });
+
+  it("破損した task locator index を Zod 境界で拒否する", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    await store.appendAccepted(startEventFor("run-corrupt", 330, "2026-07-30T00:00:00.000Z"));
+    const taskSegment = Buffer.from("stanah/gh-gantt#330", "utf8").toString("base64url");
+    await writeFile(
+      join(root, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "tasks", `${taskSegment}.json`),
+      JSON.stringify({
+        schemaVersion: "1",
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        total: "1",
+        items: [],
+      }),
+    );
+
+    await expect(
+      store.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("既存 journal の locator index を request path 外で一度だけ再構築する", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const legacy = startEventFor("legacy-run", 330, "2026-07-30T00:00:00.000Z");
+    const eventsDir = join(
+      root,
+      GANTT_DIR,
+      RUN_GRAPH_DIR,
+      RUN_GRAPH_RUNS_DIR,
+      Buffer.from(legacy.runId, "utf8").toString("base64url"),
+      "events",
+    );
+    await mkdir(eventsDir, { recursive: true });
+    await writeFile(join(eventsDir, "000000000001.json"), JSON.stringify(legacy));
+
+    const store = new RunGraphEventStore(root);
+    await store.ensureRunLocatorIndex();
+    vi.spyOn(store, "listRunIds").mockRejectedValue(new Error("再構築後の走査は禁止"));
+
+    await expect(
+      store.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({ total: 1, items: [{ runId: "legacy-run" }] });
   });
 
   it("duplicate event と連続しない sequence を追記しない", async () => {

--- a/packages/cli/src/__tests__/run-graph-store.test.ts
+++ b/packages/cli/src/__tests__/run-graph-store.test.ts
@@ -102,6 +102,7 @@ describe("[FR-VIS-026-AC4] [NFR-STABILITY-014-AC4] RunGraphEventStore は immuta
   it("[FR-VIS-026-AC4] task locator index から limit 件だけを返し request 時に全 Run を走査しない", async () => {
     const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
     const store = new RunGraphEventStore(root);
+    await store.ensureRunLocatorIndex();
     for (let index = 0; index < 55; index += 1) {
       await store.appendAccepted(
         startEventFor(
@@ -136,6 +137,114 @@ describe("[FR-VIS-026-AC4] [NFR-STABILITY-014-AC4] RunGraphEventStore は immuta
     });
     expect(bounded.total).toBe(55);
     expect(bounded.items).toHaveLength(50);
+  });
+
+  it("locator index には owner/repository を正規化した task を保存する", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    await store.ensureRunLocatorIndex();
+    const base = startEventFor("run-mixed-case", 330, "2026-07-30T00:00:00.000Z");
+    if (base.command.type !== "run_started") throw new Error("run_started event が必要です");
+    const mixedCase: RunGraphAcceptedEvent = {
+      ...base,
+      command: {
+        ...base.command,
+        task: { owner: "Stanah", repo: "GH-Gantt", issueNumber: 330 },
+      },
+    };
+
+    await store.appendAccepted(mixedCase);
+
+    await expect(
+      store.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({
+      items: [{ task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 } }],
+    });
+  });
+
+  it("writer lease が使用中なら pending の有無にかかわらず短時間で fail-closed にする", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    await store.appendAccepted(startEventFor("run-readable", 330, "2026-07-30T00:00:00.000Z"));
+    const lockDir = join(root, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "LOCK");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(
+      join(lockDir, "owner.json"),
+      JSON.stringify({
+        schemaVersion: "1",
+        pid: process.pid,
+        hostname: hostname(),
+        nonce: "00000000-0000-4000-8000-000000000003",
+      }),
+    );
+    const startedAt = Date.now();
+    await expect(
+      store.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).rejects.toMatchObject({ name: "RunGraphLocatorIndexBusyError" });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("pending transaction の修復 lease が使用中なら混在 snapshot を返さない", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    await store.appendAccepted(startEventFor("run-stable", 330, "2026-07-30T00:00:00.000Z"));
+    const interrupted = new RunGraphEventStore(root, {
+      afterJournalCommit: async () => {
+        throw new Error("process kill 境界の模擬");
+      },
+    });
+    await interrupted.appendAccepted(startEventFor("run-pending", 330, "2026-07-30T00:01:00.000Z"));
+    const lockDir = join(root, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "LOCK");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(
+      join(lockDir, "owner.json"),
+      JSON.stringify({
+        schemaVersion: "1",
+        pid: process.pid,
+        hostname: hostname(),
+        nonce: "00000000-0000-4000-8000-000000000004",
+      }),
+    );
+    const startedAt = Date.now();
+    await expect(
+      store.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).rejects.toMatchObject({ name: "RunGraphLocatorIndexBusyError" });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("complete state がない locator index を正常応答にしない", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const legacy = startEventFor("legacy-not-ready", 330, "2026-07-30T00:00:00.000Z");
+    const eventsDir = join(
+      root,
+      GANTT_DIR,
+      RUN_GRAPH_DIR,
+      RUN_GRAPH_RUNS_DIR,
+      Buffer.from(legacy.runId, "utf8").toString("base64url"),
+      "events",
+    );
+    await mkdir(eventsDir, { recursive: true });
+    await writeFile(join(eventsDir, "000000000001.json"), JSON.stringify(legacy));
+
+    await expect(
+      new RunGraphEventStore(root).listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).rejects.toMatchObject({ name: "RunGraphLocatorIndexNotReadyError" });
   });
 
   it("破損した task locator index を Zod 境界で拒否する", async () => {
@@ -192,6 +301,7 @@ describe("[FR-VIS-026-AC4] [NFR-STABILITY-014-AC4] RunGraphEventStore は immuta
 
   it("event 確定直後の中断を pending transaction から bounded 自動修復する", async () => {
     const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    await new RunGraphEventStore(root).ensureRunLocatorIndex();
     const interrupted = new RunGraphEventStore(root, {
       afterJournalCommit: async () => {
         throw new Error("process kill 境界の模擬");

--- a/packages/cli/src/__tests__/run-graph-store.test.ts
+++ b/packages/cli/src/__tests__/run-graph-store.test.ts
@@ -69,7 +69,7 @@ describe("[NFR-STABILITY-014-AC1] GraphContractStore は exact version binding �
   });
 });
 
-describe("[NFR-STABILITY-014-AC4] RunGraphEventStore は immutable sequence segment を正本にする", () => {
+describe("[FR-VIS-026-AC4] [NFR-STABILITY-014-AC4] RunGraphEventStore は immutable sequence segment を正本にする", () => {
   it("accepted event と rejection evidence を process 再生成後も同じ順序で読める", async () => {
     const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
     const store = new RunGraphEventStore(root);
@@ -99,7 +99,7 @@ describe("[NFR-STABILITY-014-AC4] RunGraphEventStore は immutable sequence segm
     await expect(new RunGraphEventStore(root).listRunIds()).resolves.toEqual(["run-328"]);
   });
 
-  it("task locator index から limit 件だけを返し request 時に全 Run を走査しない", async () => {
+  it("[FR-VIS-026-AC4] task locator index から limit 件だけを返し request 時に全 Run を走査しない", async () => {
     const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
     const store = new RunGraphEventStore(root);
     for (let index = 0; index < 55; index += 1) {

--- a/packages/cli/src/__tests__/run-graph-store.test.ts
+++ b/packages/cli/src/__tests__/run-graph-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
@@ -159,6 +159,92 @@ describe("[FR-VIS-026-AC4] [NFR-STABILITY-014-AC4] RunGraphEventStore は immuta
         limit: 20,
       }),
     ).rejects.toThrow();
+  });
+
+  it("index の事前検証に失敗した場合は accepted journal を増やさない", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const store = new RunGraphEventStore(root);
+    const started = startEventFor("run-preflight", 330, "2026-07-30T00:00:00.000Z");
+    await store.appendAccepted(started);
+    const taskSegment = Buffer.from("stanah/gh-gantt#330", "utf8").toString("base64url");
+    await writeFile(
+      join(root, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "tasks", `${taskSegment}.json`),
+      JSON.stringify({ schemaVersion: "1", total: "破損" }),
+    );
+
+    await expect(
+      store.appendAccepted({
+        ...started,
+        eventId: "attempt-after-corruption",
+        sequence: 2,
+        acceptedAt: "2026-07-30T00:01:00.000Z",
+        command: {
+          type: "attempt_started",
+          nodeId: "node-planner-1",
+          attemptId: "attempt-planner-1",
+        },
+      }),
+    ).rejects.toThrow();
+    await expect(store.readJournal(started.runId)).resolves.toMatchObject({
+      acceptedEvents: [{ eventId: started.eventId }],
+    });
+  });
+
+  it("event 確定直後の中断を pending transaction から bounded 自動修復する", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const interrupted = new RunGraphEventStore(root, {
+      afterJournalCommit: async () => {
+        throw new Error("process kill 境界の模擬");
+      },
+    });
+    const event = startEventFor("run-interrupted", 330, "2026-07-30T00:00:00.000Z");
+
+    await expect(interrupted.appendAccepted(event)).resolves.toBeUndefined();
+    const recovered = new RunGraphEventStore(root);
+    vi.spyOn(recovered, "listRunIds").mockRejectedValue(new Error("WAL修復で全Run走査は禁止"));
+    await expect(
+      recovered.listRunLocators({
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({ total: 1, items: [{ runId: event.runId }] });
+    await expect(recovered.readJournal(event.runId)).resolves.toMatchObject({
+      acceptedEvents: [{ eventId: event.eventId }],
+    });
+  });
+
+  it("stale recovery claimant ごと死亡 owner lease を再回収する", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-store-"));
+    const lockDir = join(root, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "LOCK");
+    await mkdir(lockDir, { recursive: true });
+    const ownerNonce = "00000000-0000-4000-8000-000000000001";
+    await writeFile(
+      join(lockDir, "owner.json"),
+      JSON.stringify({
+        schemaVersion: "1",
+        pid: 2_147_483_647,
+        hostname: hostname(),
+        nonce: ownerNonce,
+      }),
+    );
+    await writeFile(
+      join(lockDir, "recovery-claim.json"),
+      JSON.stringify({
+        schemaVersion: "1",
+        expectedOwnerNonce: ownerNonce,
+        claimant: {
+          pid: 2_147_483_646,
+          hostname: hostname(),
+          nonce: "00000000-0000-4000-8000-000000000002",
+          claimedAt: "2026-07-30T00:00:00.000Z",
+        },
+      }),
+    );
+
+    const store = new RunGraphEventStore(root);
+    await expect(
+      store.appendAccepted(startEventFor("run-after-stale-claim", 330, "2026-07-30T00:00:00.000Z")),
+    ).resolves.toBeUndefined();
   });
 
   it("既存 journal の locator index を request path 外で一度だけ再構築する", async () => {

--- a/packages/cli/src/__tests__/serve-command.test.ts
+++ b/packages/cli/src/__tests__/serve-command.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { RunGraphEventStore } from "../store/run-graph.js";
 
 const mocks = vi.hoisted(() => {
   const staticMiddleware = Symbol("staticMiddleware");
@@ -136,5 +137,19 @@ describe("serve コマンド", () => {
         middlewares.indexOf(mocks.rateLimitMiddleware),
       );
     });
+  });
+
+  it("locator index の準備に失敗した場合は fail-closed で server を起動しない", async () => {
+    const ensureRunLocatorIndex = vi
+      .spyOn(RunGraphEventStore.prototype, "ensureRunLocatorIndex")
+      .mockRejectedValueOnce(new Error("locator lease busy"));
+    const { serveCommand } = await import("../commands/serve.js");
+
+    await expect(
+      serveCommand.parseAsync(["serve", "--port", "0", "--api-only"], { from: "user" }),
+    ).rejects.toThrow("locator lease busy");
+
+    expect(mocks.app.listen).not.toHaveBeenCalled();
+    ensureRunLocatorIndex.mockRestore();
   });
 });

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -154,6 +154,45 @@ describe("createApiRouter", () => {
     ).resolves.toMatchObject({ statusCode: 404 });
   });
 
+  it("[FR-VIS-026-AC4] API request ごとの journal replay を limit 件に抑える", async () => {
+    await seedRunGraphProject();
+    await new GraphContractStore(dir).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+    const control = new RunGraphControlPlane(dir);
+    const runIds: string[] = [];
+    for (let index = 0; index < 3; index += 1) {
+      const started = await control.start({
+        schemaVersion: "1",
+        eventId: `bounded-start-${index}`,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        task: { owner: "o", repo: "r", issueNumber: 330 },
+        contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+      });
+      if (!started.accepted) throw new Error("run start failure");
+      runIds.push(started.view.runId);
+    }
+    await control.start({
+      schemaVersion: "1",
+      eventId: "bounded-start-other-task",
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      task: { owner: "o", repo: "r", issueNumber: 331 },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+    });
+    const inspect = vi.spyOn(RunGraphControlPlane.prototype, "inspect");
+
+    const response = await callRunGraphRoute({
+      taskId: "o/r#330",
+      runId: runIds[0],
+      limit: "1",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(runIds[0], 1, undefined);
+    expect(response.jsonPayload).toMatchObject({
+      runs: { total: 3, limit: 1, truncated: true, items: [{ runId: runIds[0] }] },
+    });
+  });
+
   it("[FR-VIS-026-AC5] Run Graph がなければ既存 task に空の overlay を返す", async () => {
     await seedRunGraphProject();
 
@@ -169,6 +208,7 @@ describe("createApiRouter", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
   });
 

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
@@ -9,7 +9,14 @@ import { GraphContractStore } from "../store/graph-contract.js";
 import { RunGraphEventStore } from "../store/run-graph.js";
 import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 import { createApiRouter } from "../server/api.js";
-import { FIXED_DEV_ROLE_GRAPH_CONTRACT, type Config, type Task } from "@gh-gantt/shared";
+import {
+  FIXED_DEV_ROLE_GRAPH_CONTRACT,
+  GANTT_DIR,
+  GRAPH_CONTRACTS_DIR,
+  RUN_GRAPH_DIR,
+  type Config,
+  type Task,
+} from "@gh-gantt/shared";
 
 describe("createApiRouter", () => {
   let dir: string;
@@ -71,6 +78,7 @@ describe("createApiRouter", () => {
     });
     await tasksStore.write({ tasks: [task], cache: { comments: {}, reactions: {} } });
     await commentsStore.write({ version: "1", fetched_at: {}, comments: {} });
+    await new RunGraphEventStore(dir).ensureRunLocatorIndex();
     return task;
   }
 
@@ -154,6 +162,55 @@ describe("createApiRouter", () => {
     await expect(
       callRunGraphRoute({ taskId: "o/r#330", runId: "missing-run", limit: "20" }),
     ).resolves.toMatchObject({ statusCode: 404 });
+  });
+
+  it("[NFR-STABILITY-014-AC4] locator writer が使用中なら短時間で 503 を返す", async () => {
+    await seedRunGraphProject();
+    const lockDir = join(dir, GANTT_DIR, RUN_GRAPH_DIR, "locator-index", "LOCK");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(
+      join(lockDir, "owner.json"),
+      JSON.stringify({
+        schemaVersion: "1",
+        pid: process.pid,
+        hostname: hostname(),
+        nonce: "00000000-0000-4000-8000-000000000005",
+      }),
+    );
+
+    const startedAt = Date.now();
+    const response = await callRunGraphRoute({ taskId: "o/r#330", limit: "20" });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(response.statusCode).toBe(503);
+    expect(response.jsonPayload).toEqual({
+      error: "Run Graph locator index is temporarily unavailable",
+    });
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("[NFR-STABILITY-014-AC1] binding 済み contract が欠損した Run Graph を fail-closed にする", async () => {
+    await seedRunGraphProject();
+    await new GraphContractStore(dir).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+    const started = await new RunGraphControlPlane(dir).start({
+      schemaVersion: "1",
+      eventId: "start-missing-contract",
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      task: { owner: "o", repo: "r", issueNumber: 330 },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+    });
+    if (!started.accepted) throw new Error("run start failure");
+    await rm(join(dir, GANTT_DIR, RUN_GRAPH_DIR, GRAPH_CONTRACTS_DIR), {
+      recursive: true,
+      force: true,
+    });
+
+    const response = await callRunGraphRoute({ taskId: "o/r#330", limit: "20" });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.jsonPayload).toMatchObject({
+      error: expect.stringContaining("Graph Contract が見つかりません"),
+    });
   });
 
   it("[FR-VIS-026-AC4] API request ごとの journal replay を limit 件に抑える", async () => {

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -5,14 +5,167 @@ import { join } from "node:path";
 import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
 import { CommentsStore } from "../store/comments.js";
+import { GraphContractStore } from "../store/graph-contract.js";
+import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 import { createApiRouter } from "../server/api.js";
-import type { Config, Task } from "@gh-gantt/shared";
+import { FIXED_DEV_ROLE_GRAPH_CONTRACT, type Config, type Task } from "@gh-gantt/shared";
 
 describe("createApiRouter", () => {
   let dir: string;
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "gh-gantt-api-test-"));
+  });
+
+  async function seedRunGraphProject(): Promise<Task> {
+    const configStore = new ConfigStore(dir);
+    const tasksStore = new TasksStore(dir);
+    const commentsStore = new CommentsStore(dir);
+    const task = {
+      id: "o/r#330",
+      type: "task",
+      github_issue: 330,
+      github_repo: "o/r",
+      parent: null,
+      sub_tasks: [],
+      title: "Run Graph を表示する",
+      body: null,
+      state: "open" as const,
+      state_reason: null,
+      assignees: [],
+      labels: [],
+      milestone: null,
+      linked_prs: [],
+      created_at: "2026-07-30T00:00:00.000Z",
+      updated_at: "2026-07-30T00:00:00.000Z",
+      closed_at: null,
+      acceptance_criteria: [],
+      acceptance_criteria_slot: false,
+      implementer: null,
+      reviewer: null,
+      require_review: false,
+      review_approved_by: null,
+      review_approved_at: null,
+      custom_fields: {},
+      start_date: null,
+      end_date: null,
+      date: null,
+      blocked_by: [],
+    } satisfies Task;
+    await configStore.write({
+      version: "1",
+      project: { name: "test", github: { owner: "o", repo: "r", project_number: 1 } },
+      sync: { auto_create_issues: false, field_mapping: { start_date: "S", end_date: "E" } },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#333333", github_label: null },
+      },
+      type_hierarchy: { task: [] },
+      statuses: { field_name: "Status", values: {} },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#f00", on_track: "#0f0", at_risk: "#ff0", overdue: "#f00" },
+      },
+      run_graph: { plan_id: "dev-role-fixed", plan_version: "1", schema_version: "1" },
+    });
+    await tasksStore.write({ tasks: [task], cache: { comments: {}, reactions: {} } });
+    await commentsStore.write({ version: "1", fetched_at: {}, comments: {} });
+    return task;
+  }
+
+  async function callRunGraphRoute(query: Record<string, unknown>) {
+    const router = createApiRouter(dir);
+    const routeLayer = router.stack.find(
+      (layer: any) => layer.route?.path === "/api/project-map/run-graph",
+    );
+    const handler = routeLayer?.route?.stack?.[0]?.handle as
+      | ((req: unknown, res: unknown) => Promise<void>)
+      | undefined;
+    if (!handler) throw new Error("GET /api/project-map/run-graph handler not found");
+    let statusCode = 200;
+    let jsonPayload: unknown;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+    await handler({ query }, res);
+    return { statusCode, jsonPayload };
+  }
+
+  it("[FR-VIS-026-AC4] GET /api/project-map/run-graph は run/node deep link を bounded detail で返す", async () => {
+    await seedRunGraphProject();
+    await new GraphContractStore(dir).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+    const started = await new RunGraphControlPlane(dir).start({
+      schemaVersion: "1",
+      eventId: "start-330",
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      task: { owner: "o", repo: "r", issueNumber: 330 },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+    });
+    if (!started.accepted || !started.view.currentNode) throw new Error("run start failure");
+
+    const response = await callRunGraphRoute({
+      taskId: "o/r#330",
+      runId: started.view.runId,
+      nodeId: started.view.currentNode.id,
+      limit: "1",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.jsonPayload).toMatchObject({
+      schemaVersion: "1",
+      taskId: "o/r#330",
+      runs: { total: 1, limit: 1, truncated: false },
+      selectedRun: {
+        runId: started.view.runId,
+        selectedNodeId: started.view.currentNode.id,
+        actual: {
+          nodes: [{ id: started.view.currentNode.id, contractNodeId: "planner" }],
+          nodesTruncated: false,
+        },
+      },
+    });
+    expect(JSON.stringify(response.jsonPayload)).not.toContain("runner log");
+
+    await expect(
+      callRunGraphRoute({
+        taskId: "o/r#330",
+        runId: started.view.runId,
+        nodeId: "missing-node",
+        limit: "1",
+      }),
+    ).resolves.toMatchObject({ statusCode: 404 });
+  });
+
+  it("[FR-VIS-026-AC4] detail limit の範囲外と未知 run を拒否する", async () => {
+    await seedRunGraphProject();
+
+    await expect(callRunGraphRoute({ taskId: "o/r#330", limit: "51" })).resolves.toMatchObject({
+      statusCode: 400,
+    });
+    await expect(
+      callRunGraphRoute({ taskId: "o/r#330", runId: "missing-run", limit: "20" }),
+    ).resolves.toMatchObject({ statusCode: 404 });
+  });
+
+  it("[FR-VIS-026-AC5] Run Graph がなければ既存 task に空の overlay を返す", async () => {
+    await seedRunGraphProject();
+
+    const response = await callRunGraphRoute({ taskId: "o/r#330", limit: "20" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.jsonPayload).toEqual({
+      schemaVersion: "1",
+      taskId: "o/r#330",
+      runs: { total: 0, limit: 20, truncated: false, items: [] },
+      selectedRun: null,
+    });
   });
 
   afterEach(async () => {

--- a/packages/cli/src/__tests__/server-api.test.ts
+++ b/packages/cli/src/__tests__/server-api.test.ts
@@ -6,6 +6,7 @@ import { ConfigStore } from "../store/config.js";
 import { TasksStore } from "../store/tasks.js";
 import { CommentsStore } from "../store/comments.js";
 import { GraphContractStore } from "../store/graph-contract.js";
+import { RunGraphEventStore } from "../store/run-graph.js";
 import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 import { createApiRouter } from "../server/api.js";
 import { FIXED_DEV_ROLE_GRAPH_CONTRACT, type Config, type Task } from "@gh-gantt/shared";
@@ -146,6 +147,7 @@ describe("createApiRouter", () => {
   it("[FR-VIS-026-AC4] detail limit の範囲外と未知 run を拒否する", async () => {
     await seedRunGraphProject();
 
+    await expect(callRunGraphRoute({ limit: "20" })).resolves.toMatchObject({ statusCode: 400 });
     await expect(callRunGraphRoute({ taskId: "o/r#330", limit: "51" })).resolves.toMatchObject({
       statusCode: 400,
     });
@@ -178,6 +180,9 @@ describe("createApiRouter", () => {
       contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
     });
     const inspect = vi.spyOn(RunGraphControlPlane.prototype, "inspect");
+    const listRunIds = vi
+      .spyOn(RunGraphEventStore.prototype, "listRunIds")
+      .mockRejectedValue(new Error("request path の全 Run 走査は禁止"));
 
     const response = await callRunGraphRoute({
       taskId: "o/r#330",
@@ -187,6 +192,7 @@ describe("createApiRouter", () => {
 
     expect(response.statusCode).toBe(200);
     expect(inspect).toHaveBeenCalledTimes(1);
+    expect(listRunIds).not.toHaveBeenCalled();
     expect(inspect).toHaveBeenCalledWith(runIds[0], 1, undefined);
     expect(response.jsonPayload).toMatchObject({
       runs: { total: 3, limit: 1, truncated: true, items: [{ runId: runIds[0] }] },

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createApiRouter } from "../server/api.js";
+import { RunGraphEventStore } from "../store/run-graph.js";
 import { DEFAULT_PORT } from "@gh-gantt/shared";
 
 export function resolveUiDistPath(moduleUrl = import.meta.url): string | null {
@@ -39,6 +40,9 @@ export const serveCommand = new Command("serve")
       }
       next();
     });
+
+    // 旧 Run Graph の locator は request path 外で一度だけ再構築する。
+    await new RunGraphEventStore(projectRoot).ensureRunLocatorIndex();
 
     // API は gh-gantt を実行したプロジェクトの同期データを読む。
     const apiRouter = createApiRouter(projectRoot);

--- a/packages/cli/src/run-graph/control-plane.ts
+++ b/packages/cli/src/run-graph/control-plane.ts
@@ -64,6 +64,23 @@ function referencedIds(command: RunGraphRunnerCommandInput["command"]): {
   return { artifactIds: command.artifactIds, evidenceIds: command.evidenceIds };
 }
 
+function boundedTailWithFocus<T>(
+  items: T[],
+  limit: number,
+  matchesFocus: ((item: T) => boolean) | null,
+): T[] {
+  const tail = items.slice(-limit);
+  if (!matchesFocus) return tail;
+  const focused = items.filter(matchesFocus).slice(-limit);
+  if (focused.length === 0) return tail;
+  const focusedSet = new Set(focused);
+  const remaining = Math.max(0, limit - focused.length);
+  const tailCompanions =
+    remaining === 0 ? [] : tail.filter((item) => !focusedSet.has(item)).slice(-remaining);
+  const selected = new Set([...focused, ...tailCompanions]);
+  return items.filter((item) => selected.has(item));
+}
+
 function contractSchemaKey(schemaId: string, schemaVersion: string): string {
   return `${schemaId}@${schemaVersion}`;
 }
@@ -685,7 +702,7 @@ export class RunGraphControlPlane {
     return { accepted: true, view: await this.inspect(input.runId) };
   }
 
-  async inspect(runId: string, limit = 20): Promise<RunGraphView> {
+  async inspect(runId: string, limit = 20, focusNodeId?: string): Promise<RunGraphView> {
     const journal = await this.events.readJournal(runId);
     const projection = this.replay(journal);
     const currentNode =
@@ -693,14 +710,35 @@ export class RunGraphControlPlane {
     const activeAttempt = currentNode?.activeAttemptId
       ? (projection.attempts.find((attempt) => attempt.id === currentNode.activeAttemptId) ?? null)
       : null;
-    const artifacts = projection.artifacts.slice(-limit);
-    const evidence = projection.evidence.slice(-limit);
+    const nodes = boundedTailWithFocus(
+      projection.nodes,
+      limit,
+      focusNodeId ? (node) => node.id === focusNodeId : null,
+    );
+    const attempts = boundedTailWithFocus(
+      projection.attempts,
+      limit,
+      focusNodeId ? (attempt) => attempt.nodeId === focusNodeId : null,
+    );
+    const artifacts = boundedTailWithFocus(
+      projection.artifacts,
+      limit,
+      focusNodeId ? (artifact) => artifact.nodeId === focusNodeId : null,
+    );
+    const evidence = boundedTailWithFocus(
+      projection.evidence,
+      limit,
+      focusNodeId ? (item) => item.nodeId === focusNodeId : null,
+    );
     return RunGraphViewSchema.parse({
       schemaVersion: "1",
       runId: projection.run.id,
       task: projection.run.task,
+      contract: projection.run.contract,
       revision: projection.revision,
       state: projection.run.state,
+      createdAt: projection.run.createdAt,
+      updatedAt: projection.run.updatedAt,
       currentNode,
       activeAttempt,
       waitReason:
@@ -710,6 +748,18 @@ export class RunGraphControlPlane {
           : null,
       budgets: projection.budgets,
       allowedNextTransitions: this.allowedNextTransitions(projection, currentNode, activeAttempt),
+      nodes: {
+        total: projection.nodes.length,
+        limit,
+        truncated: projection.nodes.length > nodes.length,
+        items: nodes,
+      },
+      attempts: {
+        total: projection.attempts.length,
+        limit,
+        truncated: projection.attempts.length > attempts.length,
+        items: attempts,
+      },
       artifacts: {
         total: projection.artifacts.length,
         limit,

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -12,7 +12,15 @@ import { createGraphQLClient } from "../github/client.js";
 import { buildDraftTaskId, getNextDraftNumber } from "../github/issues.js";
 import { resolveTaskId } from "../util/task-id.js";
 import type { Task, StatusValue, Dependency } from "@gh-gantt/shared";
-import { computeStatusDateUpdates, DependencySchema, TaskSchema } from "@gh-gantt/shared";
+import {
+  buildProjectMapRunGraphViewModel,
+  computeStatusDateUpdates,
+  DependencySchema,
+  TaskSchema,
+} from "@gh-gantt/shared";
+import { GraphContractStore } from "../store/graph-contract.js";
+import { RunGraphEventStore } from "../store/run-graph.js";
+import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 
 const CreateTaskRequestSchema = z
   .object({
@@ -49,6 +57,24 @@ const UpdateTaskRequestSchema = z
     sub_tasks: z.unknown().optional(),
   })
   .strict();
+
+const ProjectMapRunGraphQuerySchema = z
+  .object({
+    taskId: z.string().trim().min(1).max(500).optional(),
+    runId: z.string().trim().min(1).max(200).optional(),
+    nodeId: z.string().trim().min(1).max(200).optional(),
+    limit: z.coerce.number().int().min(1).max(50).default(20),
+  })
+  .strict()
+  .superRefine((query, context) => {
+    if (query.nodeId && !query.runId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["nodeId"],
+        message: "nodeId requires runId",
+      });
+    }
+  });
 
 /** newParentId から親方向へ遡り taskId に到達する場合 true (循環になる)。 */
 function wouldCreateCycle(tasks: Task[], taskId: string, newParentId: string): boolean {
@@ -636,6 +662,101 @@ export function createApiRouter(projectRoot: string): Router {
     } catch (err) {
       res.status(500).json({
         error: "Failed to reparent task: " + (err instanceof Error ? err.message : String(err)),
+      });
+    }
+  });
+
+  // planned-vs-actual Run Graph: GET /api/project-map/run-graph
+  router.get("/api/project-map/run-graph", async (req, res) => {
+    const query = ProjectMapRunGraphQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: "Invalid Project Map Run Graph query" });
+      return;
+    }
+
+    try {
+      const selectedTask = query.data.taskId
+        ? await withProjectStorage(
+            projectRoot,
+            { mode: "read", scope: "shared-cache" },
+            async ({ tasksStore }) => {
+              const tasksFile = await tasksStore.read();
+              return tasksFile.tasks.find((task) => task.id === query.data.taskId) ?? null;
+            },
+          )
+        : null;
+      if (query.data.taskId && !selectedTask) {
+        res.status(404).json({ error: "Task not found" });
+        return;
+      }
+      if (selectedTask && selectedTask.github_issue == null) {
+        res.status(400).json({ error: "Draft task does not have a Run Graph target" });
+        return;
+      }
+
+      const eventStore = new RunGraphEventStore(projectRoot);
+      const controlPlane = new RunGraphControlPlane(projectRoot);
+      const views = await Promise.all(
+        (await eventStore.listRunIds()).map((runId) =>
+          controlPlane.inspect(
+            runId,
+            query.data.limit,
+            runId === query.data.runId ? query.data.nodeId : undefined,
+          ),
+        ),
+      );
+      const filteredViews = selectedTask
+        ? views.filter(
+            (view) =>
+              view.task.issueNumber === selectedTask.github_issue &&
+              `${view.task.owner}/${view.task.repo}`.toLowerCase() ===
+                selectedTask.github_repo.toLowerCase(),
+          )
+        : views;
+      if (query.data.runId && !filteredViews.some((view) => view.runId === query.data.runId)) {
+        res.status(404).json({ error: "Run Graph not found for the selected task" });
+        return;
+      }
+
+      const sortedViews = [...filteredViews].sort(
+        (left, right) =>
+          Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+          left.runId.localeCompare(right.runId),
+      );
+      const selectedView = query.data.runId
+        ? (sortedViews.find((view) => view.runId === query.data.runId) ?? null)
+        : (sortedViews[0] ?? null);
+      if (
+        query.data.nodeId &&
+        !selectedView?.nodes.items.some((node) => node.id === query.data.nodeId)
+      ) {
+        res.status(404).json({ error: "Run Graph node not found" });
+        return;
+      }
+      const contract = selectedView
+        ? await new GraphContractStore(projectRoot).read(selectedView.contract)
+        : null;
+      const taskId =
+        selectedTask?.id ??
+        (selectedView
+          ? `${selectedView.task.owner}/${selectedView.task.repo}#${selectedView.task.issueNumber}`
+          : null);
+
+      res.json(
+        buildProjectMapRunGraphViewModel({
+          taskId,
+          contract,
+          runViews: filteredViews,
+          selectedRunId: selectedView?.runId ?? null,
+          selectedNodeId: query.data.nodeId ?? null,
+          limit: query.data.limit,
+        }),
+      );
+    } catch (error) {
+      res.status(500).json({
+        error:
+          "Failed to build Project Map Run Graph: " +
+          (error instanceof Error ? error.message : String(error)),
       });
     }
   });

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -61,7 +61,7 @@ const UpdateTaskRequestSchema = z
 
 const ProjectMapRunGraphQuerySchema = z
   .object({
-    taskId: z.string().trim().min(1).max(500).optional(),
+    taskId: z.string().trim().min(1).max(500),
     runId: z.string().trim().min(1).max(200).optional(),
     nodeId: z.string().trim().min(1).max(200).optional(),
     limit: z.coerce.number().int().min(1).max(50).default(20),
@@ -676,32 +676,29 @@ export function createApiRouter(projectRoot: string): Router {
     }
 
     try {
-      const selectedTask = query.data.taskId
-        ? await withProjectStorage(
-            projectRoot,
-            { mode: "read", scope: "shared-cache" },
-            async ({ tasksStore }) => {
-              const tasksFile = await tasksStore.read();
-              return tasksFile.tasks.find((task) => task.id === query.data.taskId) ?? null;
-            },
-          )
-        : null;
-      if (query.data.taskId && !selectedTask) {
+      const selectedTask = await withProjectStorage(
+        projectRoot,
+        { mode: "read", scope: "shared-cache" },
+        async ({ tasksStore }) => {
+          const tasksFile = await tasksStore.read();
+          return tasksFile.tasks.find((task) => task.id === query.data.taskId) ?? null;
+        },
+      );
+      if (!selectedTask) {
         res.status(404).json({ error: "Task not found" });
         return;
       }
-      if (selectedTask && selectedTask.github_issue == null) {
+      if (selectedTask.github_issue == null) {
         res.status(400).json({ error: "Draft task does not have a Run Graph target" });
         return;
       }
 
       const eventStore = new RunGraphEventStore(projectRoot);
       const controlPlane = new RunGraphControlPlane(projectRoot);
-      const [owner, repo] = selectedTask?.github_repo.split("/") ?? [];
+      const [owner, repo] = selectedTask.github_repo.split("/");
+      if (!owner || !repo) throw new Error("Task github_repo が owner/repo 形式ではありません");
       const locators = await eventStore.listRunLocators({
-        ...(selectedTask && owner && repo
-          ? { task: { owner, repo, issueNumber: selectedTask.github_issue! } }
-          : {}),
+        task: { owner, repo, issueNumber: selectedTask.github_issue },
         limit: query.data.limit,
         ...(query.data.runId ? { selectedRunId: query.data.runId } : {}),
       });
@@ -732,11 +729,7 @@ export function createApiRouter(projectRoot: string): Router {
       const contract = selectedView
         ? await new GraphContractStore(projectRoot).read(selectedView.contract)
         : null;
-      const taskId =
-        selectedTask?.id ??
-        (selectedView
-          ? `${selectedView.task.owner}/${selectedView.task.repo}#${selectedView.task.issueNumber}`
-          : null);
+      const taskId = selectedTask.id;
 
       res.json(
         ProjectMapRunGraphViewModelSchema.parse(

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -20,7 +20,11 @@ import {
   TaskSchema,
 } from "@gh-gantt/shared";
 import { GraphContractStore } from "../store/graph-contract.js";
-import { RunGraphEventStore } from "../store/run-graph.js";
+import {
+  RunGraphEventStore,
+  RunGraphLocatorIndexBusyError,
+  RunGraphLocatorIndexNotReadyError,
+} from "../store/run-graph.js";
 import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 
 const CreateTaskRequestSchema = z
@@ -745,6 +749,13 @@ export function createApiRouter(projectRoot: string): Router {
         ),
       );
     } catch (error) {
+      if (
+        error instanceof RunGraphLocatorIndexBusyError ||
+        error instanceof RunGraphLocatorIndexNotReadyError
+      ) {
+        res.status(503).json({ error: "Run Graph locator index is temporarily unavailable" });
+        return;
+      }
       res.status(500).json({
         error:
           "Failed to build Project Map Run Graph: " +

--- a/packages/cli/src/server/api.ts
+++ b/packages/cli/src/server/api.ts
@@ -16,6 +16,7 @@ import {
   buildProjectMapRunGraphViewModel,
   computeStatusDateUpdates,
   DependencySchema,
+  ProjectMapRunGraphViewModelSchema,
   TaskSchema,
 } from "@gh-gantt/shared";
 import { GraphContractStore } from "../store/graph-contract.js";
@@ -696,36 +697,31 @@ export function createApiRouter(projectRoot: string): Router {
 
       const eventStore = new RunGraphEventStore(projectRoot);
       const controlPlane = new RunGraphControlPlane(projectRoot);
-      const views = await Promise.all(
-        (await eventStore.listRunIds()).map((runId) =>
-          controlPlane.inspect(
-            runId,
-            query.data.limit,
-            runId === query.data.runId ? query.data.nodeId : undefined,
-          ),
-        ),
-      );
-      const filteredViews = selectedTask
-        ? views.filter(
-            (view) =>
-              view.task.issueNumber === selectedTask.github_issue &&
-              `${view.task.owner}/${view.task.repo}`.toLowerCase() ===
-                selectedTask.github_repo.toLowerCase(),
-          )
-        : views;
-      if (query.data.runId && !filteredViews.some((view) => view.runId === query.data.runId)) {
+      const [owner, repo] = selectedTask?.github_repo.split("/") ?? [];
+      const locators = await eventStore.listRunLocators({
+        ...(selectedTask && owner && repo
+          ? { task: { owner, repo, issueNumber: selectedTask.github_issue! } }
+          : {}),
+        limit: query.data.limit,
+        ...(query.data.runId ? { selectedRunId: query.data.runId } : {}),
+      });
+      if (query.data.runId && !locators.items.some((item) => item.runId === query.data.runId)) {
         res.status(404).json({ error: "Run Graph not found for the selected task" });
         return;
       }
-
-      const sortedViews = [...filteredViews].sort(
-        (left, right) =>
-          Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
-          left.runId.localeCompare(right.runId),
-      );
+      const views = [];
+      for (const locator of locators.items) {
+        views.push(
+          await controlPlane.inspect(
+            locator.runId,
+            query.data.limit,
+            locator.runId === query.data.runId ? query.data.nodeId : undefined,
+          ),
+        );
+      }
       const selectedView = query.data.runId
-        ? (sortedViews.find((view) => view.runId === query.data.runId) ?? null)
-        : (sortedViews[0] ?? null);
+        ? (views.find((view) => view.runId === query.data.runId) ?? null)
+        : (views[0] ?? null);
       if (
         query.data.nodeId &&
         !selectedView?.nodes.items.some((node) => node.id === query.data.nodeId)
@@ -743,14 +739,17 @@ export function createApiRouter(projectRoot: string): Router {
           : null);
 
       res.json(
-        buildProjectMapRunGraphViewModel({
-          taskId,
-          contract,
-          runViews: filteredViews,
-          selectedRunId: selectedView?.runId ?? null,
-          selectedNodeId: query.data.nodeId ?? null,
-          limit: query.data.limit,
-        }),
+        ProjectMapRunGraphViewModelSchema.parse(
+          buildProjectMapRunGraphViewModel({
+            taskId,
+            contract,
+            runViews: views,
+            selectedRunId: selectedView?.runId ?? null,
+            selectedNodeId: query.data.nodeId ?? null,
+            limit: query.data.limit,
+            totalRuns: locators.total,
+          }),
+        ),
       );
     } catch (error) {
       res.status(500).json({

--- a/packages/cli/src/store/run-graph.ts
+++ b/packages/cli/src/store/run-graph.ts
@@ -52,6 +52,15 @@ export interface RunGraphEventStoreDependencies {
 const RUN_GRAPH_LOCATOR_INDEX_DIR = "locator-index";
 const RUN_GRAPH_LOCATOR_INDEX_LIMIT = 50;
 const RECOVERY_CLAIM_STALE_MS = 60_000;
+const RUN_GRAPH_LOCATOR_READ_LEASE_TIMEOUT_MS = 100;
+
+export class RunGraphLocatorIndexBusyError extends Error {
+  override readonly name = "RunGraphLocatorIndexBusyError";
+}
+
+export class RunGraphLocatorIndexNotReadyError extends Error {
+  override readonly name = "RunGraphLocatorIndexNotReadyError";
+}
 
 const RunGraphTaskSchema = z
   .object({
@@ -226,7 +235,10 @@ async function sleep(milliseconds: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() => Promise<void>> {
+async function acquireLocatorIndexLease(
+  locatorIndexRoot: string,
+  timeoutMs = 30_000,
+): Promise<() => Promise<void>> {
   await mkdir(locatorIndexRoot, { recursive: true });
   const lockDir = join(locatorIndexRoot, "LOCK");
   const owner = RunGraphLocatorIndexLockOwnerSchema.parse({
@@ -235,7 +247,7 @@ async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() =>
     hostname: hostname(),
     nonce: randomUUID(),
   });
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + timeoutMs;
 
   while (true) {
     const candidate = `${lockDir}.candidate-${owner.nonce}`;
@@ -334,7 +346,7 @@ async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() =>
         }
       }
       if (Date.now() >= deadline) {
-        throw new Error(
+        throw new RunGraphLocatorIndexBusyError(
           `Run Graph locator index は別 process が使用中です (pid=${existing.pid}, host=${existing.hostname})`,
         );
       }
@@ -359,8 +371,9 @@ async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() =>
 async function withLocatorIndexLease<T>(
   locatorIndexRoot: string,
   operation: () => Promise<T>,
+  timeoutMs = 30_000,
 ): Promise<T> {
-  const release = await acquireLocatorIndexLease(locatorIndexRoot);
+  const release = await acquireLocatorIndexLease(locatorIndexRoot, timeoutMs);
   try {
     return await operation();
   } finally {
@@ -550,14 +563,17 @@ export class RunGraphEventStore {
         : RunGraphAcceptedEventReadSchema.parse(
             JSON.parse(await readFile(join(eventsDir, lastFile), "utf8")),
           );
-    return { runId, task: first.command.task, updatedAt: last.acceptedAt };
+    return { runId, task: normalizedTask(first.command.task), updatedAt: last.acceptedAt };
   }
 
   private async prepareLocatorTransaction(
     event: RunGraphAcceptedEvent,
     input: RunGraphRunLocator,
   ): Promise<RunGraphPendingLocatorTransaction> {
-    const locator = RunGraphRunLocatorSchema.parse(input);
+    const locator = RunGraphRunLocatorSchema.parse({
+      ...input,
+      task: normalizedTask(input.task),
+    });
     const locatorPath = this.locatorPath(locator.runId);
     const previousLocator = await readJsonOptional(locatorPath, RunGraphRunLocatorSchema);
     if (previousLocator && !sameTask(previousLocator.task, locator.task)) {
@@ -701,8 +717,7 @@ export class RunGraphEventStore {
     total: number;
     items: RunGraphRunLocator[];
   }> {
-    return withLocatorIndexLease(this.locatorIndexRoot, async () => {
-      await this.recoverPendingLocatorTransaction();
+    const readStableIndex = async () => {
       const limit = Math.min(50, Math.max(1, input.limit));
       const index = await readJsonOptional(
         this.taskLocatorIndexPath(input.task),
@@ -728,6 +743,23 @@ export class RunGraphEventStore {
         }
       }
       return { total: index?.total ?? 0, items };
-    });
+    };
+    return withLocatorIndexLease(
+      this.locatorIndexRoot,
+      async () => {
+        await this.recoverPendingLocatorTransaction();
+        const state = await readJsonOptional(
+          this.locatorIndexStatePath(),
+          RunGraphLocatorIndexStateSchema,
+        );
+        if (!state) {
+          throw new RunGraphLocatorIndexNotReadyError(
+            "Run Graph locator index の complete state がありません",
+          );
+        }
+        return readStableIndex();
+      },
+      RUN_GRAPH_LOCATOR_READ_LEASE_TIMEOUT_MS,
+    );
   }
 }

--- a/packages/cli/src/store/run-graph.ts
+++ b/packages/cli/src/store/run-graph.ts
@@ -1,5 +1,8 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import {
   GANTT_DIR,
   RUN_GRAPH_DIR,
@@ -21,10 +24,92 @@ export interface RunGraphRunLocator {
 }
 
 export interface RunGraphRunLocatorQuery {
-  task?: { owner: string; repo: string; issueNumber: number };
+  task: { owner: string; repo: string; issueNumber: number };
   limit: number;
   selectedRunId?: string;
 }
+
+interface RunGraphTaskLocatorIndex {
+  schemaVersion: "1";
+  task: { owner: string; repo: string; issueNumber: number };
+  total: number;
+  items: RunGraphRunLocator[];
+}
+
+const RUN_GRAPH_LOCATOR_INDEX_DIR = "locator-index";
+const RUN_GRAPH_LOCATOR_INDEX_LIMIT = 50;
+
+const RunGraphTaskSchema = z
+  .object({
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+    issueNumber: z.number().int().positive(),
+  })
+  .strict();
+
+const RunGraphRunLocatorSchema: z.ZodType<RunGraphRunLocator> = z
+  .object({
+    runId: z.string().min(1),
+    task: RunGraphTaskSchema,
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const RunGraphTaskLocatorIndexSchema: z.ZodType<RunGraphTaskLocatorIndex> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    task: RunGraphTaskSchema,
+    total: z.number().int().nonnegative(),
+    items: z.array(RunGraphRunLocatorSchema).max(RUN_GRAPH_LOCATOR_INDEX_LIMIT),
+  })
+  .strict()
+  .superRefine((index, context) => {
+    if (index.items.length > index.total) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "locator items は total 以下である必要があります",
+      });
+    }
+    if (new Set(index.items.map((item) => item.runId)).size !== index.items.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "locator runId は一意である必要があります",
+      });
+    }
+    if (index.items.some((item) => !sameTask(item.task, index.task))) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "locator task は index task と一致する必要があります",
+      });
+    }
+  });
+
+const RunGraphLocatorIndexStateSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    rebuiltAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const RunGraphLocatorIndexLockOwnerSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    pid: z.number().int().positive(),
+    hostname: z.string().min(1),
+    nonce: z.string().uuid(),
+  })
+  .strict();
+
+const RunGraphLocatorIndexRecoveryClaimSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    expectedOwnerNonce: z.string().uuid(),
+    claimantNonce: z.string().uuid(),
+  })
+  .strict();
 
 function safeSegment(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
@@ -32,6 +117,161 @@ function safeSegment(value: string): string {
 
 function restoreSegment(value: string): string {
   return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function normalizedTask(task: RunGraphRunLocator["task"]): RunGraphRunLocator["task"] {
+  return {
+    owner: task.owner.toLowerCase(),
+    repo: task.repo.toLowerCase(),
+    issueNumber: task.issueNumber,
+  };
+}
+
+function taskKey(task: RunGraphRunLocator["task"]): string {
+  const normalized = normalizedTask(task);
+  return `${normalized.owner}/${normalized.repo}#${normalized.issueNumber}`;
+}
+
+function sameTask(left: RunGraphRunLocator["task"], right: RunGraphRunLocator["task"]): boolean {
+  return taskKey(left) === taskKey(right);
+}
+
+function sortLocators(locators: RunGraphRunLocator[]): RunGraphRunLocator[] {
+  return [...locators].sort(
+    (left, right) =>
+      Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+      left.runId.localeCompare(right.runId),
+  );
+}
+
+async function readJsonOptional<T>(path: string, schema: z.ZodType<T>): Promise<T | null> {
+  try {
+    return schema.parse(JSON.parse(await readFile(path, "utf8")));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temporary, JSON.stringify(value, null, 2) + "\n");
+  try {
+    await rename(temporary, path);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() => Promise<void>> {
+  await mkdir(locatorIndexRoot, { recursive: true });
+  const lockDir = join(locatorIndexRoot, "LOCK");
+  const owner = RunGraphLocatorIndexLockOwnerSchema.parse({
+    schemaVersion: "1",
+    pid: process.pid,
+    hostname: hostname(),
+    nonce: randomUUID(),
+  });
+  const deadline = Date.now() + 30_000;
+
+  while (true) {
+    const candidate = `${lockDir}.candidate-${owner.nonce}`;
+    try {
+      await mkdir(candidate);
+      await writeJsonAtomic(join(candidate, "owner.json"), owner);
+      await rename(candidate, lockDir);
+      break;
+    } catch (error) {
+      await rm(candidate, { recursive: true, force: true }).catch(() => undefined);
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "ENOTEMPTY") throw error;
+
+      const existing = await readJsonOptional(
+        join(lockDir, "owner.json"),
+        RunGraphLocatorIndexLockOwnerSchema,
+      );
+      if (!existing) continue;
+      const claimPath = join(lockDir, "recovery-claim.json");
+      const recoveryClaim = await readJsonOptional(
+        claimPath,
+        RunGraphLocatorIndexRecoveryClaimSchema,
+      );
+      if (!recoveryClaim && existing.hostname === owner.hostname && !isProcessAlive(existing.pid)) {
+        const claim = RunGraphLocatorIndexRecoveryClaimSchema.parse({
+          schemaVersion: "1",
+          expectedOwnerNonce: existing.nonce,
+          claimantNonce: owner.nonce,
+        });
+        try {
+          await writeFile(claimPath, JSON.stringify(claim, null, 2) + "\n", { flag: "wx" });
+          const confirmed = await readJsonOptional(
+            join(lockDir, "owner.json"),
+            RunGraphLocatorIndexLockOwnerSchema,
+          );
+          if (confirmed?.nonce === claim.expectedOwnerNonce) {
+            const recovered = `${lockDir}.recovered-${existing.nonce}-${randomUUID()}`;
+            await rename(lockDir, recovered);
+            await rm(recovered, { recursive: true, force: true });
+            continue;
+          }
+        } catch (recoveryError) {
+          const recoveryCode = (recoveryError as NodeJS.ErrnoException).code;
+          if (
+            recoveryCode !== "ENOENT" &&
+            recoveryCode !== "EEXIST" &&
+            recoveryCode !== "ENOTEMPTY"
+          ) {
+            throw recoveryError;
+          }
+        }
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Run Graph locator index は別 process が使用中です (pid=${existing.pid}, host=${existing.hostname})`,
+        );
+      }
+      await sleep(25);
+    }
+  }
+
+  return async () => {
+    const current = await readJsonOptional(
+      join(lockDir, "owner.json"),
+      RunGraphLocatorIndexLockOwnerSchema,
+    );
+    if (!current || current.nonce !== owner.nonce) {
+      throw new Error("Run Graph locator index lock の所有権を失いました");
+    }
+    const retired = `${lockDir}.retired-${owner.nonce}-${randomUUID()}`;
+    await rename(lockDir, retired);
+    await rm(retired, { recursive: true, force: true }).catch(() => undefined);
+  };
+}
+
+async function withLocatorIndexLease<T>(
+  locatorIndexRoot: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireLocatorIndexLease(locatorIndexRoot);
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
 }
 
 async function listJsonFiles(path: string): Promise<string[]> {
@@ -46,9 +286,16 @@ async function listJsonFiles(path: string): Promise<string[]> {
 /** run ごとの accepted event を immutable sequence segment として保持する。 */
 export class RunGraphEventStore {
   private readonly root: string;
+  private readonly locatorIndexRoot: string;
 
   constructor(projectRoot: string) {
     this.root = join(projectRoot, GANTT_DIR, RUN_GRAPH_DIR, RUN_GRAPH_RUNS_DIR);
+    this.locatorIndexRoot = join(
+      projectRoot,
+      GANTT_DIR,
+      RUN_GRAPH_DIR,
+      RUN_GRAPH_LOCATOR_INDEX_DIR,
+    );
   }
 
   private runDir(runId: string): string {
@@ -57,25 +304,41 @@ export class RunGraphEventStore {
 
   async appendAccepted(input: RunGraphAcceptedEvent): Promise<void> {
     const event = RunGraphAcceptedEventSchema.parse(input);
-    const eventsDir = join(this.runDir(event.runId), "events");
-    await mkdir(eventsDir, { recursive: true });
-    const journal = await this.readJournalOrEmpty(event.runId);
-    if (journal.acceptedEvents.some((item) => item.eventId === event.eventId)) {
-      throw new Error(`duplicate event ID: ${event.eventId}`);
-    }
-    const expected = journal.acceptedEvents.length + 1;
-    if (event.sequence !== expected) {
-      throw new Error(`event sequence は ${expected} である必要があります`);
-    }
-    const filePath = join(eventsDir, `${String(event.sequence).padStart(12, "0")}.json`);
-    try {
-      await writeFile(filePath, JSON.stringify(event, null, 2) + "\n", { flag: "wx" });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+    await withLocatorIndexLease(this.locatorIndexRoot, async () => {
+      await mkdir(this.locatorIndexRoot, { recursive: true });
+      const eventsDir = join(this.runDir(event.runId), "events");
+      await mkdir(eventsDir, { recursive: true });
+      const journal = await this.readJournalOrEmpty(event.runId);
+      if (journal.acceptedEvents.some((item) => item.eventId === event.eventId)) {
+        throw new Error(`duplicate event ID: ${event.eventId}`);
+      }
+      const expected = journal.acceptedEvents.length + 1;
+      if (event.sequence < expected) {
         throw new Error(`duplicate event segment: ${event.eventId}`);
       }
-      throw error;
-    }
+      if (event.sequence !== expected) {
+        throw new Error(`event sequence は ${expected} である必要があります`);
+      }
+      const first = event.sequence === 1 ? event : journal.acceptedEvents[0];
+      if (first?.command.type !== "run_started") {
+        throw new Error(`Run Graph の先頭 event が run_started ではありません: ${event.runId}`);
+      }
+      await rm(this.locatorIndexStatePath(), { force: true });
+      const filePath = join(eventsDir, `${String(event.sequence).padStart(12, "0")}.json`);
+      try {
+        await writeFile(filePath, JSON.stringify(event, null, 2) + "\n", { flag: "wx" });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new Error(`duplicate event segment: ${event.eventId}`);
+        }
+        throw error;
+      }
+      await this.updateRunLocator({
+        runId: event.runId,
+        task: first.command.task,
+        updatedAt: event.acceptedAt,
+      });
+    });
   }
 
   async appendRejection(input: RunGraphRejection): Promise<void> {
@@ -133,7 +396,19 @@ export class RunGraphEventStore {
     }
   }
 
-  private async readRunLocator(runId: string): Promise<RunGraphRunLocator | null> {
+  private locatorPath(runId: string): string {
+    return join(this.locatorIndexRoot, "runs", `${safeSegment(runId)}.json`);
+  }
+
+  private taskLocatorIndexPath(task: RunGraphRunLocator["task"]): string {
+    return join(this.locatorIndexRoot, "tasks", `${safeSegment(taskKey(task))}.json`);
+  }
+
+  private locatorIndexStatePath(): string {
+    return join(this.locatorIndexRoot, "state.json");
+  }
+
+  private async readJournalLocator(runId: string): Promise<RunGraphRunLocator | null> {
     const eventsDir = join(this.runDir(runId), "events");
     const files = await listJsonFiles(eventsDir);
     const firstFile = files[0];
@@ -154,44 +429,120 @@ export class RunGraphEventStore {
     return { runId, task: first.command.task, updatedAt: last.acceptedAt };
   }
 
+  private async updateRunLocator(input: RunGraphRunLocator): Promise<void> {
+    const locator = RunGraphRunLocatorSchema.parse(input);
+    const locatorPath = this.locatorPath(locator.runId);
+    const previousLocator = await readJsonOptional(locatorPath, RunGraphRunLocatorSchema);
+    if (previousLocator && !sameTask(previousLocator.task, locator.task)) {
+      throw new Error(`Run Graph locator の task は変更できません: ${locator.runId}`);
+    }
+    const task = normalizedTask(locator.task);
+    const indexPath = this.taskLocatorIndexPath(task);
+    const current = await readJsonOptional(indexPath, RunGraphTaskLocatorIndexSchema);
+    if (current && !sameTask(current.task, task)) {
+      throw new Error(`Run Graph task locator index が一致しません: ${taskKey(task)}`);
+    }
+    const items = sortLocators([
+      locator,
+      ...(current?.items ?? []).filter((item) => item.runId !== locator.runId),
+    ]).slice(0, RUN_GRAPH_LOCATOR_INDEX_LIMIT);
+    const index = RunGraphTaskLocatorIndexSchema.parse({
+      schemaVersion: "1",
+      task,
+      total: (current?.total ?? 0) + (previousLocator ? 0 : 1),
+      items,
+    });
+    await mkdir(join(this.locatorIndexRoot, "runs"), { recursive: true });
+    await mkdir(join(this.locatorIndexRoot, "tasks"), { recursive: true });
+    await writeJsonAtomic(locatorPath, locator);
+    await writeJsonAtomic(indexPath, index);
+  }
+
+  private async rebuildRunLocatorIndex(): Promise<void> {
+    const locators: RunGraphRunLocator[] = [];
+    for (const runId of await this.listRunIds()) {
+      const locator = await this.readJournalLocator(runId);
+      if (locator) locators.push(locator);
+    }
+    const byTask = new Map<string, RunGraphRunLocator[]>();
+    for (const locator of locators) {
+      const key = taskKey(locator.task);
+      byTask.set(key, [...(byTask.get(key) ?? []), locator]);
+    }
+    await mkdir(join(this.locatorIndexRoot, "runs"), { recursive: true });
+    await mkdir(join(this.locatorIndexRoot, "tasks"), { recursive: true });
+    for (const locator of locators) {
+      await writeJsonAtomic(
+        this.locatorPath(locator.runId),
+        RunGraphRunLocatorSchema.parse(locator),
+      );
+    }
+    for (const taskLocators of byTask.values()) {
+      const sorted = sortLocators(taskLocators);
+      const task = normalizedTask(sorted[0]!.task);
+      await writeJsonAtomic(
+        this.taskLocatorIndexPath(task),
+        RunGraphTaskLocatorIndexSchema.parse({
+          schemaVersion: "1",
+          task,
+          total: sorted.length,
+          items: sorted.slice(0, RUN_GRAPH_LOCATOR_INDEX_LIMIT),
+        }),
+      );
+    }
+    await writeJsonAtomic(
+      this.locatorIndexStatePath(),
+      RunGraphLocatorIndexStateSchema.parse({
+        schemaVersion: "1",
+        rebuiltAt: new Date().toISOString(),
+      }),
+    );
+  }
+
+  /** 旧 journal の locator を server 起動時に再構築し、request path の全 Run 走査を避ける。 */
+  async ensureRunLocatorIndex(): Promise<void> {
+    await withLocatorIndexLease(this.locatorIndexRoot, async () => {
+      const state = await readJsonOptional(
+        this.locatorIndexStatePath(),
+        RunGraphLocatorIndexStateSchema,
+      );
+      if (state) return;
+      await this.rebuildRunLocatorIndex();
+    });
+  }
+
   /**
-   * journal 全文を replay せず、各 run の先頭・末尾 event だけで候補を絞る。
-   * file read は直列に行い、詳細 replay は返却した最大 limit 件だけを caller が実行する。
+   * task 単位の bounded locator index と選択 run の locator だけで候補を絞る。
+   * 詳細 replay は返却した最大 limit 件だけを caller が実行する。
    */
   async listRunLocators(input: RunGraphRunLocatorQuery): Promise<{
     total: number;
     items: RunGraphRunLocator[];
   }> {
     const limit = Math.min(50, Math.max(1, input.limit));
-    const locators: RunGraphRunLocator[] = [];
-    for (const runId of await this.listRunIds()) {
-      const locator = await this.readRunLocator(runId);
-      if (!locator) continue;
-      if (
-        input.task &&
-        (locator.task.issueNumber !== input.task.issueNumber ||
-          locator.task.owner.toLowerCase() !== input.task.owner.toLowerCase() ||
-          locator.task.repo.toLowerCase() !== input.task.repo.toLowerCase())
-      ) {
-        continue;
-      }
-      locators.push(locator);
-    }
-    locators.sort(
-      (left, right) =>
-        Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
-        left.runId.localeCompare(right.runId),
+    const index = await readJsonOptional(
+      this.taskLocatorIndexPath(input.task),
+      RunGraphTaskLocatorIndexSchema,
     );
-    let items = locators.slice(0, limit);
+    if (index && !sameTask(index.task, input.task)) {
+      throw new Error(`Run Graph task locator index が一致しません: ${taskKey(input.task)}`);
+    }
+    let items = (index?.items ?? []).slice(0, limit);
     if (input.selectedRunId && !items.some((item) => item.runId === input.selectedRunId)) {
-      const selected = locators.find((item) => item.runId === input.selectedRunId);
-      if (selected) {
+      const selected = await readJsonOptional(
+        this.locatorPath(input.selectedRunId),
+        RunGraphRunLocatorSchema,
+      );
+      if (selected && sameTask(selected.task, input.task)) {
+        if (!index || index.total < 1) {
+          throw new Error(`Run Graph locator index が不完全です: ${taskKey(input.task)}`);
+        }
         items = [selected, ...items.filter((item) => item.runId !== selected.runId)].slice(
           0,
           limit,
         );
       }
     }
-    return { total: locators.length, items };
+    return { total: index?.total ?? 0, items };
   }
 }

--- a/packages/cli/src/store/run-graph.ts
+++ b/packages/cli/src/store/run-graph.ts
@@ -36,8 +36,22 @@ interface RunGraphTaskLocatorIndex {
   items: RunGraphRunLocator[];
 }
 
+interface RunGraphPendingLocatorTransaction {
+  schemaVersion: "1";
+  event: { runId: string; eventId: string; sequence: number };
+  locator: RunGraphRunLocator;
+  taskIndex: RunGraphTaskLocatorIndex;
+  restoreCompleteState: boolean;
+}
+
+export interface RunGraphEventStoreDependencies {
+  /** test only: journal commit と派生 index commit の境界を模擬する。 */
+  afterJournalCommit?: () => Promise<void>;
+}
+
 const RUN_GRAPH_LOCATOR_INDEX_DIR = "locator-index";
 const RUN_GRAPH_LOCATOR_INDEX_LIMIT = 50;
+const RECOVERY_CLAIM_STALE_MS = 60_000;
 
 const RunGraphTaskSchema = z
   .object({
@@ -107,9 +121,44 @@ const RunGraphLocatorIndexRecoveryClaimSchema = z
   .object({
     schemaVersion: z.literal("1"),
     expectedOwnerNonce: z.string().uuid(),
-    claimantNonce: z.string().uuid(),
+    claimant: z
+      .object({
+        pid: z.number().int().positive(),
+        hostname: z.string().min(1),
+        nonce: z.string().uuid(),
+        claimedAt: z.string().datetime({ offset: true }),
+      })
+      .strict(),
   })
   .strict();
+
+const RunGraphPendingLocatorTransactionSchema: z.ZodType<RunGraphPendingLocatorTransaction> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    event: z
+      .object({
+        runId: z.string().min(1),
+        eventId: z.string().min(1),
+        sequence: z.number().int().positive(),
+      })
+      .strict(),
+    locator: RunGraphRunLocatorSchema,
+    taskIndex: RunGraphTaskLocatorIndexSchema,
+    restoreCompleteState: z.boolean(),
+  })
+  .strict()
+  .superRefine((transaction, context) => {
+    if (
+      transaction.event.runId !== transaction.locator.runId ||
+      !sameTask(transaction.locator.task, transaction.taskIndex.task)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["locator"],
+        message: "pending transaction の event・locator・task index は一致する必要があります",
+      });
+    }
+  });
 
 function safeSegment(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
@@ -210,11 +259,56 @@ async function acquireLocatorIndexLease(locatorIndexRoot: string): Promise<() =>
         claimPath,
         RunGraphLocatorIndexRecoveryClaimSchema,
       );
+      if (recoveryClaim && recoveryClaim.expectedOwnerNonce !== existing.nonce) {
+        throw new Error("Run Graph locator index の recovery claim が owner と一致しません");
+      }
+      const claimAge = recoveryClaim
+        ? Date.now() - Date.parse(recoveryClaim.claimant.claimedAt)
+        : 0;
+      const claimantDead =
+        recoveryClaim?.claimant.hostname === owner.hostname &&
+        !isProcessAlive(recoveryClaim.claimant.pid);
+      if (recoveryClaim && (claimantDead || claimAge >= RECOVERY_CLAIM_STALE_MS)) {
+        const confirmedOwner = await readJsonOptional(
+          join(lockDir, "owner.json"),
+          RunGraphLocatorIndexLockOwnerSchema,
+        );
+        const confirmedClaim = await readJsonOptional(
+          claimPath,
+          RunGraphLocatorIndexRecoveryClaimSchema,
+        );
+        if (
+          confirmedOwner?.nonce === recoveryClaim.expectedOwnerNonce &&
+          confirmedClaim?.claimant.nonce === recoveryClaim.claimant.nonce
+        ) {
+          const recovered = `${lockDir}.recovered-${existing.nonce}-${randomUUID()}`;
+          try {
+            await rename(lockDir, recovered);
+            await rm(recovered, { recursive: true, force: true });
+            continue;
+          } catch (recoveryError) {
+            const recoveryCode = (recoveryError as NodeJS.ErrnoException).code;
+            if (
+              recoveryCode !== "ENOENT" &&
+              recoveryCode !== "EEXIST" &&
+              recoveryCode !== "ENOTEMPTY"
+            ) {
+              throw recoveryError;
+            }
+            continue;
+          }
+        }
+      }
       if (!recoveryClaim && existing.hostname === owner.hostname && !isProcessAlive(existing.pid)) {
         const claim = RunGraphLocatorIndexRecoveryClaimSchema.parse({
           schemaVersion: "1",
           expectedOwnerNonce: existing.nonce,
-          claimantNonce: owner.nonce,
+          claimant: {
+            pid: owner.pid,
+            hostname: owner.hostname,
+            nonce: owner.nonce,
+            claimedAt: new Date().toISOString(),
+          },
         });
         try {
           await writeFile(claimPath, JSON.stringify(claim, null, 2) + "\n", { flag: "wx" });
@@ -287,8 +381,9 @@ async function listJsonFiles(path: string): Promise<string[]> {
 export class RunGraphEventStore {
   private readonly root: string;
   private readonly locatorIndexRoot: string;
+  private readonly dependencies: RunGraphEventStoreDependencies;
 
-  constructor(projectRoot: string) {
+  constructor(projectRoot: string, dependencies: RunGraphEventStoreDependencies = {}) {
     this.root = join(projectRoot, GANTT_DIR, RUN_GRAPH_DIR, RUN_GRAPH_RUNS_DIR);
     this.locatorIndexRoot = join(
       projectRoot,
@@ -296,6 +391,7 @@ export class RunGraphEventStore {
       RUN_GRAPH_DIR,
       RUN_GRAPH_LOCATOR_INDEX_DIR,
     );
+    this.dependencies = dependencies;
   }
 
   private runDir(runId: string): string {
@@ -304,8 +400,12 @@ export class RunGraphEventStore {
 
   async appendAccepted(input: RunGraphAcceptedEvent): Promise<void> {
     const event = RunGraphAcceptedEventSchema.parse(input);
-    await withLocatorIndexLease(this.locatorIndexRoot, async () => {
+    const release = await acquireLocatorIndexLease(this.locatorIndexRoot);
+    let journalCommitted = false;
+    let failure: unknown = null;
+    try {
       await mkdir(this.locatorIndexRoot, { recursive: true });
+      await this.recoverPendingLocatorTransaction();
       const eventsDir = join(this.runDir(event.runId), "events");
       await mkdir(eventsDir, { recursive: true });
       const journal = await this.readJournalOrEmpty(event.runId);
@@ -323,6 +423,12 @@ export class RunGraphEventStore {
       if (first?.command.type !== "run_started") {
         throw new Error(`Run Graph の先頭 event が run_started ではありません: ${event.runId}`);
       }
+      const transaction = await this.prepareLocatorTransaction(event, {
+        runId: event.runId,
+        task: first.command.task,
+        updatedAt: event.acceptedAt,
+      });
+      await writeJsonAtomic(this.pendingLocatorTransactionPath(), transaction);
       await rm(this.locatorIndexStatePath(), { force: true });
       const filePath = join(eventsDir, `${String(event.sequence).padStart(12, "0")}.json`);
       try {
@@ -333,12 +439,22 @@ export class RunGraphEventStore {
         }
         throw error;
       }
-      await this.updateRunLocator({
-        runId: event.runId,
-        task: first.command.task,
-        updatedAt: event.acceptedAt,
-      });
-    });
+      journalCommitted = true;
+      await this.dependencies.afterJournalCommit?.();
+      await this.applyPendingLocatorTransaction(transaction);
+    } catch (error) {
+      failure = error;
+      if (!journalCommitted) {
+        await rm(this.pendingLocatorTransactionPath(), { force: true }).catch(() => undefined);
+      }
+    }
+    try {
+      await release();
+    } catch (error) {
+      failure ??= error;
+    }
+    // event segment が確定した後は accepted を正本とし、残った WAL を次回 bounded 修復する。
+    if (failure && !journalCommitted) throw failure;
   }
 
   async appendRejection(input: RunGraphRejection): Promise<void> {
@@ -400,12 +516,20 @@ export class RunGraphEventStore {
     return join(this.locatorIndexRoot, "runs", `${safeSegment(runId)}.json`);
   }
 
+  private eventPath(runId: string, sequence: number): string {
+    return join(this.runDir(runId), "events", `${String(sequence).padStart(12, "0")}.json`);
+  }
+
   private taskLocatorIndexPath(task: RunGraphRunLocator["task"]): string {
     return join(this.locatorIndexRoot, "tasks", `${safeSegment(taskKey(task))}.json`);
   }
 
   private locatorIndexStatePath(): string {
     return join(this.locatorIndexRoot, "state.json");
+  }
+
+  private pendingLocatorTransactionPath(): string {
+    return join(this.locatorIndexRoot, "pending-transaction.json");
   }
 
   private async readJournalLocator(runId: string): Promise<RunGraphRunLocator | null> {
@@ -429,7 +553,10 @@ export class RunGraphEventStore {
     return { runId, task: first.command.task, updatedAt: last.acceptedAt };
   }
 
-  private async updateRunLocator(input: RunGraphRunLocator): Promise<void> {
+  private async prepareLocatorTransaction(
+    event: RunGraphAcceptedEvent,
+    input: RunGraphRunLocator,
+  ): Promise<RunGraphPendingLocatorTransaction> {
     const locator = RunGraphRunLocatorSchema.parse(input);
     const locatorPath = this.locatorPath(locator.runId);
     const previousLocator = await readJsonOptional(locatorPath, RunGraphRunLocatorSchema);
@@ -452,10 +579,64 @@ export class RunGraphEventStore {
       total: (current?.total ?? 0) + (previousLocator ? 0 : 1),
       items,
     });
+    const state = await readJsonOptional(
+      this.locatorIndexStatePath(),
+      RunGraphLocatorIndexStateSchema,
+    );
+    return RunGraphPendingLocatorTransactionSchema.parse({
+      schemaVersion: "1",
+      event: { runId: event.runId, eventId: event.eventId, sequence: event.sequence },
+      locator,
+      taskIndex: index,
+      restoreCompleteState: state !== null,
+    });
+  }
+
+  private async applyPendingLocatorTransaction(
+    input: RunGraphPendingLocatorTransaction,
+  ): Promise<void> {
+    const transaction = RunGraphPendingLocatorTransactionSchema.parse(input);
     await mkdir(join(this.locatorIndexRoot, "runs"), { recursive: true });
     await mkdir(join(this.locatorIndexRoot, "tasks"), { recursive: true });
-    await writeJsonAtomic(locatorPath, locator);
-    await writeJsonAtomic(indexPath, index);
+    await writeJsonAtomic(this.locatorPath(transaction.locator.runId), transaction.locator);
+    await writeJsonAtomic(
+      this.taskLocatorIndexPath(transaction.taskIndex.task),
+      transaction.taskIndex,
+    );
+    if (transaction.restoreCompleteState) {
+      await writeJsonAtomic(
+        this.locatorIndexStatePath(),
+        RunGraphLocatorIndexStateSchema.parse({
+          schemaVersion: "1",
+          rebuiltAt: new Date().toISOString(),
+        }),
+      );
+    }
+    await rm(this.pendingLocatorTransactionPath(), { force: true });
+  }
+
+  private async recoverPendingLocatorTransaction(): Promise<void> {
+    const transaction = await readJsonOptional(
+      this.pendingLocatorTransactionPath(),
+      RunGraphPendingLocatorTransactionSchema,
+    );
+    if (!transaction) return;
+    const event = (await readJsonOptional(
+      this.eventPath(transaction.event.runId, transaction.event.sequence),
+      RunGraphAcceptedEventReadSchema,
+    )) as RunGraphAcceptedEvent | null;
+    if (!event) {
+      await rm(this.pendingLocatorTransactionPath(), { force: true });
+      return;
+    }
+    if (
+      event.runId !== transaction.event.runId ||
+      event.eventId !== transaction.event.eventId ||
+      event.sequence !== transaction.event.sequence
+    ) {
+      throw new Error("Run Graph pending transaction と accepted event が一致しません");
+    }
+    await this.applyPendingLocatorTransaction(transaction);
   }
 
   private async rebuildRunLocatorIndex(): Promise<void> {
@@ -502,6 +683,7 @@ export class RunGraphEventStore {
   /** 旧 journal の locator を server 起動時に再構築し、request path の全 Run 走査を避ける。 */
   async ensureRunLocatorIndex(): Promise<void> {
     await withLocatorIndexLease(this.locatorIndexRoot, async () => {
+      await this.recoverPendingLocatorTransaction();
       const state = await readJsonOptional(
         this.locatorIndexStatePath(),
         RunGraphLocatorIndexStateSchema,
@@ -519,30 +701,33 @@ export class RunGraphEventStore {
     total: number;
     items: RunGraphRunLocator[];
   }> {
-    const limit = Math.min(50, Math.max(1, input.limit));
-    const index = await readJsonOptional(
-      this.taskLocatorIndexPath(input.task),
-      RunGraphTaskLocatorIndexSchema,
-    );
-    if (index && !sameTask(index.task, input.task)) {
-      throw new Error(`Run Graph task locator index が一致しません: ${taskKey(input.task)}`);
-    }
-    let items = (index?.items ?? []).slice(0, limit);
-    if (input.selectedRunId && !items.some((item) => item.runId === input.selectedRunId)) {
-      const selected = await readJsonOptional(
-        this.locatorPath(input.selectedRunId),
-        RunGraphRunLocatorSchema,
+    return withLocatorIndexLease(this.locatorIndexRoot, async () => {
+      await this.recoverPendingLocatorTransaction();
+      const limit = Math.min(50, Math.max(1, input.limit));
+      const index = await readJsonOptional(
+        this.taskLocatorIndexPath(input.task),
+        RunGraphTaskLocatorIndexSchema,
       );
-      if (selected && sameTask(selected.task, input.task)) {
-        if (!index || index.total < 1) {
-          throw new Error(`Run Graph locator index が不完全です: ${taskKey(input.task)}`);
-        }
-        items = [selected, ...items.filter((item) => item.runId !== selected.runId)].slice(
-          0,
-          limit,
-        );
+      if (index && !sameTask(index.task, input.task)) {
+        throw new Error(`Run Graph task locator index が一致しません: ${taskKey(input.task)}`);
       }
-    }
-    return { total: index?.total ?? 0, items };
+      let items = (index?.items ?? []).slice(0, limit);
+      if (input.selectedRunId && !items.some((item) => item.runId === input.selectedRunId)) {
+        const selected = await readJsonOptional(
+          this.locatorPath(input.selectedRunId),
+          RunGraphRunLocatorSchema,
+        );
+        if (selected && sameTask(selected.task, input.task)) {
+          if (!index || index.total < 1) {
+            throw new Error(`Run Graph locator index が不完全です: ${taskKey(input.task)}`);
+          }
+          items = [selected, ...items.filter((item) => item.runId !== selected.runId)].slice(
+            0,
+            limit,
+          );
+        }
+      }
+      return { total: index?.total ?? 0, items };
+    });
   }
 }

--- a/packages/cli/src/store/run-graph.ts
+++ b/packages/cli/src/store/run-graph.ts
@@ -14,6 +14,18 @@ import {
   type RunGraphRejection,
 } from "@gh-gantt/shared";
 
+export interface RunGraphRunLocator {
+  runId: string;
+  task: { owner: string; repo: string; issueNumber: number };
+  updatedAt: string;
+}
+
+export interface RunGraphRunLocatorQuery {
+  task?: { owner: string; repo: string; issueNumber: number };
+  limit: number;
+  selectedRunId?: string;
+}
+
 function safeSegment(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
 }
@@ -119,5 +131,67 @@ export class RunGraphEventStore {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw error;
     }
+  }
+
+  private async readRunLocator(runId: string): Promise<RunGraphRunLocator | null> {
+    const eventsDir = join(this.runDir(runId), "events");
+    const files = await listJsonFiles(eventsDir);
+    const firstFile = files[0];
+    const lastFile = files.at(-1);
+    if (!firstFile || !lastFile) return null;
+    const first = RunGraphAcceptedEventReadSchema.parse(
+      JSON.parse(await readFile(join(eventsDir, firstFile), "utf8")),
+    );
+    if (first.command.type !== "run_started") {
+      throw new Error(`Run Graph の先頭 event が run_started ではありません: ${runId}`);
+    }
+    const last =
+      lastFile === firstFile
+        ? first
+        : RunGraphAcceptedEventReadSchema.parse(
+            JSON.parse(await readFile(join(eventsDir, lastFile), "utf8")),
+          );
+    return { runId, task: first.command.task, updatedAt: last.acceptedAt };
+  }
+
+  /**
+   * journal 全文を replay せず、各 run の先頭・末尾 event だけで候補を絞る。
+   * file read は直列に行い、詳細 replay は返却した最大 limit 件だけを caller が実行する。
+   */
+  async listRunLocators(input: RunGraphRunLocatorQuery): Promise<{
+    total: number;
+    items: RunGraphRunLocator[];
+  }> {
+    const limit = Math.min(50, Math.max(1, input.limit));
+    const locators: RunGraphRunLocator[] = [];
+    for (const runId of await this.listRunIds()) {
+      const locator = await this.readRunLocator(runId);
+      if (!locator) continue;
+      if (
+        input.task &&
+        (locator.task.issueNumber !== input.task.issueNumber ||
+          locator.task.owner.toLowerCase() !== input.task.owner.toLowerCase() ||
+          locator.task.repo.toLowerCase() !== input.task.repo.toLowerCase())
+      ) {
+        continue;
+      }
+      locators.push(locator);
+    }
+    locators.sort(
+      (left, right) =>
+        Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+        left.runId.localeCompare(right.runId),
+    );
+    let items = locators.slice(0, limit);
+    if (input.selectedRunId && !items.some((item) => item.runId === input.selectedRunId)) {
+      const selected = locators.find((item) => item.runId === input.selectedRunId);
+      if (selected) {
+        items = [selected, ...items.filter((item) => item.runId !== selected.runId)].slice(
+          0,
+          limit,
+        );
+      }
+    }
+    return { total: locators.length, items };
   }
 }

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -668,6 +668,25 @@ describe("[FR-VIS-026-AC4] Run Graph の一覧と deep link を bounded にす�
     ).toContain("node=node-executor");
   });
 
+  it("run 内の repository 表記ではなく選択 task の canonical ID で deep link を生成する", () => {
+    const canonicalTaskId = "Stanah/gh-gantt#330";
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: canonicalTaskId,
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView()],
+      selectedRunId: "run-330",
+      selectedNodeId: "node-executor",
+    });
+
+    expect(vm.runs.items[0]?.taskId).toBe(canonicalTaskId);
+    expect(vm.runs.items[0]?.deepLink).toContain("task=Stanah%2Fgh-gantt%23330");
+    expect(vm.selectedRun?.taskId).toBe(canonicalTaskId);
+    expect(vm.selectedRun?.deepLink).toContain("task=Stanah%2Fgh-gantt%23330");
+    expect(
+      vm.selectedRun?.actual.nodes.find((node) => node.id === "node-executor")?.deepLink,
+    ).toContain("task=Stanah%2Fgh-gantt%23330");
+  });
+
   it("planned node と edge も同じ limit の bounded collection にする", () => {
     const vm = buildProjectMapRunGraphViewModel({
       taskId: "stanah/gh-gantt#330",

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -3,6 +3,7 @@ import type { Config, Task } from "../types.js";
 import { FIXED_DEV_ROLE_GRAPH_CONTRACT, type RunGraphView } from "../run-graph.js";
 import {
   buildProjectMapRunGraphViewModel,
+  ProjectMapRunGraphViewModelSchema,
   buildProjectMapViewModel,
   buildBoardColumns,
   buildTaskHierarchy,
@@ -424,7 +425,7 @@ describe("[FR-VIS-026-AC1] planned と actual の Run Graph を同じ ViewModel 
       limit: 20,
     });
 
-    expect(vm.selectedRun?.planned.nodes.map((node) => node.id)).toContain("executor");
+    expect(vm.selectedRun?.planned.nodes.items.map((node) => node.id)).toContain("executor");
     expect(vm.selectedRun?.actual.nodes.find((node) => node.id === "node-executor")).toMatchObject({
       contractNodeId: "executor",
       displayState: "completed",
@@ -457,9 +458,29 @@ describe("[FR-VIS-026-AC2] Run Graph の状態と attempt 要約を導出する"
       vm.selectedRun?.actual.nodes.find((node) => node.id === "node-implementer-2")?.displayState,
     ).toBe("retrying");
     expect(vm.selectedRun?.actual.attempts[0]).toMatchObject({
+      id: "attempt-executor",
+      nodeId: "node-executor",
       actor: { id: "runner-1", role: "executor" },
       durationMs: 60000,
+      evidenceCount: 0,
     });
+  });
+
+  it("timed_out と stalled の attempt に終了時刻を設定する", () => {
+    const base = runView();
+    for (const state of ["timed_out", "stalled"] as const) {
+      const attempt = { ...base.attempts.items[0]!, state };
+      const vm = buildProjectMapRunGraphViewModel({
+        taskId: "stanah/gh-gantt#330",
+        contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+        runViews: [
+          runView({
+            attempts: { total: 1, limit: 20, truncated: false, items: [attempt] },
+          }),
+        ],
+      });
+      expect(vm.selectedRun?.actual.attempts[0]?.endedAt).toBe(attempt.updatedAt);
+    }
   });
 
   it("active / queued / running / waiting_human / failed / completed / cancelled を正規化する", () => {
@@ -601,6 +622,31 @@ describe("[FR-VIS-026-AC3] planned との差分と unknown metric を保持す�
       expect.arrayContaining(["unexpected_node", "unexpected_edge", "skip", "cancel"]),
     );
   });
+
+  it("Graph Contract の direct branch edge を node 配列順だけで skip としない", () => {
+    const base = runView();
+    const planner = base.nodes.items[0]!;
+    const human = {
+      ...base.nodes.items[1]!,
+      id: "node-human",
+      contractNodeId: "human-pr",
+      previousNodeId: planner.id,
+    };
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [
+        runView({
+          currentNode: human,
+          nodes: { total: 2, limit: 20, truncated: false, items: [planner, human] },
+          attempts: { total: 0, limit: 20, truncated: false, items: [] },
+        }),
+      ],
+    });
+
+    expect(vm.selectedRun?.actual.transitions[0]?.isPlanned).toBe(true);
+    expect(vm.selectedRun?.deviations.map((item) => item.kind)).not.toContain("skip");
+  });
 });
 
 describe("[FR-VIS-026-AC4] Run Graph の一覧と deep link を bounded にする", () => {
@@ -620,6 +666,42 @@ describe("[FR-VIS-026-AC4] Run Graph の一覧と deep link を bounded にす�
     expect(
       vm.selectedRun?.actual.nodes.find((node) => node.id === "node-executor")?.deepLink,
     ).toContain("node=node-executor");
+  });
+
+  it("planned node と edge も同じ limit の bounded collection にする", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView()],
+      limit: 2,
+    });
+
+    expect(vm.selectedRun?.planned.nodes).toMatchObject({
+      total: FIXED_DEV_ROLE_GRAPH_CONTRACT.nodes.length,
+      limit: 2,
+      truncated: true,
+    });
+    expect(vm.selectedRun?.planned.nodes.items).toHaveLength(2);
+    expect(vm.selectedRun?.planned.edges).toMatchObject({
+      total: FIXED_DEV_ROLE_GRAPH_CONTRACT.edges.length,
+      limit: 2,
+      truncated: true,
+    });
+    expect(vm.selectedRun?.planned.edges.items).toHaveLength(2);
+  });
+
+  it("agent/UI 共通 response を strict schema で検証する", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView()],
+      limit: 2,
+    });
+
+    expect(ProjectMapRunGraphViewModelSchema.safeParse(vm).success).toBe(true);
+    expect(ProjectMapRunGraphViewModelSchema.safeParse({ ...vm, unexpected: true }).success).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -623,6 +623,43 @@ describe("[FR-VIS-026-AC3] planned との差分と unknown metric を保持す�
     );
   });
 
+  it("複数種別の deviation が schema 上限を超えても bounded に切り詰める", () => {
+    const base = runView();
+    const nodes = Array.from({ length: 50 }, (_, index) => ({
+      ...base.nodes.items[0]!,
+      id: `node-overflow-${index}`,
+      contractNodeId: "rogue",
+      state: "cancelled" as const,
+      previousNodeId: `node-overflow-${(index + 49) % 50}`,
+      outputArtifactIds: [],
+    }));
+    const attempts = nodes.map((node, index) => ({
+      ...base.attempts.items[0]!,
+      id: `attempt-overflow-${index}`,
+      nodeId: node.id,
+      ordinal: 2,
+      state: "failed" as const,
+      previousAttemptId: null,
+    }));
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: null,
+      runViews: [
+        runView({
+          state: "cancelled",
+          currentNode: nodes.at(-1)!,
+          nodes: { total: 50, limit: 50, truncated: false, items: nodes },
+          attempts: { total: 50, limit: 50, truncated: false, items: attempts },
+        }),
+      ],
+      limit: 50,
+    });
+
+    expect(vm.selectedRun?.deviations).toHaveLength(200);
+    expect(vm.selectedRun?.deviationsTruncated).toBe(true);
+    expect(ProjectMapRunGraphViewModelSchema.safeParse(vm).success).toBe(true);
+  });
+
   it("Graph Contract の direct branch edge を node 配列順だけで skip としない", () => {
     const base = runView();
     const planner = base.nodes.items[0]!;

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import type { Config, Task } from "../types.js";
+import { FIXED_DEV_ROLE_GRAPH_CONTRACT, type RunGraphView } from "../run-graph.js";
 import {
+  buildProjectMapRunGraphViewModel,
   buildProjectMapViewModel,
   buildBoardColumns,
   buildTaskHierarchy,
@@ -315,5 +317,322 @@ describe("優先度の正規化", () => {
       getNormalizedPriority(baseTask({ custom_fields: { Priority: "??" } }), config),
     ).toBeNull();
     expect(getNormalizedPriority(baseTask({ custom_fields: {} }), config)).toBeNull();
+  });
+});
+
+function runView(overrides: Partial<RunGraphView> = {}): RunGraphView {
+  const actor = { id: "runner-1", role: "executor" } as const;
+  const nodes: RunGraphView["nodes"]["items"] = [
+    {
+      id: "node-planner",
+      runId: "run-330",
+      contractNodeId: "planner",
+      state: "completed",
+      actor: { id: "planner-1", role: "planner" },
+      createdAt: "2026-07-30T00:00:00.000Z",
+      updatedAt: "2026-07-30T00:01:00.000Z",
+      activeAttemptId: null,
+      previousNodeId: null,
+      inputArtifactIds: [],
+      outputArtifactIds: ["artifact-plan"],
+    },
+    {
+      id: "node-implementer-1",
+      runId: "run-330",
+      contractNodeId: "implementer",
+      state: "completed",
+      actor: { id: "implementer-1", role: "implementer" },
+      createdAt: "2026-07-30T00:01:00.000Z",
+      updatedAt: "2026-07-30T00:03:00.000Z",
+      activeAttemptId: null,
+      previousNodeId: "node-planner",
+      inputArtifactIds: ["artifact-plan"],
+      outputArtifactIds: ["artifact-impl"],
+    },
+    {
+      id: "node-executor",
+      runId: "run-330",
+      contractNodeId: "executor",
+      state: "completed",
+      actor,
+      createdAt: "2026-07-30T00:03:00.000Z",
+      updatedAt: "2026-07-30T00:04:00.000Z",
+      activeAttemptId: null,
+      previousNodeId: "node-implementer-1",
+      inputArtifactIds: ["artifact-impl"],
+      outputArtifactIds: [],
+    },
+    {
+      id: "node-implementer-2",
+      runId: "run-330",
+      contractNodeId: "implementer",
+      state: "ready",
+      actor: { id: "implementer", role: "implementer" },
+      createdAt: "2026-07-30T00:04:00.000Z",
+      updatedAt: "2026-07-30T00:04:00.000Z",
+      activeAttemptId: null,
+      previousNodeId: "node-executor",
+      inputArtifactIds: ["artifact-plan", "artifact-impl"],
+      outputArtifactIds: [],
+    },
+  ];
+  const attempts: RunGraphView["attempts"]["items"] = [
+    {
+      id: "attempt-executor",
+      runId: "run-330",
+      nodeId: "node-executor",
+      ordinal: 1,
+      state: "succeeded",
+      actor,
+      createdAt: "2026-07-30T00:03:00.000Z",
+      updatedAt: "2026-07-30T00:04:00.000Z",
+      previousAttemptId: null,
+      inputArtifactIds: ["artifact-impl"],
+      outputArtifactIds: [],
+    },
+  ];
+  return {
+    schemaVersion: "1",
+    runId: "run-330",
+    task: { owner: "stanah", repo: "gh-gantt", issueNumber: 330 },
+    contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+    revision: 10,
+    state: "running",
+    createdAt: "2026-07-30T00:00:00.000Z",
+    updatedAt: "2026-07-30T00:04:00.000Z",
+    currentNode: nodes.at(-1)!,
+    activeAttempt: null,
+    waitReason: null,
+    budgets: { executorRetries: 1, improvementIterations: 0 },
+    allowedNextTransitions: ["attempt_started"],
+    nodes: { total: nodes.length, limit: 20, truncated: false, items: nodes },
+    attempts: { total: attempts.length, limit: 20, truncated: false, items: attempts },
+    artifacts: { total: 0, limit: 20, truncated: false, items: [] },
+    evidence: { total: 0, limit: 20, truncated: false, items: [] },
+    ...overrides,
+  };
+}
+
+describe("[FR-VIS-026-AC1] planned と actual の Run Graph を同じ ViewModel に導出する", () => {
+  it("planned node/edge と actual transition を stable ID で対応付ける", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView()],
+      selectedRunId: "run-330",
+      selectedNodeId: "node-executor",
+      limit: 20,
+    });
+
+    expect(vm.selectedRun?.planned.nodes.map((node) => node.id)).toContain("executor");
+    expect(vm.selectedRun?.actual.nodes.find((node) => node.id === "node-executor")).toMatchObject({
+      contractNodeId: "executor",
+      displayState: "completed",
+      isPlanned: true,
+    });
+    expect(vm.selectedRun?.actual.transitions).toContainEqual(
+      expect.objectContaining({
+        fromNodeId: "node-implementer-1",
+        toNodeId: "node-executor",
+        isPlanned: true,
+      }),
+    );
+    expect(vm.selectedRun?.selectedNodeId).toBe("node-executor");
+  });
+});
+
+describe("[FR-VIS-026-AC2] Run Graph の状態と attempt 要約を導出する", () => {
+  it("active run、retrying node、actor、duration、待機理由を区別する", () => {
+    const waiting = runView({ state: "waiting_human", waitReason: "review_budget_exhausted" });
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [waiting],
+      selectedRunId: "run-330",
+    });
+
+    expect(vm.selectedRun?.displayState).toBe("waiting_human");
+    expect(vm.selectedRun?.waitReason).toBe("review_budget_exhausted");
+    expect(
+      vm.selectedRun?.actual.nodes.find((node) => node.id === "node-implementer-2")?.displayState,
+    ).toBe("retrying");
+    expect(vm.selectedRun?.actual.attempts[0]).toMatchObject({
+      actor: { id: "runner-1", role: "executor" },
+      durationMs: 60000,
+    });
+  });
+
+  it("active / queued / running / waiting_human / failed / completed / cancelled を正規化する", () => {
+    const runCases = [
+      ["pending", "queued"],
+      ["running", "active"],
+      ["paused", "active"],
+      ["waiting_human", "waiting_human"],
+      ["failed", "failed"],
+      ["completed", "completed"],
+      ["cancelled", "cancelled"],
+    ] as const;
+    for (const [state, expected] of runCases) {
+      const vm = buildProjectMapRunGraphViewModel({
+        taskId: "stanah/gh-gantt#330",
+        contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+        runViews: [runView({ state })],
+      });
+      expect(vm.selectedRun?.displayState).toBe(expected);
+    }
+
+    const base = runView();
+    const first = base.nodes.items[0]!;
+    for (const [state, expected] of [
+      ["ready", "queued"],
+      ["running", "running"],
+      ["waiting_human", "waiting_human"],
+      ["failed", "failed"],
+      ["completed", "completed"],
+      ["cancelled", "cancelled"],
+    ] as const) {
+      const node = { ...first, state };
+      const vm = buildProjectMapRunGraphViewModel({
+        taskId: "stanah/gh-gantt#330",
+        contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+        runViews: [
+          runView({
+            currentNode: node,
+            nodes: { total: 1, limit: 20, truncated: false, items: [node] },
+            attempts: { total: 0, limit: 20, truncated: false, items: [] },
+          }),
+        ],
+      });
+      expect(vm.selectedRun?.actual.nodes[0]?.displayState).toBe(expected);
+    }
+  });
+});
+
+describe("[FR-VIS-026-AC3] planned との差分と unknown metric を保持する", () => {
+  it("同じ node の2回目以降の attempt を retry deviation として扱う", () => {
+    const base = runView();
+    const planner = { ...base.nodes.items[0]!, state: "ready" as const };
+    const firstAttempt = {
+      ...base.attempts.items[0]!,
+      id: "attempt-planner-1",
+      nodeId: planner.id,
+      ordinal: 1,
+      state: "failed" as const,
+    };
+    const retryAttempt = {
+      ...firstAttempt,
+      id: "attempt-planner-2",
+      ordinal: 2,
+      state: "created" as const,
+      previousAttemptId: firstAttempt.id,
+    };
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [
+        runView({
+          currentNode: planner,
+          nodes: { total: 1, limit: 20, truncated: false, items: [planner] },
+          attempts: {
+            total: 2,
+            limit: 20,
+            truncated: false,
+            items: [firstAttempt, retryAttempt],
+          },
+        }),
+      ],
+    });
+
+    expect(vm.selectedRun?.actual.nodes[0]?.displayState).toBe("retrying");
+    expect(vm.selectedRun?.deviations).toContainEqual(
+      expect.objectContaining({ kind: "retry", nodeId: planner.id }),
+    );
+  });
+
+  it("fallback/retry を deviation とし、未取得の token/cost/latency を 0 にしない", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView()],
+      selectedRunId: "run-330",
+    });
+
+    expect(vm.selectedRun?.deviations.map((item) => item.kind)).toEqual(
+      expect.arrayContaining(["retry", "fallback"]),
+    );
+    expect(vm.selectedRun?.metrics.duration).toMatchObject({ known: true, value: 240000 });
+    expect(vm.selectedRun?.metrics.tokens).toEqual({ known: false, value: null, unit: "token" });
+    expect(vm.selectedRun?.metrics.cost).toEqual({ known: false, value: null, unit: "currency" });
+    expect(vm.selectedRun?.metrics.latency).toEqual({
+      known: false,
+      value: null,
+      unit: "ms",
+    });
+  });
+
+  it("planned にない node/edge、skip、cancel を deviation として列挙する", () => {
+    const base = runView();
+    const planner = base.nodes.items[0]!;
+    const executor = {
+      ...base.nodes.items[2]!,
+      previousNodeId: planner.id,
+      state: "cancelled" as const,
+    };
+    const rogue = {
+      ...base.nodes.items[1]!,
+      id: "node-rogue",
+      contractNodeId: "rogue",
+      previousNodeId: executor.id,
+    };
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [
+        runView({
+          state: "cancelled",
+          currentNode: rogue,
+          nodes: { total: 3, limit: 20, truncated: false, items: [planner, executor, rogue] },
+          attempts: { total: 0, limit: 20, truncated: false, items: [] },
+        }),
+      ],
+    });
+
+    expect(vm.selectedRun?.deviations.map((item) => item.kind)).toEqual(
+      expect.arrayContaining(["unexpected_node", "unexpected_edge", "skip", "cancel"]),
+    );
+  });
+});
+
+describe("[FR-VIS-026-AC4] Run Graph の一覧と deep link を bounded にする", () => {
+  it("run 一覧を limit で切り詰め、run/node の URL を返す", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: FIXED_DEV_ROLE_GRAPH_CONTRACT,
+      runViews: [runView({ runId: "run-old", updatedAt: "2026-07-30T00:03:00.000Z" }), runView()],
+      selectedRunId: "run-old",
+      selectedNodeId: "node-executor",
+      limit: 1,
+    });
+
+    expect(vm.runs).toMatchObject({ total: 2, limit: 1, truncated: true });
+    expect(vm.runs.items.map((run) => run.runId)).toEqual(["run-old"]);
+    expect(vm.selectedRun?.deepLink).toContain("run=run-old");
+    expect(
+      vm.selectedRun?.actual.nodes.find((node) => node.id === "node-executor")?.deepLink,
+    ).toContain("node=node-executor");
+  });
+});
+
+describe("[FR-VIS-026-AC5] Run Graph がない project の互換性を保つ", () => {
+  it("空の bounded collection と null detail を返す", () => {
+    const vm = buildProjectMapRunGraphViewModel({
+      taskId: "stanah/gh-gantt#330",
+      contract: null,
+      runViews: [],
+      limit: 20,
+    });
+
+    expect(vm.runs).toEqual({ total: 0, limit: 20, truncated: false, items: [] });
+    expect(vm.selectedRun).toBeNull();
   });
 });

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -702,6 +702,12 @@ describe("[FR-VIS-026-AC4] Run Graph の一覧と deep link を bounded にす�
     expect(ProjectMapRunGraphViewModelSchema.safeParse({ ...vm, unexpected: true }).success).toBe(
       false,
     );
+    expect(
+      ProjectMapRunGraphViewModelSchema.safeParse({
+        ...vm,
+        runs: { ...vm.runs, truncated: !vm.runs.truncated },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/shared/src/__tests__/run-graph.test.ts
+++ b/packages/shared/src/__tests__/run-graph.test.ts
@@ -528,19 +528,31 @@ describe("[NFR-STABILITY-014-AC2] [NFR-STABILITY-014-AC4] replay projection と 
       schemaVersion: "1",
       runId: "run-1",
       task: { owner: "stanah", repo: "gh-gantt", issueNumber: 328 },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
       revision: 3,
       state: "running",
+      createdAt: timestamp,
+      updatedAt: timestamp,
       currentNode: node,
       activeAttempt: attempt,
       waitReason: null,
       budgets: { executorRetries: 0, improvementIterations: 0 },
       allowedNextTransitions: ["attempt_finished"],
+      nodes: { total: 2, limit: 1, truncated: true, items: [node] },
+      attempts: { total: 2, limit: 1, truncated: true, items: [attempt] },
       artifacts: { total: 2, limit: 1, truncated: true, items: [artifact] },
       evidence: { total: 2, limit: 1, truncated: true, items: [evidence] },
     });
 
+    expect(view.nodes).toMatchObject({ total: 2, limit: 1, truncated: true });
+    expect(view.attempts).toMatchObject({ total: 2, limit: 1, truncated: true });
     expect(view.artifacts).toMatchObject({ total: 2, limit: 1, truncated: true });
     expect(view.task).toEqual({ owner: "stanah", repo: "gh-gantt", issueNumber: 328 });
+    expect(view.contract).toEqual({
+      planId: "dev-role-fixed",
+      planVersion: "1",
+      schemaVersion: "1",
+    });
     expect(() =>
       RunGraphViewSchema.parse({
         ...view,

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -1057,8 +1057,7 @@ function runDeepLink(taskId: string, runId: string, nodeId?: string | null): str
     .join("&")}`;
 }
 
-function buildRunSummary(view: RunGraphView): ProjectMapRunSummary {
-  const taskId = runTaskId(view);
+function buildRunSummary(view: RunGraphView, taskId: string): ProjectMapRunSummary {
   return {
     runId: view.runId,
     taskId,
@@ -1077,11 +1076,11 @@ function buildRunSummary(view: RunGraphView): ProjectMapRunSummary {
 
 function buildSelectedRun(
   view: RunGraphView,
+  taskId: string,
   contract: GraphContract | null,
   requestedNodeId: string | null,
   limit: number,
 ): ProjectMapSelectedRun {
-  const taskId = runTaskId(view);
   const contractNodes = new Map((contract?.nodes ?? []).map((node) => [node.id, node]));
   const actualNodeById = new Map(view.nodes.items.map((node) => [node.id, node]));
   const selectedNodeId =
@@ -1302,7 +1301,9 @@ export function buildProjectMapRunGraphViewModel(
       Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
       left.runId.localeCompare(right.runId),
   );
-  const summaries = sortedViews.map(buildRunSummary);
+  const summaries = sortedViews.map((view) =>
+    buildRunSummary(view, input.taskId ?? runTaskId(view)),
+  );
   const totalRuns = Math.max(input.totalRuns ?? summaries.length, summaries.length);
   const selectedView = input.selectedRunId
     ? (sortedViews.find((view) => view.runId === input.selectedRunId) ?? null)
@@ -1327,7 +1328,13 @@ export function buildProjectMapRunGraphViewModel(
       items,
     },
     selectedRun: selectedView
-      ? buildSelectedRun(selectedView, input.contract, input.selectedNodeId ?? null, limit)
+      ? buildSelectedRun(
+          selectedView,
+          input.taskId ?? runTaskId(selectedView),
+          input.contract,
+          input.selectedNodeId ?? null,
+          limit,
+        )
       : null,
   };
 }

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -806,6 +806,14 @@ function projectMapBoundedCollectionSchema<T extends z.ZodType>(itemSchema: T) {
           message: "items は limit と total 以下である必要があります",
         });
       }
+      const expectedTruncated = collection.total > collection.items.length;
+      if (collection.truncated !== expectedTruncated) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["truncated"],
+          message: "truncated は total と items 件数から導出する必要があります",
+        });
+      }
     });
 }
 

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -726,6 +726,7 @@ export interface ProjectMapSelectedRun {
     attemptsTruncated: boolean;
   };
   deviations: ProjectMapRunDeviation[];
+  deviationsTruncated: boolean;
   metrics: {
     duration: ProjectMapRunMetric;
     tokens: ProjectMapRunMetric;
@@ -908,6 +909,8 @@ const ProjectMapRunDeviationSchema = z
   })
   .strict();
 
+export const PROJECT_MAP_RUN_DEVIATION_LIMIT = 200;
+
 /** UI/agent API が共用する planned-vs-actual response の strict runtime schema。 */
 export const ProjectMapRunGraphViewModelSchema: z.ZodType<ProjectMapRunGraphViewModel> = z
   .object({
@@ -938,7 +941,8 @@ export const ProjectMapRunGraphViewModelSchema: z.ZodType<ProjectMapRunGraphView
             attemptsTruncated: z.boolean(),
           })
           .strict(),
-        deviations: z.array(ProjectMapRunDeviationSchema).max(200),
+        deviations: z.array(ProjectMapRunDeviationSchema).max(PROJECT_MAP_RUN_DEVIATION_LIMIT),
+        deviationsTruncated: z.boolean(),
         metrics: z
           .object({
             duration: ProjectMapRunMetricSchema,
@@ -1239,6 +1243,7 @@ function buildSelectedRun(
     });
   }
 
+  const deviationItems = [...deviations.values()];
   const duration = finiteDuration(view.createdAt, view.updatedAt);
   const plannedNodes = (contract?.nodes ?? []).map((node) => ({ id: node.id, role: node.role }));
   const plannedEdges = (contract?.edges ?? []).map((edge) => ({
@@ -1276,7 +1281,8 @@ function buildSelectedRun(
       nodesTruncated: view.nodes.truncated,
       attemptsTruncated: view.attempts.truncated,
     },
-    deviations: [...deviations.values()],
+    deviations: deviationItems.slice(0, PROJECT_MAP_RUN_DEVIATION_LIMIT),
+    deviationsTruncated: deviationItems.length > PROJECT_MAP_RUN_DEVIATION_LIMIT,
     metrics: {
       duration: { known: duration != null, value: duration, unit: "ms" },
       tokens: { known: false, value: null, unit: "token" },

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { Task, Config, StatusValue, StatusCategory, GroupingFacet } from "./types.js";
 import {
   calculateCriticalPath,
@@ -5,13 +6,21 @@ import {
   dependencyEdgeKey,
   type CriticalPathResult,
 } from "./dependency-graph.js";
-import type {
-  GraphContract,
-  RunGraphActor,
-  RunGraphAttemptState,
-  RunGraphNodeState,
-  RunGraphRunState,
-  RunGraphView,
+import {
+  RUN_GRAPH_ATTEMPT_STATES,
+  RUN_GRAPH_NODE_STATES,
+  RUN_GRAPH_ROLES,
+  RUN_GRAPH_RUN_STATES,
+  RunGraphActorSchema,
+  RunGraphArtifactSchema,
+  RunGraphEvidenceSchema,
+  type RunGraphBoundedCollection,
+  type GraphContract,
+  type RunGraphActor,
+  type RunGraphAttemptState,
+  type RunGraphNodeState,
+  type RunGraphRunState,
+  type RunGraphView,
 } from "./run-graph.js";
 
 /**
@@ -678,6 +687,7 @@ export interface ProjectMapActualAttempt {
   endedAt: string | null;
   durationMs: number | null;
   artifactCount: number;
+  evidenceCount: number;
 }
 
 export interface ProjectMapActualTransition {
@@ -705,8 +715,8 @@ export interface ProjectMapSelectedRun {
   selectedNodeId: string | null;
   deepLink: string;
   planned: {
-    nodes: ProjectMapPlannedNode[];
-    edges: ProjectMapPlannedEdge[];
+    nodes: RunGraphBoundedCollection<ProjectMapPlannedNode>;
+    edges: RunGraphBoundedCollection<ProjectMapPlannedEdge>;
   };
   actual: {
     nodes: ProjectMapActualNode[];
@@ -745,7 +755,197 @@ export interface ProjectMapRunGraphInput {
   selectedRunId?: string | null;
   selectedNodeId?: string | null;
   limit?: number;
+  totalRuns?: number;
 }
+
+const ProjectMapRunDisplayStateSchema = z.enum([
+  "active",
+  "queued",
+  "running",
+  "retrying",
+  "waiting_human",
+  "failed",
+  "completed",
+  "cancelled",
+]);
+
+const ProjectMapRunDeviationKindSchema = z.enum([
+  "unexpected_node",
+  "unexpected_edge",
+  "skip",
+  "retry",
+  "fallback",
+  "cancel",
+]);
+
+const ProjectMapRunMetricSchema = z
+  .object({
+    known: z.boolean(),
+    value: z.number().nullable(),
+    unit: z.enum(["ms", "token", "currency"]),
+  })
+  .strict();
+
+function projectMapBoundedCollectionSchema<T extends z.ZodType>(itemSchema: T) {
+  return z
+    .object({
+      total: z.number().int().nonnegative(),
+      limit: z.number().int().min(1).max(50),
+      truncated: z.boolean(),
+      items: z.array(itemSchema).max(50),
+    })
+    .strict()
+    .superRefine((collection, context) => {
+      if (
+        collection.items.length > collection.limit ||
+        collection.items.length > collection.total
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["items"],
+          message: "items は limit と total 以下である必要があります",
+        });
+      }
+    });
+}
+
+const ProjectMapRunSummarySchema = z
+  .object({
+    runId: z.string().min(1).max(200),
+    taskId: z.string().min(1).max(500),
+    state: z.enum(RUN_GRAPH_RUN_STATES),
+    displayState: ProjectMapRunDisplayStateSchema,
+    currentNodeId: z.string().min(1).max(200).nullable(),
+    currentContractNodeId: z.string().min(1).nullable(),
+    waitReason: z.string().min(1).max(2000).nullable(),
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    nodeCount: z.number().int().nonnegative(),
+    attemptCount: z.number().int().nonnegative(),
+    deepLink: z.string().min(1),
+  })
+  .strict();
+
+const ProjectMapPlannedNodeSchema = z
+  .object({ id: z.string().min(1), role: z.enum(RUN_GRAPH_ROLES) })
+  .strict();
+
+const ProjectMapPlannedEdgeSchema = z
+  .object({
+    id: z.string().min(1),
+    from: z.string().min(1),
+    to: z.string().min(1),
+    conditions: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
+const ProjectMapActualNodeSchema = z
+  .object({
+    id: z.string().min(1).max(200),
+    contractNodeId: z.string().min(1),
+    state: z.enum(RUN_GRAPH_NODE_STATES),
+    displayState: ProjectMapRunDisplayStateSchema,
+    actor: RunGraphActorSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    endedAt: z.string().datetime({ offset: true }).nullable(),
+    durationMs: z.number().nonnegative().nullable(),
+    attemptCount: z.number().int().nonnegative(),
+    artifactCount: z.number().int().nonnegative(),
+    evidenceCount: z.number().int().nonnegative(),
+    isPlanned: z.boolean(),
+    deepLink: z.string().min(1),
+  })
+  .strict();
+
+const ProjectMapActualAttemptSchema = z
+  .object({
+    id: z.string().min(1).max(200),
+    nodeId: z.string().min(1).max(200),
+    ordinal: z.number().int().positive(),
+    state: z.enum(RUN_GRAPH_ATTEMPT_STATES),
+    actor: RunGraphActorSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    updatedAt: z.string().datetime({ offset: true }),
+    endedAt: z.string().datetime({ offset: true }).nullable(),
+    durationMs: z.number().nonnegative().nullable(),
+    artifactCount: z.number().int().nonnegative(),
+    evidenceCount: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const ProjectMapActualTransitionSchema = z
+  .object({
+    fromNodeId: z.string().min(1).max(200),
+    toNodeId: z.string().min(1).max(200),
+    fromContractNodeId: z.string().min(1),
+    toContractNodeId: z.string().min(1),
+    isPlanned: z.boolean(),
+  })
+  .strict();
+
+const ProjectMapRunDeviationSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: ProjectMapRunDeviationKindSchema,
+    nodeId: z.string().min(1).max(200).nullable(),
+    transition: z
+      .object({
+        fromNodeId: z.string().min(1).max(200),
+        toNodeId: z.string().min(1).max(200),
+      })
+      .strict()
+      .nullable(),
+    reason: z.string().min(1),
+  })
+  .strict();
+
+/** UI/agent API が共用する planned-vs-actual response の strict runtime schema。 */
+export const ProjectMapRunGraphViewModelSchema: z.ZodType<ProjectMapRunGraphViewModel> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    taskId: z.string().min(1).max(500).nullable(),
+    runs: projectMapBoundedCollectionSchema(ProjectMapRunSummarySchema),
+    selectedRun: z
+      .object({
+        runId: z.string().min(1).max(200),
+        taskId: z.string().min(1).max(500),
+        state: z.enum(RUN_GRAPH_RUN_STATES),
+        displayState: ProjectMapRunDisplayStateSchema,
+        waitReason: z.string().min(1).max(2000).nullable(),
+        selectedNodeId: z.string().min(1).max(200).nullable(),
+        deepLink: z.string().min(1),
+        planned: z
+          .object({
+            nodes: projectMapBoundedCollectionSchema(ProjectMapPlannedNodeSchema),
+            edges: projectMapBoundedCollectionSchema(ProjectMapPlannedEdgeSchema),
+          })
+          .strict(),
+        actual: z
+          .object({
+            nodes: z.array(ProjectMapActualNodeSchema).max(50),
+            transitions: z.array(ProjectMapActualTransitionSchema).max(50),
+            attempts: z.array(ProjectMapActualAttemptSchema).max(50),
+            nodesTruncated: z.boolean(),
+            attemptsTruncated: z.boolean(),
+          })
+          .strict(),
+        deviations: z.array(ProjectMapRunDeviationSchema).max(200),
+        metrics: z
+          .object({
+            duration: ProjectMapRunMetricSchema,
+            tokens: ProjectMapRunMetricSchema,
+            cost: ProjectMapRunMetricSchema,
+            latency: ProjectMapRunMetricSchema,
+          })
+          .strict(),
+        artifacts: projectMapBoundedCollectionSchema(RunGraphArtifactSchema),
+        evidence: projectMapBoundedCollectionSchema(RunGraphEvidenceSchema),
+      })
+      .strict()
+      .nullable(),
+  })
+  .strict();
 
 function runTaskId(view: RunGraphView): string {
   return `${view.task.owner}/${view.task.repo}#${view.task.issueNumber}`;
@@ -787,8 +987,54 @@ function nodeDisplayState(state: RunGraphNodeState, retrying: boolean): ProjectM
 
 function isTerminalState(state: string): boolean {
   return (
-    state === "completed" || state === "failed" || state === "cancelled" || state === "succeeded"
+    state === "completed" ||
+    state === "failed" ||
+    state === "cancelled" ||
+    state === "succeeded" ||
+    state === "timed_out" ||
+    state === "stalled"
   );
+}
+
+function plannedPathLength(from: string, to: string, edges: GraphContract["edges"]): number | null {
+  if (from === to) return 0;
+  const outgoing = new Map<string, string[]>();
+  for (const edge of edges) {
+    const targets = outgoing.get(edge.from) ?? [];
+    targets.push(edge.to);
+    outgoing.set(edge.from, targets);
+  }
+  const queue: Array<{ id: string; distance: number }> = [{ id: from, distance: 0 }];
+  const visited = new Set([from]);
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index]!;
+    for (const target of outgoing.get(current.id) ?? []) {
+      if (target === to) return current.distance + 1;
+      if (target === "terminal" || visited.has(target)) continue;
+      visited.add(target);
+      queue.push({ id: target, distance: current.distance + 1 });
+    }
+  }
+  return null;
+}
+
+function boundedWithFocus<T>(
+  items: T[],
+  limit: number,
+  matchesFocus: ((item: T) => boolean) | null,
+): RunGraphBoundedCollection<T> {
+  const head = items.slice(0, limit);
+  const focused = matchesFocus ? items.filter(matchesFocus).slice(0, limit) : [];
+  const focusedSet = new Set(focused);
+  const companions = head.filter((item) => !focusedSet.has(item)).slice(0, limit - focused.length);
+  const selected = new Set([...focused, ...companions]);
+  const boundedItems = items.filter((item) => selected.has(item));
+  return {
+    total: items.length,
+    limit,
+    truncated: items.length > boundedItems.length,
+    items: boundedItems,
+  };
 }
 
 function runDeepLink(taskId: string, runId: string, nodeId?: string | null): string {
@@ -825,11 +1071,18 @@ function buildSelectedRun(
   view: RunGraphView,
   contract: GraphContract | null,
   requestedNodeId: string | null,
+  limit: number,
 ): ProjectMapSelectedRun {
   const taskId = runTaskId(view);
   const contractNodes = new Map((contract?.nodes ?? []).map((node) => [node.id, node]));
-  const contractNodeOrder = new Map((contract?.nodes ?? []).map((node, index) => [node.id, index]));
   const actualNodeById = new Map(view.nodes.items.map((node) => [node.id, node]));
+  const selectedNodeId =
+    requestedNodeId && actualNodeById.has(requestedNodeId)
+      ? requestedNodeId
+      : (view.currentNode?.id ?? null);
+  const selectedContractNodeId = selectedNodeId
+    ? (actualNodeById.get(selectedNodeId)?.contractNodeId ?? null)
+    : null;
   const firstOccurrence = new Map<string, string>();
   for (const node of view.nodes.items) {
     if (!firstOccurrence.has(node.contractNodeId))
@@ -869,6 +1122,8 @@ function buildSelectedRun(
     endedAt: isTerminalState(attempt.state) ? attempt.updatedAt : null,
     durationMs: finiteDuration(attempt.createdAt, attempt.updatedAt),
     artifactCount: view.artifacts.items.filter((item) => item.producerAttemptId === attempt.id)
+      .length,
+    evidenceCount: view.evidence.items.filter((item) => item.producerAttemptId === attempt.id)
       .length,
   }));
 
@@ -934,9 +1189,19 @@ function buildSelectedRun(
         reason: `planned にない edge ${edgeKey}`,
       });
     }
-    const fromRank = contractNodeOrder.get(previous.contractNodeId);
-    const toRank = contractNodeOrder.get(node.contractNodeId);
-    if (fromRank != null && toRank != null && toRank < fromRank) {
+    const contractEdges = contract?.edges ?? [];
+    const returnsToVisitedNode = firstOccurrence.get(node.contractNodeId) !== node.id;
+    const reversePathLength = plannedPathLength(
+      node.contractNodeId,
+      previous.contractNodeId,
+      contractEdges,
+    );
+    const forwardPathLength = plannedPathLength(
+      previous.contractNodeId,
+      node.contractNodeId,
+      contractEdges,
+    );
+    if (returnsToVisitedNode || (!isPlanned && reversePathLength != null)) {
       const id = `fallback:${previous.id}->${node.id}`;
       deviations.set(id, {
         id,
@@ -945,7 +1210,7 @@ function buildSelectedRun(
         transition: { fromNodeId: previous.id, toNodeId: node.id },
         reason: `${previous.contractNodeId} から ${node.contractNodeId} へ戻った`,
       });
-    } else if (fromRank != null && toRank != null && toRank > fromRank + 1) {
+    } else if (!isPlanned && forwardPathLength != null && forwardPathLength > 1) {
       const id = `skip:${previous.id}->${node.id}`;
       deviations.set(id, {
         id,
@@ -967,11 +1232,14 @@ function buildSelectedRun(
     });
   }
 
-  const selectedNodeId =
-    requestedNodeId && actualNodeById.has(requestedNodeId)
-      ? requestedNodeId
-      : (view.currentNode?.id ?? null);
   const duration = finiteDuration(view.createdAt, view.updatedAt);
+  const plannedNodes = (contract?.nodes ?? []).map((node) => ({ id: node.id, role: node.role }));
+  const plannedEdges = (contract?.edges ?? []).map((edge) => ({
+    id: edge.id,
+    from: edge.from,
+    to: edge.to,
+    conditions: [edge.condition],
+  }));
   return {
     runId: view.runId,
     taskId,
@@ -981,13 +1249,18 @@ function buildSelectedRun(
     selectedNodeId,
     deepLink: runDeepLink(taskId, view.runId, selectedNodeId),
     planned: {
-      nodes: (contract?.nodes ?? []).map((node) => ({ id: node.id, role: node.role })),
-      edges: (contract?.edges ?? []).map((edge) => ({
-        id: edge.id,
-        from: edge.from,
-        to: edge.to,
-        conditions: [edge.condition],
-      })),
+      nodes: boundedWithFocus(
+        plannedNodes,
+        limit,
+        selectedContractNodeId ? (node) => node.id === selectedContractNodeId : null,
+      ),
+      edges: boundedWithFocus(
+        plannedEdges,
+        limit,
+        selectedContractNodeId
+          ? (edge) => edge.from === selectedContractNodeId || edge.to === selectedContractNodeId
+          : null,
+      ),
     },
     actual: {
       nodes: actualNodes,
@@ -1022,6 +1295,7 @@ export function buildProjectMapRunGraphViewModel(
       left.runId.localeCompare(right.runId),
   );
   const summaries = sortedViews.map(buildRunSummary);
+  const totalRuns = Math.max(input.totalRuns ?? summaries.length, summaries.length);
   const selectedView = input.selectedRunId
     ? (sortedViews.find((view) => view.runId === input.selectedRunId) ?? null)
     : (sortedViews[0] ?? null);
@@ -1039,13 +1313,13 @@ export function buildProjectMapRunGraphViewModel(
     schemaVersion: "1",
     taskId: input.taskId,
     runs: {
-      total: summaries.length,
+      total: totalRuns,
       limit,
-      truncated: summaries.length > items.length,
+      truncated: totalRuns > items.length,
       items,
     },
     selectedRun: selectedView
-      ? buildSelectedRun(selectedView, input.contract, input.selectedNodeId ?? null)
+      ? buildSelectedRun(selectedView, input.contract, input.selectedNodeId ?? null, limit)
       : null,
   };
 }

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -5,6 +5,14 @@ import {
   dependencyEdgeKey,
   type CriticalPathResult,
 } from "./dependency-graph.js";
+import type {
+  GraphContract,
+  RunGraphActor,
+  RunGraphAttemptState,
+  RunGraphNodeState,
+  RunGraphRunState,
+  RunGraphView,
+} from "./run-graph.js";
 
 /**
  * Project Board の列 ID。
@@ -584,6 +592,462 @@ export function buildProjectMapViewModel(
   }
 
   return { hierarchy, boardColumns, readinessById, nextActions, criticalPath, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// planned-vs-actual Run Graph overlay (FR-VIS-026)
+// ---------------------------------------------------------------------------
+
+/** Project Map が operator 向けに正規化する Run / Node の表示状態。 */
+export type ProjectMapRunDisplayState =
+  | "active"
+  | "queued"
+  | "running"
+  | "retrying"
+  | "waiting_human"
+  | "failed"
+  | "completed"
+  | "cancelled";
+
+export type ProjectMapRunDeviationKind =
+  | "unexpected_node"
+  | "unexpected_edge"
+  | "skip"
+  | "retry"
+  | "fallback"
+  | "cancel";
+
+export interface ProjectMapRunMetric {
+  known: boolean;
+  value: number | null;
+  unit: "ms" | "token" | "currency";
+}
+
+export interface ProjectMapRunSummary {
+  runId: string;
+  taskId: string;
+  state: RunGraphRunState;
+  displayState: ProjectMapRunDisplayState;
+  currentNodeId: string | null;
+  currentContractNodeId: string | null;
+  waitReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  nodeCount: number;
+  attemptCount: number;
+  deepLink: string;
+}
+
+export interface ProjectMapPlannedNode {
+  id: string;
+  role: string;
+}
+
+export interface ProjectMapPlannedEdge {
+  id: string;
+  from: string;
+  to: string;
+  conditions: string[];
+}
+
+export interface ProjectMapActualNode {
+  id: string;
+  contractNodeId: string;
+  state: RunGraphNodeState;
+  displayState: ProjectMapRunDisplayState;
+  actor: RunGraphActor;
+  createdAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  durationMs: number | null;
+  attemptCount: number;
+  artifactCount: number;
+  evidenceCount: number;
+  isPlanned: boolean;
+  deepLink: string;
+}
+
+export interface ProjectMapActualAttempt {
+  id: string;
+  nodeId: string;
+  ordinal: number;
+  state: RunGraphAttemptState;
+  actor: RunGraphActor;
+  createdAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  durationMs: number | null;
+  artifactCount: number;
+}
+
+export interface ProjectMapActualTransition {
+  fromNodeId: string;
+  toNodeId: string;
+  fromContractNodeId: string;
+  toContractNodeId: string;
+  isPlanned: boolean;
+}
+
+export interface ProjectMapRunDeviation {
+  id: string;
+  kind: ProjectMapRunDeviationKind;
+  nodeId: string | null;
+  transition: { fromNodeId: string; toNodeId: string } | null;
+  reason: string;
+}
+
+export interface ProjectMapSelectedRun {
+  runId: string;
+  taskId: string;
+  state: RunGraphRunState;
+  displayState: ProjectMapRunDisplayState;
+  waitReason: string | null;
+  selectedNodeId: string | null;
+  deepLink: string;
+  planned: {
+    nodes: ProjectMapPlannedNode[];
+    edges: ProjectMapPlannedEdge[];
+  };
+  actual: {
+    nodes: ProjectMapActualNode[];
+    transitions: ProjectMapActualTransition[];
+    attempts: ProjectMapActualAttempt[];
+    nodesTruncated: boolean;
+    attemptsTruncated: boolean;
+  };
+  deviations: ProjectMapRunDeviation[];
+  metrics: {
+    duration: ProjectMapRunMetric;
+    tokens: ProjectMapRunMetric;
+    cost: ProjectMapRunMetric;
+    latency: ProjectMapRunMetric;
+  };
+  artifacts: RunGraphView["artifacts"];
+  evidence: RunGraphView["evidence"];
+}
+
+export interface ProjectMapRunGraphViewModel {
+  schemaVersion: "1";
+  taskId: string | null;
+  runs: {
+    total: number;
+    limit: number;
+    truncated: boolean;
+    items: ProjectMapRunSummary[];
+  };
+  selectedRun: ProjectMapSelectedRun | null;
+}
+
+export interface ProjectMapRunGraphInput {
+  taskId: string | null;
+  contract: GraphContract | null;
+  runViews: RunGraphView[];
+  selectedRunId?: string | null;
+  selectedNodeId?: string | null;
+  limit?: number;
+}
+
+function runTaskId(view: RunGraphView): string {
+  return `${view.task.owner}/${view.task.repo}#${view.task.issueNumber}`;
+}
+
+function finiteDuration(start: string, end: string): number | null {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return null;
+  return endMs - startMs;
+}
+
+function runDisplayState(state: RunGraphRunState): ProjectMapRunDisplayState {
+  switch (state) {
+    case "pending":
+      return "queued";
+    case "running":
+    case "paused":
+      return "active";
+    default:
+      return state;
+  }
+}
+
+function nodeDisplayState(state: RunGraphNodeState, retrying: boolean): ProjectMapRunDisplayState {
+  if (retrying && (state === "pending" || state === "ready" || state === "running")) {
+    return "retrying";
+  }
+  switch (state) {
+    case "pending":
+    case "ready":
+      return "queued";
+    case "paused":
+      return "running";
+    default:
+      return state;
+  }
+}
+
+function isTerminalState(state: string): boolean {
+  return (
+    state === "completed" || state === "failed" || state === "cancelled" || state === "succeeded"
+  );
+}
+
+function runDeepLink(taskId: string, runId: string, nodeId?: string | null): string {
+  const pairs: Array<[string, string]> = [
+    ["view", "project-map"],
+    ["task", taskId],
+    ["run", runId],
+  ];
+  if (nodeId) pairs.push(["node", nodeId]);
+  return `?${pairs
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&")}`;
+}
+
+function buildRunSummary(view: RunGraphView): ProjectMapRunSummary {
+  const taskId = runTaskId(view);
+  return {
+    runId: view.runId,
+    taskId,
+    state: view.state,
+    displayState: runDisplayState(view.state),
+    currentNodeId: view.currentNode?.id ?? null,
+    currentContractNodeId: view.currentNode?.contractNodeId ?? null,
+    waitReason: view.waitReason,
+    createdAt: view.createdAt,
+    updatedAt: view.updatedAt,
+    nodeCount: view.nodes.total,
+    attemptCount: view.attempts.total,
+    deepLink: runDeepLink(taskId, view.runId, view.currentNode?.id),
+  };
+}
+
+function buildSelectedRun(
+  view: RunGraphView,
+  contract: GraphContract | null,
+  requestedNodeId: string | null,
+): ProjectMapSelectedRun {
+  const taskId = runTaskId(view);
+  const contractNodes = new Map((contract?.nodes ?? []).map((node) => [node.id, node]));
+  const contractNodeOrder = new Map((contract?.nodes ?? []).map((node, index) => [node.id, index]));
+  const actualNodeById = new Map(view.nodes.items.map((node) => [node.id, node]));
+  const firstOccurrence = new Map<string, string>();
+  for (const node of view.nodes.items) {
+    if (!firstOccurrence.has(node.contractNodeId))
+      firstOccurrence.set(node.contractNodeId, node.id);
+  }
+
+  const actualNodes: ProjectMapActualNode[] = view.nodes.items.map((node) => {
+    const attempts = view.attempts.items.filter((attempt) => attempt.nodeId === node.id);
+    const retrying =
+      firstOccurrence.get(node.contractNodeId) !== node.id || attempts.some((a) => a.ordinal > 1);
+    return {
+      id: node.id,
+      contractNodeId: node.contractNodeId,
+      state: node.state,
+      displayState: nodeDisplayState(node.state, retrying),
+      actor: node.actor,
+      createdAt: node.createdAt,
+      updatedAt: node.updatedAt,
+      endedAt: isTerminalState(node.state) ? node.updatedAt : null,
+      durationMs: finiteDuration(node.createdAt, node.updatedAt),
+      attemptCount: attempts.length,
+      artifactCount: view.artifacts.items.filter((item) => item.nodeId === node.id).length,
+      evidenceCount: view.evidence.items.filter((item) => item.nodeId === node.id).length,
+      isPlanned: contractNodes.has(node.contractNodeId),
+      deepLink: runDeepLink(taskId, view.runId, node.id),
+    };
+  });
+
+  const actualAttempts: ProjectMapActualAttempt[] = view.attempts.items.map((attempt) => ({
+    id: attempt.id,
+    nodeId: attempt.nodeId,
+    ordinal: attempt.ordinal,
+    state: attempt.state,
+    actor: attempt.actor,
+    createdAt: attempt.createdAt,
+    updatedAt: attempt.updatedAt,
+    endedAt: isTerminalState(attempt.state) ? attempt.updatedAt : null,
+    durationMs: finiteDuration(attempt.createdAt, attempt.updatedAt),
+    artifactCount: view.artifacts.items.filter((item) => item.producerAttemptId === attempt.id)
+      .length,
+  }));
+
+  const plannedEdgeKeys = new Set(
+    (contract?.edges ?? []).map((edge) => `${edge.from}->${edge.to}`),
+  );
+  const transitions: ProjectMapActualTransition[] = [];
+  const deviations = new Map<string, ProjectMapRunDeviation>();
+
+  for (const node of view.nodes.items) {
+    const hasRetriedAttempt = view.attempts.items.some(
+      (attempt) => attempt.nodeId === node.id && attempt.ordinal > 1,
+    );
+    if (!contractNodes.has(node.contractNodeId)) {
+      const id = `unexpected-node:${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "unexpected_node",
+        nodeId: node.id,
+        transition: null,
+        reason: `planned にない node ${node.contractNodeId}`,
+      });
+    }
+    if (firstOccurrence.get(node.contractNodeId) !== node.id || hasRetriedAttempt) {
+      const id = `retry:${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "retry",
+        nodeId: node.id,
+        transition: null,
+        reason: `${node.contractNodeId} を再試行`,
+      });
+    }
+    if (node.state === "cancelled") {
+      const id = `cancel:${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "cancel",
+        nodeId: node.id,
+        transition: null,
+        reason: `${node.contractNodeId} が cancelled`,
+      });
+    }
+    if (!node.previousNodeId) continue;
+    const previous = actualNodeById.get(node.previousNodeId);
+    if (!previous) continue;
+    const edgeKey = `${previous.contractNodeId}->${node.contractNodeId}`;
+    const isPlanned = plannedEdgeKeys.has(edgeKey);
+    transitions.push({
+      fromNodeId: previous.id,
+      toNodeId: node.id,
+      fromContractNodeId: previous.contractNodeId,
+      toContractNodeId: node.contractNodeId,
+      isPlanned,
+    });
+    if (!isPlanned) {
+      const id = `unexpected-edge:${previous.id}->${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "unexpected_edge",
+        nodeId: node.id,
+        transition: { fromNodeId: previous.id, toNodeId: node.id },
+        reason: `planned にない edge ${edgeKey}`,
+      });
+    }
+    const fromRank = contractNodeOrder.get(previous.contractNodeId);
+    const toRank = contractNodeOrder.get(node.contractNodeId);
+    if (fromRank != null && toRank != null && toRank < fromRank) {
+      const id = `fallback:${previous.id}->${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "fallback",
+        nodeId: node.id,
+        transition: { fromNodeId: previous.id, toNodeId: node.id },
+        reason: `${previous.contractNodeId} から ${node.contractNodeId} へ戻った`,
+      });
+    } else if (fromRank != null && toRank != null && toRank > fromRank + 1) {
+      const id = `skip:${previous.id}->${node.id}`;
+      deviations.set(id, {
+        id,
+        kind: "skip",
+        nodeId: node.id,
+        transition: { fromNodeId: previous.id, toNodeId: node.id },
+        reason: `${previous.contractNodeId} と ${node.contractNodeId} の間の planned node を skip`,
+      });
+    }
+  }
+
+  if (view.state === "cancelled") {
+    deviations.set(`cancel:${view.runId}`, {
+      id: `cancel:${view.runId}`,
+      kind: "cancel",
+      nodeId: view.currentNode?.id ?? null,
+      transition: null,
+      reason: `run ${view.runId} が cancelled`,
+    });
+  }
+
+  const selectedNodeId =
+    requestedNodeId && actualNodeById.has(requestedNodeId)
+      ? requestedNodeId
+      : (view.currentNode?.id ?? null);
+  const duration = finiteDuration(view.createdAt, view.updatedAt);
+  return {
+    runId: view.runId,
+    taskId,
+    state: view.state,
+    displayState: runDisplayState(view.state),
+    waitReason: view.waitReason,
+    selectedNodeId,
+    deepLink: runDeepLink(taskId, view.runId, selectedNodeId),
+    planned: {
+      nodes: (contract?.nodes ?? []).map((node) => ({ id: node.id, role: node.role })),
+      edges: (contract?.edges ?? []).map((edge) => ({
+        id: edge.id,
+        from: edge.from,
+        to: edge.to,
+        conditions: [edge.condition],
+      })),
+    },
+    actual: {
+      nodes: actualNodes,
+      transitions,
+      attempts: actualAttempts,
+      nodesTruncated: view.nodes.truncated,
+      attemptsTruncated: view.attempts.truncated,
+    },
+    deviations: [...deviations.values()],
+    metrics: {
+      duration: { known: duration != null, value: duration, unit: "ms" },
+      tokens: { known: false, value: null, unit: "token" },
+      cost: { known: false, value: null, unit: "currency" },
+      latency: { known: false, value: null, unit: "ms" },
+    },
+    artifacts: view.artifacts,
+    evidence: view.evidence,
+  };
+}
+
+/**
+ * Graph Contract と bounded RunGraphView から Project Map/API 共通の overlay を導出する。
+ * runner log 本文は受け取らず、bounded entity/reference だけを返す。
+ */
+export function buildProjectMapRunGraphViewModel(
+  input: ProjectMapRunGraphInput,
+): ProjectMapRunGraphViewModel {
+  const limit = Math.min(50, Math.max(1, input.limit ?? 20));
+  const sortedViews = [...input.runViews].sort(
+    (left, right) =>
+      Date.parse(right.updatedAt) - Date.parse(left.updatedAt) ||
+      left.runId.localeCompare(right.runId),
+  );
+  const summaries = sortedViews.map(buildRunSummary);
+  const selectedView = input.selectedRunId
+    ? (sortedViews.find((view) => view.runId === input.selectedRunId) ?? null)
+    : (sortedViews[0] ?? null);
+  let items = summaries.slice(0, limit);
+  if (selectedView && !items.some((summary) => summary.runId === selectedView.runId)) {
+    const selectedSummary = summaries.find((summary) => summary.runId === selectedView.runId);
+    if (selectedSummary) {
+      items = [
+        selectedSummary,
+        ...items.filter((summary) => summary.runId !== selectedView.runId),
+      ].slice(0, limit);
+    }
+  }
+  return {
+    schemaVersion: "1",
+    taskId: input.taskId,
+    runs: {
+      total: summaries.length,
+      limit,
+      truncated: summaries.length > items.length,
+      items,
+    },
+    selectedRun: selectedView
+      ? buildSelectedRun(selectedView, input.contract, input.selectedNodeId ?? null)
+      : null,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/run-graph.ts
+++ b/packages/shared/src/run-graph.ts
@@ -1267,13 +1267,7 @@ export const RunGraphViewSchema: z.ZodType<RunGraphView> = z
     schemaVersion: z.literal("1"),
     runId: OpaqueIdSchema,
     task: TaskReferenceSchema,
-    contract: z
-      .object({
-        planId: z.string().min(1),
-        planVersion: z.string().min(1),
-        schemaVersion: z.string().min(1),
-      })
-      .strict(),
+    contract: ContractReferenceSchema,
     revision: z.number().int().nonnegative(),
     state: z.enum(RUN_GRAPH_RUN_STATES),
     createdAt: TimestampSchema,

--- a/packages/shared/src/run-graph.ts
+++ b/packages/shared/src/run-graph.ts
@@ -1074,13 +1074,18 @@ export interface RunGraphView {
   schemaVersion: "1";
   runId: string;
   task: { owner: string; repo: string; issueNumber: number };
+  contract: RunGraphRun["contract"];
   revision: number;
   state: RunGraphRunState;
+  createdAt: string;
+  updatedAt: string;
   currentNode: RunGraphNode | null;
   activeAttempt: RunGraphAttempt | null;
   waitReason: string | null;
   budgets: RunGraphBudgetProjection;
   allowedNextTransitions: RunGraphRunnerCommandType[];
+  nodes: RunGraphBoundedCollection<RunGraphNode>;
+  attempts: RunGraphBoundedCollection<RunGraphAttempt>;
   artifacts: RunGraphBoundedCollection<RunGraphArtifact>;
   evidence: RunGraphBoundedCollection<RunGraphEvidence>;
 }
@@ -1254,19 +1259,32 @@ function boundedCollectionSchema<T>(
 
 const BoundedArtifactCollectionSchema = boundedCollectionSchema(RunGraphArtifactSchema);
 const BoundedEvidenceCollectionSchema = boundedCollectionSchema(RunGraphEvidenceSchema);
+const BoundedNodeCollectionSchema = boundedCollectionSchema(RunGraphNodeSchema);
+const BoundedAttemptCollectionSchema = boundedCollectionSchema(RunGraphAttemptSchema);
 
 export const RunGraphViewSchema: z.ZodType<RunGraphView> = z
   .object({
     schemaVersion: z.literal("1"),
     runId: OpaqueIdSchema,
     task: TaskReferenceSchema,
+    contract: z
+      .object({
+        planId: z.string().min(1),
+        planVersion: z.string().min(1),
+        schemaVersion: z.string().min(1),
+      })
+      .strict(),
     revision: z.number().int().nonnegative(),
     state: z.enum(RUN_GRAPH_RUN_STATES),
+    createdAt: TimestampSchema,
+    updatedAt: TimestampSchema,
     currentNode: RunGraphNodeSchema.nullable(),
     activeAttempt: RunGraphAttemptSchema.nullable(),
     waitReason: z.string().min(1).max(2000).nullable(),
     budgets: RunGraphBudgetProjectionSchema,
     allowedNextTransitions: z.array(z.enum(RUN_GRAPH_RUNNER_COMMAND_TYPES)),
+    nodes: BoundedNodeCollectionSchema,
+    attempts: BoundedAttemptCollectionSchema,
     artifacts: BoundedArtifactCollectionSchema,
     evidence: BoundedEvidenceCollectionSchema,
   })

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -802,7 +802,12 @@ export function App() {
                     runGraphLoading={projectMapRunGraph.loading}
                     runGraphError={projectMapRunGraph.error}
                     onSelectRun={setSelectedRunId}
-                    onSelectRunNode={setSelectedNodeId}
+                    onSelectRunNode={(nodeId) =>
+                      setSelectedNodeId(
+                        nodeId,
+                        projectMapRunGraph.viewModel?.selectedRun?.runId ?? null,
+                      )
+                    }
                     syncRefreshKey={syncing}
                   />
                 ) : null}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -26,6 +26,8 @@ import { useCustomNonWorkingDays } from "./hooks/useCustomNonWorkingDays.js";
 import { useHolidayPreset } from "./hooks/useHolidayPreset.js";
 import { useFilterPresets, type FilterPresetState } from "./hooks/useFilterPresets.js";
 import { useTaskDeepLink } from "./hooks/useTaskDeepLink.js";
+import { useProjectMapRunGraph } from "./hooks/useProjectMapRunGraph.js";
+import { useRunGraphDeepLink } from "./hooks/useRunGraphDeepLink.js";
 import { downloadGanttExport } from "./lib/export-download.js";
 import type { ExportRequest } from "./components/toolbar/ExportMenu.js";
 
@@ -80,7 +82,20 @@ export function App() {
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
   const [detailPanelWidth, setDetailPanelWidth] = useState(400);
   const [viewScale, setViewScale] = useState<ViewScale>("month");
-  const [viewMode, setViewMode] = useState<AppViewMode>("gantt");
+  const [viewMode, setViewMode] = useState<AppViewMode>(() => {
+    if (typeof window === "undefined") return "gantt";
+    return new URL(window.location.href).searchParams.get("view") === "project-map"
+      ? "project-map"
+      : "gantt";
+  });
+  const { selectedRunId, selectedNodeId, setSelectedRunId, setSelectedNodeId, clearRunSelection } =
+    useRunGraphDeepLink();
+  const projectMapRunGraph = useProjectMapRunGraph(
+    selectedTaskId,
+    selectedRunId,
+    selectedNodeId,
+    viewMode === "project-map",
+  );
   const [taskSortMode, setTaskSortMode] = useState<TaskSortMode>("default");
   const [labelGroupingEnabled, setLabelGroupingEnabled] = useState(false);
   const [ganttHeader, setGanttHeader] = useState<React.ReactNode>(null);
@@ -130,17 +145,27 @@ export function App() {
     setGanttHeader(node);
   }, []);
 
-  const handleSelectTask = useCallback((taskId: string) => {
-    setSelectedTaskId((prev) => (prev === taskId ? null : taskId));
-  }, []);
+  const handleSelectTask = useCallback(
+    (taskId: string) => {
+      const nextTaskId = selectedTaskId === taskId ? null : taskId;
+      if (nextTaskId !== selectedTaskId) clearRunSelection();
+      setSelectedTaskId(nextTaskId);
+    },
+    [clearRunSelection, selectedTaskId, setSelectedTaskId],
+  );
 
   const handleDeselectTask = useCallback(() => {
+    clearRunSelection();
     setSelectedTaskId(null);
-  }, []);
+  }, [clearRunSelection, setSelectedTaskId]);
 
-  const activateTask = useCallback((taskId: string) => {
-    setSelectedTaskId(taskId);
-  }, []);
+  const activateTask = useCallback(
+    (taskId: string) => {
+      if (taskId !== selectedTaskId) clearRunSelection();
+      setSelectedTaskId(taskId);
+    },
+    [clearRunSelection, selectedTaskId, setSelectedTaskId],
+  );
 
   const {
     enabled,
@@ -773,6 +798,11 @@ export function App() {
                     config={config}
                     selectedTaskId={selectedTaskId}
                     onSelectTask={handleSelectTask}
+                    runGraphViewModel={projectMapRunGraph.viewModel}
+                    runGraphLoading={projectMapRunGraph.loading}
+                    runGraphError={projectMapRunGraph.error}
+                    onSelectRun={setSelectedRunId}
+                    onSelectRunNode={setSelectedNodeId}
                     syncRefreshKey={syncing}
                   />
                 ) : null}

--- a/packages/ui/src/__tests__/project-map-run-graph.test.tsx
+++ b/packages/ui/src/__tests__/project-map-run-graph.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+import React from "react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProjectMapRunGraphViewModel } from "@gh-gantt/shared";
+import { RunGraphPanel } from "../components/project-map/RunGraphPanel.js";
+import { useRunGraphDeepLink } from "../hooks/useRunGraphDeepLink.js";
+import { useProjectMapRunGraph } from "../hooks/useProjectMapRunGraph.js";
+
+const viewModel: ProjectMapRunGraphViewModel = {
+  schemaVersion: "1",
+  taskId: "stanah/gh-gantt#330",
+  runs: {
+    total: 1,
+    limit: 20,
+    truncated: false,
+    items: [
+      {
+        runId: "run-330",
+        taskId: "stanah/gh-gantt#330",
+        state: "waiting_human",
+        displayState: "waiting_human",
+        currentNodeId: "node-2",
+        currentContractNodeId: "implementer",
+        waitReason: "review_budget_exhausted",
+        createdAt: "2026-07-30T00:00:00.000Z",
+        updatedAt: "2026-07-30T00:04:00.000Z",
+        nodeCount: 2,
+        attemptCount: 1,
+        deepLink: "?view=project-map&task=stanah%2Fgh-gantt%23330&run=run-330&node=node-2",
+      },
+    ],
+  },
+  selectedRun: {
+    runId: "run-330",
+    taskId: "stanah/gh-gantt#330",
+    state: "waiting_human",
+    displayState: "waiting_human",
+    waitReason: "review_budget_exhausted",
+    selectedNodeId: "node-2",
+    deepLink: "?view=project-map&task=stanah%2Fgh-gantt%23330&run=run-330&node=node-2",
+    planned: {
+      nodes: [
+        { id: "planner", role: "planner" },
+        { id: "implementer", role: "implementer" },
+      ],
+      edges: [{ id: "plan-valid", from: "planner", to: "implementer", conditions: ["plan_valid"] }],
+    },
+    actual: {
+      nodes: [
+        {
+          id: "node-1",
+          contractNodeId: "planner",
+          state: "completed",
+          displayState: "completed",
+          actor: { id: "planner-1", role: "planner" },
+          createdAt: "2026-07-30T00:00:00.000Z",
+          updatedAt: "2026-07-30T00:01:00.000Z",
+          endedAt: "2026-07-30T00:01:00.000Z",
+          durationMs: 60000,
+          attemptCount: 1,
+          artifactCount: 0,
+          evidenceCount: 0,
+          isPlanned: true,
+          deepLink: "?view=project-map&task=stanah%2Fgh-gantt%23330&run=run-330&node=node-1",
+        },
+        {
+          id: "node-2",
+          contractNodeId: "implementer",
+          state: "ready",
+          displayState: "retrying",
+          actor: { id: "implementer-1", role: "implementer" },
+          createdAt: "2026-07-30T00:01:00.000Z",
+          updatedAt: "2026-07-30T00:04:00.000Z",
+          endedAt: null,
+          durationMs: 180000,
+          attemptCount: 0,
+          artifactCount: 0,
+          evidenceCount: 0,
+          isPlanned: true,
+          deepLink: "?view=project-map&task=stanah%2Fgh-gantt%23330&run=run-330&node=node-2",
+        },
+      ],
+      transitions: [
+        {
+          fromNodeId: "node-1",
+          toNodeId: "node-2",
+          fromContractNodeId: "planner",
+          toContractNodeId: "implementer",
+          isPlanned: true,
+        },
+      ],
+      attempts: [
+        {
+          id: "attempt-1",
+          nodeId: "node-1",
+          ordinal: 1,
+          state: "succeeded",
+          actor: { id: "planner-1", role: "planner" },
+          createdAt: "2026-07-30T00:00:00.000Z",
+          updatedAt: "2026-07-30T00:01:00.000Z",
+          endedAt: "2026-07-30T00:01:00.000Z",
+          durationMs: 60000,
+          artifactCount: 0,
+        },
+      ],
+      nodesTruncated: false,
+      attemptsTruncated: false,
+    },
+    deviations: [
+      {
+        id: "retry:node-2",
+        kind: "retry",
+        nodeId: "node-2",
+        transition: null,
+        reason: "implementer を再試行",
+      },
+    ],
+    metrics: {
+      duration: { known: true, value: 240000, unit: "ms" },
+      tokens: { known: false, value: null, unit: "token" },
+      cost: { known: false, value: null, unit: "currency" },
+      latency: { known: false, value: null, unit: "ms" },
+    },
+    artifacts: { total: 0, limit: 20, truncated: false, items: [] },
+    evidence: { total: 0, limit: 20, truncated: false, items: [] },
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.history.replaceState({}, "", "/");
+});
+
+function DeepLinkProbe() {
+  const { selectedRunId, selectedNodeId, setSelectedRunId, setSelectedNodeId } =
+    useRunGraphDeepLink();
+  return (
+    <div>
+      <output aria-label="selected run">{selectedRunId ?? ""}</output>
+      <output aria-label="selected node">{selectedNodeId ?? ""}</output>
+      <button type="button" onClick={() => setSelectedRunId("run-next")}>
+        run
+      </button>
+      <button type="button" onClick={() => setSelectedNodeId("node-next")}>
+        node
+      </button>
+    </div>
+  );
+}
+
+function FetchProbe({ taskId = "stanah/gh-gantt#330" }: { taskId?: string | null }) {
+  const result = useProjectMapRunGraph(taskId, "run-330", "node-2", true);
+  return (
+    <div>
+      <output aria-label="run loading">{String(result.loading)}</output>
+      <output aria-label="run data">{result.viewModel?.selectedRun?.runId ?? ""}</output>
+      <output aria-label="run error">{result.error ?? ""}</output>
+    </div>
+  );
+}
+
+describe("[FR-VIS-026-AC6] planned-vs-actual panel の操作性", () => {
+  it("状態、待機理由、planned/actual、attempt、差分、unknown metric を表示する", () => {
+    const { getByLabelText, getByText, getAllByText } = render(
+      <RunGraphPanel
+        viewModel={viewModel}
+        loading={false}
+        error={null}
+        onSelectRun={vi.fn()}
+        onSelectNode={vi.fn()}
+      />,
+    );
+
+    expect(getByText("Planned vs Actual")).toBeTruthy();
+    expect(getByText("waiting_human")).toBeTruthy();
+    expect(getByText("review_budget_exhausted")).toBeTruthy();
+    expect(getByLabelText("Planned nodes").textContent).toContain("planner");
+    expect(getByLabelText("Planned nodes").textContent).toContain("planner → implementer");
+    expect(getByLabelText("Actual nodes").textContent).toContain("retrying");
+    expect(getByLabelText("Actual nodes").textContent).toContain("node-1 → node-2");
+    expect(getByLabelText("Actual nodes").textContent).toContain("artifact 0 · evidence 0");
+    expect(getByText("implementer を再試行")).toBeTruthy();
+    expect(within(getByLabelText("Attempts")).getByText(/planner-1.*60s/)).toBeTruthy();
+    expect(getAllByText("unknown")).toHaveLength(3);
+  });
+
+  it("run 選択と node の Enter 操作を callback に渡し deep link を公開する", () => {
+    const onSelectRun = vi.fn();
+    const onSelectNode = vi.fn();
+    const { getByLabelText, getByRole } = render(
+      <RunGraphPanel
+        viewModel={viewModel}
+        loading={false}
+        error={null}
+        onSelectRun={onSelectRun}
+        onSelectNode={onSelectNode}
+      />,
+    );
+
+    fireEvent.change(getByLabelText("Run を選択"), { target: { value: "run-330" } });
+    expect(onSelectRun).toHaveBeenCalledWith("run-330");
+
+    const node = getByRole("button", { name: /implementer.*node-2/ });
+    fireEvent.keyDown(node, { key: "Enter" });
+    expect(onSelectNode).toHaveBeenCalledWith("node-2");
+    expect(getByRole("link", { name: "選択 node の deep link" }).getAttribute("href")).toContain(
+      "node=node-2",
+    );
+  });
+
+  it("Run Graph がない場合は空状態を表示する", () => {
+    const { getByText } = render(
+      <RunGraphPanel
+        viewModel={{
+          ...viewModel,
+          runs: { total: 0, limit: 20, truncated: false, items: [] },
+          selectedRun: null,
+        }}
+        loading={false}
+        error={null}
+        onSelectRun={vi.fn()}
+        onSelectNode={vi.fn()}
+      />,
+    );
+
+    expect(getByText("このタスクの Run Graph はありません")).toBeTruthy();
+  });
+});
+
+describe("[FR-VIS-026-AC4] run/node の URL deep link", () => {
+  it("query から復元し、run 変更時は stale node を消して Project Map view を維持する", () => {
+    window.history.replaceState({}, "", "/?labels=area%3Aui&run=run-330&node=node-2");
+    const { getByLabelText, getByText } = render(<DeepLinkProbe />);
+
+    expect(getByLabelText("selected run").textContent).toBe("run-330");
+    expect(getByLabelText("selected node").textContent).toBe("node-2");
+
+    fireEvent.click(getByText("run"));
+    const afterRun = new URL(window.location.href).searchParams;
+    expect(afterRun.get("run")).toBe("run-next");
+    expect(afterRun.has("node")).toBe(false);
+    expect(afterRun.get("view")).toBe("project-map");
+    expect(afterRun.get("labels")).toBe("area:ui");
+
+    fireEvent.click(getByText("node"));
+    expect(new URL(window.location.href).searchParams.get("node")).toBe("node-next");
+  });
+
+  it("選択 task/run/node だけを bounded API query に渡す", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => viewModel,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getByLabelText } = render(<FetchProbe />);
+    await waitFor(() => expect(getByLabelText("run data").textContent).toBe("run-330"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]), "http://localhost");
+    expect(requestUrl.pathname).toBe("/api/project-map/run-graph");
+    expect(requestUrl.searchParams.get("taskId")).toBe("stanah/gh-gantt#330");
+    expect(requestUrl.searchParams.get("runId")).toBe("run-330");
+    expect(requestUrl.searchParams.get("nodeId")).toBe("node-2");
+    expect(requestUrl.searchParams.get("limit")).toBe("20");
+    expect(getByLabelText("run loading").textContent).toBe("false");
+    expect(getByLabelText("run error").textContent).toBe("");
+  });
+});

--- a/packages/ui/src/__tests__/project-map-run-graph.test.tsx
+++ b/packages/ui/src/__tests__/project-map-run-graph.test.tsx
@@ -40,11 +40,23 @@ const viewModel: ProjectMapRunGraphViewModel = {
     selectedNodeId: "node-2",
     deepLink: "?view=project-map&task=stanah%2Fgh-gantt%23330&run=run-330&node=node-2",
     planned: {
-      nodes: [
-        { id: "planner", role: "planner" },
-        { id: "implementer", role: "implementer" },
-      ],
-      edges: [{ id: "plan-valid", from: "planner", to: "implementer", conditions: ["plan_valid"] }],
+      nodes: {
+        total: 2,
+        limit: 20,
+        truncated: false,
+        items: [
+          { id: "planner", role: "planner" },
+          { id: "implementer", role: "implementer" },
+        ],
+      },
+      edges: {
+        total: 1,
+        limit: 20,
+        truncated: false,
+        items: [
+          { id: "plan-valid", from: "planner", to: "implementer", conditions: ["plan_valid"] },
+        ],
+      },
     },
     actual: {
       nodes: [
@@ -102,6 +114,7 @@ const viewModel: ProjectMapRunGraphViewModel = {
           endedAt: "2026-07-30T00:01:00.000Z",
           durationMs: 60000,
           artifactCount: 0,
+          evidenceCount: 0,
         },
       ],
       nodesTruncated: false,
@@ -182,7 +195,11 @@ describe("[FR-VIS-026-AC6] planned-vs-actual panel の操作性", () => {
     expect(getByLabelText("Actual nodes").textContent).toContain("node-1 → node-2");
     expect(getByLabelText("Actual nodes").textContent).toContain("artifact 0 · evidence 0");
     expect(getByText("implementer を再試行")).toBeTruthy();
-    expect(within(getByLabelText("Attempts")).getByText(/planner-1.*60s/)).toBeTruthy();
+    expect(
+      within(getByLabelText("Attempts")).getByText(
+        /node-1.*attempt-1.*planner-1.*planner.*2026-07-30T00:00:00.000Z.*2026-07-30T00:01:00.000Z.*60s.*artifact 0.*evidence 0/,
+      ),
+    ).toBeTruthy();
     expect(getAllByText("unknown")).toHaveLength(3);
   });
 
@@ -267,5 +284,26 @@ describe("[FR-VIS-026-AC4] run/node の URL deep link", () => {
     expect(requestUrl.searchParams.get("limit")).toBe("20");
     expect(getByLabelText("run loading").textContent).toBe("false");
     expect(getByLabelText("run error").textContent).toBe("");
+  });
+
+  it("strict schema に合わない API 応答を表示へ渡さない", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          schemaVersion: "1",
+          taskId: "stanah/gh-gantt#330",
+          runs: { total: 0, limit: 20, truncated: false, items: [] },
+          selectedRun: null,
+          unexpected: "field",
+        }),
+      }),
+    );
+
+    const { getByLabelText } = render(<FetchProbe />);
+    await waitFor(() => expect(getByLabelText("run error").textContent).not.toBe(""));
+
+    expect(getByLabelText("run data").textContent).toBe("");
   });
 });

--- a/packages/ui/src/__tests__/project-map-run-graph.test.tsx
+++ b/packages/ui/src/__tests__/project-map-run-graph.test.tsx
@@ -146,7 +146,7 @@ afterEach(() => {
   window.history.replaceState({}, "", "/");
 });
 
-function DeepLinkProbe() {
+function DeepLinkProbe({ displayedRunId = null }: { displayedRunId?: string | null }) {
   const { selectedRunId, selectedNodeId, setSelectedRunId, setSelectedNodeId } =
     useRunGraphDeepLink();
   return (
@@ -158,6 +158,9 @@ function DeepLinkProbe() {
       </button>
       <button type="button" onClick={() => setSelectedNodeId("node-next")}>
         node
+      </button>
+      <button type="button" onClick={() => setSelectedNodeId("node-default", displayedRunId)}>
+        default node
       </button>
     </div>
   );
@@ -263,6 +266,17 @@ describe("[FR-VIS-026-AC4] run/node の URL deep link", () => {
 
     fireEvent.click(getByText("node"));
     expect(new URL(window.location.href).searchParams.get("node")).toBe("node-next");
+  });
+
+  it("URL に run がなくても表示中の既定 run と node を一緒に deep link へ保存する", () => {
+    window.history.replaceState({}, "", "/?view=project-map&task=stanah%2Fgh-gantt%23330");
+    const { getByText } = render(<DeepLinkProbe displayedRunId="run-330" />);
+
+    fireEvent.click(getByText("default node"));
+
+    const params = new URL(window.location.href).searchParams;
+    expect(params.get("run")).toBe("run-330");
+    expect(params.get("node")).toBe("node-default");
   });
 
   it("選択 task/run/node だけを bounded API query に渡す", async () => {

--- a/packages/ui/src/__tests__/project-map-run-graph.test.tsx
+++ b/packages/ui/src/__tests__/project-map-run-graph.test.tsx
@@ -129,6 +129,7 @@ const viewModel: ProjectMapRunGraphViewModel = {
         reason: "implementer を再試行",
       },
     ],
+    deviationsTruncated: false,
     metrics: {
       duration: { known: true, value: 240000, unit: "ms" },
       tokens: { known: false, value: null, unit: "token" },
@@ -246,6 +247,23 @@ describe("[FR-VIS-026-AC6] planned-vs-actual panel の操作性", () => {
     );
 
     expect(getByText("このタスクの Run Graph はありません")).toBeTruthy();
+  });
+
+  it("deviation が上限を超えた場合は一部表示であることを示す", () => {
+    const { getByText } = render(
+      <RunGraphPanel
+        viewModel={{
+          ...viewModel,
+          selectedRun: { ...viewModel.selectedRun!, deviationsTruncated: true },
+        }}
+        loading={false}
+        error={null}
+        onSelectRun={vi.fn()}
+        onSelectNode={vi.fn()}
+      />,
+    );
+
+    expect(getByText("差分は先頭 200 件のみ表示")).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/__tests__/project-map.test.tsx
+++ b/packages/ui/src/__tests__/project-map.test.tsx
@@ -93,7 +93,7 @@ function renderPage(selectedTaskId: string | null, onSelectTask = vi.fn()) {
 }
 
 describe("[FR-VIS-024] Project Map ページ", () => {
-  it("5 パネルのレイアウトと System Tree のタスクが描画される", () => {
+  it("6 パネルのレイアウトと System Tree のタスクが描画される", () => {
     const { container, getByText } = renderPage(null);
     expect(container.querySelector('[data-testid="project-map-page"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="project-map-layout"]')).not.toBeNull();
@@ -103,6 +103,8 @@ describe("[FR-VIS-024] Project Map ページ", () => {
     expect(getByText("Dependency Map")).toBeTruthy();
     expect(getByText("Next Actions")).toBeTruthy();
     expect(getByText("Compact Gantt")).toBeTruthy();
+    expect(getByText("Planned vs Actual")).toBeTruthy();
+    expect(container.querySelector('[aria-label="Run Graph"]')).not.toBeNull();
   });
 
   it("依存解除済みでない t2 は Ready Now ではなく Blocked 列に出る（t1 完了済みなら Ready）", () => {

--- a/packages/ui/src/components/project-map/ProjectMapLayout.tsx
+++ b/packages/ui/src/components/project-map/ProjectMapLayout.tsx
@@ -6,6 +6,7 @@ interface ProjectMapLayoutProps {
   dependency: React.ReactNode;
   nextActions: React.ReactNode;
   timeline: React.ReactNode;
+  runGraph: React.ReactNode;
 }
 
 const panelStyle: React.CSSProperties = {
@@ -30,6 +31,7 @@ export function ProjectMapLayout({
   dependency,
   nextActions,
   timeline,
+  runGraph,
 }: ProjectMapLayoutProps) {
   return (
     <div
@@ -41,10 +43,11 @@ export function ProjectMapLayout({
         height: "100%",
         boxSizing: "border-box",
         gridTemplateColumns: "minmax(220px, 1fr) minmax(280px, 1.6fr) minmax(240px, 1fr)",
-        gridTemplateRows: "minmax(0, 1.4fr) minmax(0, 1fr)",
+        gridTemplateRows: "minmax(280px, 1.4fr) minmax(220px, 1fr) minmax(260px, 1.1fr)",
         gridTemplateAreas: `
           "tree board dependency"
           "next next timeline"
+          "run run run"
         `,
         overflow: "auto",
       }}
@@ -63,6 +66,9 @@ export function ProjectMapLayout({
       </section>
       <section style={{ ...panelStyle, gridArea: "timeline" }} aria-label="Compact Timeline">
         {timeline}
+      </section>
+      <section style={{ ...panelStyle, gridArea: "run" }} aria-label="Run Graph">
+        {runGraph}
       </section>
     </div>
   );

--- a/packages/ui/src/components/project-map/ProjectMapLayout.tsx
+++ b/packages/ui/src/components/project-map/ProjectMapLayout.tsx
@@ -21,8 +21,9 @@ const panelStyle: React.CSSProperties = {
 };
 
 /**
- * Project Map の 5 パネルを 2 段グリッドで配置するレイアウト。
- * 上段に System Tree / Project Board / Dependency Map、下段に Next Actions / Compact Gantt。
+ * Project Map の 6 パネルを 3 段グリッドで配置するレイアウト。
+ * 上段に System Tree / Project Board / Dependency Map、中段に Next Actions / Compact Gantt、
+ * 下段に Planned vs Actual Run Graph を配置する。
  * 画面幅が狭い場合 (max-width 980px) は 1 カラムに折り返す。
  */
 export function ProjectMapLayout({

--- a/packages/ui/src/components/project-map/ProjectMapPage.tsx
+++ b/packages/ui/src/components/project-map/ProjectMapPage.tsx
@@ -3,6 +3,7 @@ import {
   groupTasks,
   getGroupDimensions,
   type GroupDimension,
+  type ProjectMapRunGraphViewModel,
   type ProjectMapViewModel,
   type Task as SharedTask,
 } from "@gh-gantt/shared";
@@ -16,19 +17,25 @@ import { NextActionsPanel } from "./NextActionsPanel.js";
 import { CompactTimelinePanel } from "./CompactTimelinePanel.js";
 import { ProjectMapToolbar, type ProjectMapFilterState } from "./ProjectMapToolbar.js";
 import { taskMatchesFilter, filterHierarchy } from "./filter-util.js";
+import { RunGraphPanel } from "./RunGraphPanel.js";
 
 interface ProjectMapPageProps {
   viewModel: ProjectMapViewModel;
   config: Config;
   selectedTaskId: string | null;
   onSelectTask: (taskId: string) => void;
+  runGraphViewModel?: ProjectMapRunGraphViewModel | null;
+  runGraphLoading?: boolean;
+  runGraphError?: string | null;
+  onSelectRun?: (runId: string) => void;
+  onSelectRunNode?: (nodeId: string) => void;
   /** 同期状態の再取得トリガー（pull/push 後に変化させる）。 */
   syncRefreshKey?: unknown;
 }
 
 /**
  * Project Map ビューのページ。ツールバー（検索・readiness フィルタ・同期状態）と
- * 5 パネルを配置し、ViewModel を各パネルへ配る。フィルタは Tree / Board / Next Actions /
+ * 6 パネルを配置し、ViewModel を各パネルへ配る。フィルタは Tree / Board / Next Actions /
  * Timeline に一貫適用される（Dependency Map は選択タスク中心のため選択スコープを優先）。
  */
 export function ProjectMapPage({
@@ -36,6 +43,11 @@ export function ProjectMapPage({
   config,
   selectedTaskId,
   onSelectTask,
+  runGraphViewModel = null,
+  runGraphLoading = false,
+  runGraphError = null,
+  onSelectRun = () => undefined,
+  onSelectRunNode = () => undefined,
   syncRefreshKey,
 }: ProjectMapPageProps) {
   const [filter, setFilter] = useState<ProjectMapFilterState>({ search: "", readiness: null });
@@ -160,6 +172,15 @@ export function ProjectMapPage({
               readinessById={viewModel.readinessById}
               selectedTaskId={selectedTaskId}
               onSelectTask={onSelectTask}
+            />
+          }
+          runGraph={
+            <RunGraphPanel
+              viewModel={runGraphViewModel}
+              loading={runGraphLoading}
+              error={runGraphError}
+              onSelectRun={onSelectRun}
+              onSelectNode={onSelectRunNode}
             />
           }
         />

--- a/packages/ui/src/components/project-map/RunGraphPanel.tsx
+++ b/packages/ui/src/components/project-map/RunGraphPanel.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import type { ProjectMapRunGraphViewModel, ProjectMapRunMetric } from "@gh-gantt/shared";
+import { PanelBody, PanelEmpty, PanelHeader } from "./ProjectMapLayout.js";
+
+interface RunGraphPanelProps {
+  viewModel: ProjectMapRunGraphViewModel | null;
+  loading: boolean;
+  error: string | null;
+  onSelectRun: (runId: string) => void;
+  onSelectNode: (nodeId: string) => void;
+}
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--color-border)",
+  borderRadius: 4,
+  padding: 8,
+  minWidth: 0,
+};
+
+function formatDuration(value: number | null): string {
+  if (value == null) return "unknown";
+  if (value < 1000) return `${value}ms`;
+  const seconds = value / 1000;
+  return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`;
+}
+
+function Metric({ label, metric }: { label: string; metric: ProjectMapRunMetric }) {
+  const value =
+    metric.known && metric.value != null
+      ? metric.unit === "ms"
+        ? formatDuration(metric.value)
+        : `${metric.value} ${metric.unit}`
+      : "unknown";
+  return (
+    <div>
+      <dt style={{ color: "var(--color-text-muted)" }}>{label}</dt>
+      <dd style={{ margin: 0, fontWeight: 600 }}>{value}</dd>
+    </div>
+  );
+}
+
+/** Project Map 上で planned と actual の Run Graph を比較する読み取り専用 panel。 */
+export function RunGraphPanel({
+  viewModel,
+  loading,
+  error,
+  onSelectRun,
+  onSelectNode,
+}: RunGraphPanelProps) {
+  return (
+    <>
+      <PanelHeader title="Planned vs Actual" hint="Run Graph" />
+      {loading ? (
+        <div role="status" style={{ padding: 12 }}>
+          Run Graph を読み込み中…
+        </div>
+      ) : null}
+      {error ? (
+        <div role="alert" style={{ padding: 12, color: "var(--color-danger, #e74c3c)" }}>
+          {error}
+        </div>
+      ) : null}
+      {!loading && !error && !viewModel ? <PanelEmpty message="タスクを選択してください" /> : null}
+      {!loading && !error && viewModel && viewModel.runs.total === 0 ? (
+        <PanelEmpty message="このタスクの Run Graph はありません" />
+      ) : null}
+      {!loading && !error && viewModel?.selectedRun ? (
+        <PanelBody>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+            <label style={{ fontSize: 11 }}>
+              Run
+              <select
+                aria-label="Run を選択"
+                value={viewModel.selectedRun.runId}
+                onChange={(event) => onSelectRun(event.target.value)}
+                style={{ marginLeft: 6 }}
+              >
+                {viewModel.runs.items.map((run) => (
+                  <option key={run.runId} value={run.runId}>
+                    {run.runId} · {run.displayState}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <strong style={{ fontSize: 11 }}>{viewModel.selectedRun.displayState}</strong>
+            {viewModel.selectedRun.waitReason ? (
+              <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+                {viewModel.selectedRun.waitReason}
+              </span>
+            ) : null}
+            <a href={viewModel.selectedRun.deepLink} aria-label="選択 node の deep link">
+              deep link
+            </a>
+          </div>
+
+          <dl
+            aria-label="Run metrics"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, minmax(80px, 1fr))",
+              gap: 8,
+              margin: "0 0 8px",
+              fontSize: 10,
+            }}
+          >
+            <Metric label="duration" metric={viewModel.selectedRun.metrics.duration} />
+            <Metric label="tokens" metric={viewModel.selectedRun.metrics.tokens} />
+            <Metric label="cost" metric={viewModel.selectedRun.metrics.cost} />
+            <Metric label="latency" metric={viewModel.selectedRun.metrics.latency} />
+          </dl>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, minmax(220px, 1fr))",
+              gap: 8,
+            }}
+          >
+            <section aria-label="Planned nodes" style={sectionStyle}>
+              <strong style={{ fontSize: 11 }}>Planned</strong>
+              <ol style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
+                {viewModel.selectedRun.planned.nodes.map((node) => (
+                  <li key={node.id}>
+                    {node.id} · {node.role}
+                  </li>
+                ))}
+              </ol>
+              <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 10 }}>
+                {viewModel.selectedRun.planned.edges.map((edge) => (
+                  <li key={edge.id}>
+                    {edge.from} → {edge.to} · {edge.conditions.join(" / ")}
+                  </li>
+                ))}
+              </ul>
+            </section>
+            <section aria-label="Actual nodes" style={sectionStyle}>
+              <strong style={{ fontSize: 11 }}>Actual</strong>
+              <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
+                {viewModel.selectedRun.actual.nodes.map((node) => (
+                  <button
+                    key={node.id}
+                    type="button"
+                    aria-pressed={viewModel.selectedRun?.selectedNodeId === node.id}
+                    aria-label={`${node.contractNodeId} ${node.id}`}
+                    onClick={() => onSelectNode(node.id)}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") return;
+                      event.preventDefault();
+                      onSelectNode(node.id);
+                    }}
+                    style={{ textAlign: "left", fontSize: 11 }}
+                  >
+                    {node.contractNodeId} · {node.displayState} · {node.actor.id} ·{" "}
+                    {formatDuration(node.durationMs)} · artifact {node.artifactCount} · evidence{" "}
+                    {node.evidenceCount}
+                  </button>
+                ))}
+              </div>
+              <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 10 }}>
+                {viewModel.selectedRun.actual.transitions.map((transition) => (
+                  <li key={`${transition.fromNodeId}->${transition.toNodeId}`}>
+                    {transition.fromNodeId} → {transition.toNodeId} ·{" "}
+                    {transition.isPlanned ? "planned" : "unplanned"}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, minmax(220px, 1fr))",
+              gap: 8,
+              marginTop: 8,
+            }}
+          >
+            <section aria-label="Attempts" style={sectionStyle}>
+              <strong style={{ fontSize: 11 }}>Attempts</strong>
+              {viewModel.selectedRun.actual.attempts.length === 0 ? (
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>attempt なし</div>
+              ) : (
+                <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
+                  {viewModel.selectedRun.actual.attempts.map((attempt) => (
+                    <li key={attempt.id}>
+                      {attempt.actor.id} · {attempt.state} · {formatDuration(attempt.durationMs)} ·
+                      artifact {attempt.artifactCount}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+            <section aria-label="Run deviations" style={sectionStyle}>
+              <strong style={{ fontSize: 11 }}>Differences</strong>
+              {viewModel.selectedRun.deviations.length === 0 ? (
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+                  planned との差分なし
+                </div>
+              ) : (
+                <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
+                  {viewModel.selectedRun.deviations.map((deviation) => (
+                    <li key={deviation.id}>{deviation.reason}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+        </PanelBody>
+      ) : null}
+    </>
+  );
+}

--- a/packages/ui/src/components/project-map/RunGraphPanel.tsx
+++ b/packages/ui/src/components/project-map/RunGraphPanel.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import type { ProjectMapRunGraphViewModel, ProjectMapRunMetric } from "@gh-gantt/shared";
+import {
+  PROJECT_MAP_RUN_DEVIATION_LIMIT,
+  type ProjectMapRunGraphViewModel,
+  type ProjectMapRunMetric,
+} from "@gh-gantt/shared";
 import { PanelBody, PanelEmpty, PanelHeader } from "./ProjectMapLayout.js";
 
 interface RunGraphPanelProps {
@@ -223,6 +227,11 @@ export function RunGraphPanel({
                   ))}
                 </ul>
               )}
+              {viewModel.selectedRun.deviationsTruncated ? (
+                <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>
+                  差分は先頭 {PROJECT_MAP_RUN_DEVIATION_LIMIT} 件のみ表示
+                </div>
+              ) : null}
               {viewModel.selectedRun.artifacts.truncated ||
               viewModel.selectedRun.evidence.truncated ? (
                 <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>

--- a/packages/ui/src/components/project-map/RunGraphPanel.tsx
+++ b/packages/ui/src/components/project-map/RunGraphPanel.tsx
@@ -119,19 +119,25 @@ export function RunGraphPanel({
             <section aria-label="Planned nodes" style={sectionStyle}>
               <strong style={{ fontSize: 11 }}>Planned</strong>
               <ol style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
-                {viewModel.selectedRun.planned.nodes.map((node) => (
+                {viewModel.selectedRun.planned.nodes.items.map((node) => (
                   <li key={node.id}>
                     {node.id} · {node.role}
                   </li>
                 ))}
               </ol>
               <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 10 }}>
-                {viewModel.selectedRun.planned.edges.map((edge) => (
+                {viewModel.selectedRun.planned.edges.items.map((edge) => (
                   <li key={edge.id}>
                     {edge.from} → {edge.to} · {edge.conditions.join(" / ")}
                   </li>
                 ))}
               </ul>
+              {viewModel.selectedRun.planned.nodes.truncated ||
+              viewModel.selectedRun.planned.edges.truncated ? (
+                <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>
+                  planned detail は上限 {viewModel.selectedRun.planned.nodes.limit} 件
+                </div>
+              ) : null}
             </section>
             <section aria-label="Actual nodes" style={sectionStyle}>
               <strong style={{ fontSize: 11 }}>Actual</strong>
@@ -150,9 +156,9 @@ export function RunGraphPanel({
                     }}
                     style={{ textAlign: "left", fontSize: 11 }}
                   >
-                    {node.contractNodeId} · {node.displayState} · {node.actor.id} ·{" "}
-                    {formatDuration(node.durationMs)} · artifact {node.artifactCount} · evidence{" "}
-                    {node.evidenceCount}
+                    {node.contractNodeId} · {node.displayState} · {node.actor.id} · {node.createdAt}{" "}
+                    → {node.endedAt ?? "running"} · {formatDuration(node.durationMs)} · artifact{" "}
+                    {node.artifactCount} · evidence {node.evidenceCount}
                   </button>
                 ))}
               </div>
@@ -164,6 +170,11 @@ export function RunGraphPanel({
                   </li>
                 ))}
               </ul>
+              {viewModel.selectedRun.actual.nodesTruncated ? (
+                <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>
+                  actual node は一部のみ表示
+                </div>
+              ) : null}
             </section>
           </div>
 
@@ -183,18 +194,27 @@ export function RunGraphPanel({
                 <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
                   {viewModel.selectedRun.actual.attempts.map((attempt) => (
                     <li key={attempt.id}>
-                      {attempt.actor.id} · {attempt.state} · {formatDuration(attempt.durationMs)} ·
-                      artifact {attempt.artifactCount}
+                      {attempt.nodeId} · {attempt.id} · {attempt.actor.id} · {attempt.actor.role} ·{" "}
+                      {attempt.createdAt} → {attempt.endedAt ?? "running"} ·{" "}
+                      {formatDuration(attempt.durationMs)} · artifact {attempt.artifactCount} ·
+                      evidence {attempt.evidenceCount}
                     </li>
                   ))}
                 </ul>
               )}
+              {viewModel.selectedRun.actual.attemptsTruncated ? (
+                <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>
+                  attempt は一部のみ表示
+                </div>
+              ) : null}
             </section>
             <section aria-label="Run deviations" style={sectionStyle}>
               <strong style={{ fontSize: 11 }}>Differences</strong>
               {viewModel.selectedRun.deviations.length === 0 ? (
                 <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
-                  planned との差分なし
+                  {viewModel.selectedRun.actual.nodesTruncated
+                    ? "表示範囲に planned との差分なし（全履歴は未確認）"
+                    : "planned との差分なし"}
                 </div>
               ) : (
                 <ul style={{ margin: "6px 0 0", paddingLeft: 20, fontSize: 11 }}>
@@ -203,6 +223,12 @@ export function RunGraphPanel({
                   ))}
                 </ul>
               )}
+              {viewModel.selectedRun.artifacts.truncated ||
+              viewModel.selectedRun.evidence.truncated ? (
+                <div style={{ fontSize: 10, color: "var(--color-text-muted)" }}>
+                  artifact/evidence 件数は bounded 表示
+                </div>
+              ) : null}
             </section>
           </div>
         </PanelBody>

--- a/packages/ui/src/hooks/useProjectMapRunGraph.ts
+++ b/packages/ui/src/hooks/useProjectMapRunGraph.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import type { ProjectMapRunGraphViewModel } from "@gh-gantt/shared";
+
+/** 選択中 task/run/node の bounded planned-vs-actual overlay を取得する。 */
+export function useProjectMapRunGraph(
+  taskId: string | null,
+  runId: string | null,
+  nodeId: string | null,
+  enabled = true,
+) {
+  const [viewModel, setViewModel] = useState<ProjectMapRunGraphViewModel | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !taskId) {
+      setViewModel(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const params = new URLSearchParams({ taskId, limit: "20" });
+    if (runId) params.set("runId", runId);
+    if (nodeId) params.set("nodeId", nodeId);
+    setLoading(true);
+    setError(null);
+
+    void fetch(`/api/project-map/run-graph?${params.toString()}`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(payload?.error ?? "Run Graph の取得に失敗しました");
+        }
+        return (await response.json()) as ProjectMapRunGraphViewModel;
+      })
+      .then((payload) => {
+        if (!controller.signal.aborted) setViewModel(payload);
+      })
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return;
+        setViewModel(null);
+        setError(reason instanceof Error ? reason.message : "Run Graph の取得に失敗しました");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [enabled, nodeId, runId, taskId]);
+
+  return { viewModel, loading, error } as const;
+}

--- a/packages/ui/src/hooks/useProjectMapRunGraph.ts
+++ b/packages/ui/src/hooks/useProjectMapRunGraph.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
-import type { ProjectMapRunGraphViewModel } from "@gh-gantt/shared";
+import {
+  ProjectMapRunGraphViewModelSchema,
+  type ProjectMapRunGraphViewModel,
+} from "@gh-gantt/shared";
 
 /** 選択中 task/run/node の bounded planned-vs-actual overlay を取得する。 */
 export function useProjectMapRunGraph(
@@ -35,7 +38,9 @@ export function useProjectMapRunGraph(
           const payload = (await response.json().catch(() => null)) as { error?: string } | null;
           throw new Error(payload?.error ?? "Run Graph の取得に失敗しました");
         }
-        return (await response.json()) as ProjectMapRunGraphViewModel;
+        const parsed = ProjectMapRunGraphViewModelSchema.safeParse(await response.json());
+        if (!parsed.success) throw new Error("Run Graph 応答の検証に失敗しました");
+        return parsed.data;
       })
       .then((payload) => {
         if (!controller.signal.aborted) setViewModel(payload);

--- a/packages/ui/src/hooks/useRunGraphDeepLink.ts
+++ b/packages/ui/src/hooks/useRunGraphDeepLink.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+
+export const SELECTED_RUN_QUERY_KEY = "run";
+export const SELECTED_RUN_NODE_QUERY_KEY = "node";
+
+function readSelection(): { runId: string | null; nodeId: string | null } {
+  if (typeof window === "undefined") return { runId: null, nodeId: null };
+  const params = new URL(window.location.href).searchParams;
+  return {
+    runId: params.get(SELECTED_RUN_QUERY_KEY),
+    nodeId: params.get(SELECTED_RUN_NODE_QUERY_KEY),
+  };
+}
+
+function updateUrl(runId: string | null, nodeId: string | null): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (runId) {
+    url.searchParams.set(SELECTED_RUN_QUERY_KEY, runId);
+    url.searchParams.set("view", "project-map");
+  } else {
+    url.searchParams.delete(SELECTED_RUN_QUERY_KEY);
+  }
+  if (nodeId) url.searchParams.set(SELECTED_RUN_NODE_QUERY_KEY, nodeId);
+  else url.searchParams.delete(SELECTED_RUN_NODE_QUERY_KEY);
+  window.history.replaceState({}, "", url.toString());
+}
+
+/** run/node 選択を URL query と同期し、再読込可能な deep link にする。 */
+export function useRunGraphDeepLink() {
+  const initial = readSelection();
+  const [selectedRunId, setRunId] = useState<string | null>(initial.runId);
+  const [selectedNodeId, setNodeId] = useState<string | null>(initial.nodeId);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      const selection = readSelection();
+      setRunId(selection.runId);
+      setNodeId(selection.nodeId);
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  const setSelectedRunId = useCallback((runId: string | null) => {
+    setRunId(runId);
+    setNodeId(null);
+    updateUrl(runId, null);
+  }, []);
+
+  const setSelectedNodeId = useCallback((nodeId: string | null) => {
+    setNodeId(nodeId);
+    const runId = readSelection().runId;
+    updateUrl(runId, nodeId);
+  }, []);
+
+  const clearRunSelection = useCallback(() => {
+    setRunId(null);
+    setNodeId(null);
+    updateUrl(null, null);
+  }, []);
+
+  return {
+    selectedRunId,
+    selectedNodeId,
+    setSelectedRunId,
+    setSelectedNodeId,
+    clearRunSelection,
+  } as const;
+}

--- a/packages/ui/src/hooks/useRunGraphDeepLink.ts
+++ b/packages/ui/src/hooks/useRunGraphDeepLink.ts
@@ -48,9 +48,10 @@ export function useRunGraphDeepLink() {
     updateUrl(runId, null);
   }, []);
 
-  const setSelectedNodeId = useCallback((nodeId: string | null) => {
+  const setSelectedNodeId = useCallback((nodeId: string | null, displayedRunId?: string | null) => {
     setNodeId(nodeId);
-    const runId = readSelection().runId;
+    const runId = readSelection().runId ?? displayedRunId ?? null;
+    setRunId(runId);
     updateUrl(runId, nodeId);
   }, []);
 


### PR DESCRIPTION
## Summary

- Project Map に planned-vs-actual Run Graph パネルを追加し、run / node / attempt の状態、待機理由、artifact / evidence、差分、unknown を含む運用メトリクスを同一 ViewModel で表示する
- task / run / node の deep link と strict Zod 境界を持つ bounded API を追加し、planned / actual / run summary を最大50件へ制限する
- task locator index、process 間 lease、pending transaction により、全 Run 走査を request path から除外し、event 確定後の中断と stale recovery claimant を自動修復する
- locator 読み取りを100ms上限の同一 lease 内で完結させ、writer競合や complete state 不在は混在 snapshot を返さず503で fail-closed にする
- deviation を200件へ制限して一部表示を明示し、locator task の正規化と deep link の canonical task ID を回帰テストで固定する
- FR-VIS-026、Project Map 文書、UI / API / accessibility / legacy empty / crash recovery の回帰テストを追加する

Closes #330

## Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（1285 tests: workflow 66 / shared 212 / CLI 763 / UI 229 / smoke 15）
- `pnpm build`
- `pnpm req:trace`（covered 209 / uncovered 20 / failing 0）
- `git diff --exit-code docs/requirements.yaml`
- `pnpm req:validate`（既存 orphaned AC warning 23件のみ）
- `pnpm docs:gen`
- betterleaks 1.5.0 と pinned Docker 1.1.2 で staged 差分18.78KBと `origin/main...HEAD` 全差分149.70KBを検査し、すべて `no leaks found`
- pre-commit の pinned betterleaks 1.1.2 をスキップせず実行し、`no leaks found`
- Standards / Spec 独立再レビュー: finding なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Project Map に「Planned vs Actual Run Graph」パネルを追加しました。
  * 実行状態、待機理由、試行回数、メトリクス、成果物・証跡、planned との差分を確認できます。
  * 実行やノードを選択すると、URL のディープリンクから同じ表示を復元できます。
  * データがない場合は既存の Project Map を維持し、空状態を表示します。
* **改善**
  * 大量の実行履歴でも表示範囲を制限し、必要な詳細を優先表示します。
  * パネルはキーボード操作と支援技術に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
