### PR TITLE
feat(sync): 変更系コマンドを即時pushする (#297)

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -89,6 +89,14 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/push-executor.test.ts
+          - id: FR-SYNC-003-AC7
+            description: update / close / link は auto_push を既定で有効にし、--no-push による抑止、変更 task 限定の即時同期、対象単位の conflict skip、失敗後のローカル差分保持を行える
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/command-structure.test.ts
+              - packages/cli/src/__tests__/push-executor.test.ts
+              - packages/cli/src/__tests__/write-through-push.test.ts
+              - packages/shared/src/__tests__/schema.test.ts
       - id: FR-SYNC-004
         summary: リモートデータからローカルタスクへのマッピング
         acceptance_criteria:

--- a/packages/cli/src/__tests__/command-structure.test.ts
+++ b/packages/cli/src/__tests__/command-structure.test.ts
@@ -101,4 +101,16 @@ describe("[FR-CLI-006-AC1] init/pull/push/status/create/list/show/update/link/de
       expect(topLevel).not.toBe(alias);
     }
   });
+
+  it("[FR-SYNC-003-AC7] 変更系コマンドはトップレベルと task エイリアスで --no-push を受理する", () => {
+    const taskCommand = program.commands.find((command) => command.name() === "task")!;
+
+    for (const name of ["update", "link", "close"]) {
+      const topLevel = program.commands.find((command) => command.name() === name)!;
+      const alias = taskCommand.commands.find((command) => command.name() === name)!;
+
+      expect(topLevel.options.map((option) => option.long)).toContain("--no-push");
+      expect(alias.options.map((option) => option.long)).toContain("--no-push");
+    }
+  });
 });

--- a/packages/cli/src/__tests__/push-executor.test.ts
+++ b/packages/cli/src/__tests__/push-executor.test.ts
@@ -3082,4 +3082,61 @@ describe("executePush", () => {
       }
     });
   });
+
+  describe("[FR-SYNC-003-AC7] write-through push の対象を task ID で限定できる", () => {
+    it("対象外の dirty task は API 呼び出しと snapshot 更新の対象にしない", async () => {
+      const baseTask1 = makeTask("o/r#1", { github_issue: 1, title: "変更前1" });
+      const baseTask2 = makeTask("o/r#2", { github_issue: 2, title: "変更前2" });
+      const task1 = { ...baseTask1, title: "変更後1" };
+      const task2 = { ...baseTask2, title: "変更後2" };
+      const tasksFile: TasksFile = {
+        tasks: [task1, task2],
+        cache: { comments: {}, reactions: {} },
+      };
+      const syncState: SyncState = {
+        last_synced_at: "2026-01-01T00:00:00Z",
+        project_node_id: "PVT_1",
+        id_map: {
+          "o/r#1": { issue_number: 1, issue_node_id: "ISSUE_1", project_item_id: "ITEM_1" },
+          "o/r#2": { issue_number: 2, issue_node_id: "ISSUE_2", project_item_id: "ITEM_2" },
+        },
+        field_ids: {},
+        snapshots: {
+          "o/r#1": {
+            hash: hashTask(baseTask1),
+            synced_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            syncFields: extractSyncFields(baseTask1),
+          },
+          "o/r#2": {
+            hash: hashTask(baseTask2),
+            synced_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            syncFields: extractSyncFields(baseTask2),
+          },
+        },
+      };
+      const originalTask2Snapshot = syncState.snapshots["o/r#2"];
+      const mockGql = makeMockGql();
+
+      const { result, syncState: newSyncState } = await executePush(
+        mockGql as any,
+        makeConfig(),
+        tasksFile,
+        syncState,
+        { targetTaskIds: ["o/r#1"] },
+      );
+
+      expect(result).toEqual({ created: 0, updated: 1, skipped: 0 });
+      const updateIssueCalls = mockGql.mock.calls.filter((call) =>
+        (call[0] as string).includes("updateIssue"),
+      );
+      expect(updateIssueCalls.map((call) => call[1]?.issueId)).toEqual(["ISSUE_1"]);
+      expect(newSyncState.snapshots["o/r#2"]).toBe(originalTask2Snapshot);
+      expect(computeLocalDiff(tasksFile.tasks, newSyncState).map((diff) => diff.id)).toEqual([
+        "o/r#2",
+      ]);
+      expect(newSyncState.last_synced_at).toBe("2026-01-01T00:00:00Z");
+    });
+  });
 });

--- a/packages/cli/src/__tests__/regressions/issue-302-draft-parent-ref.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-302-draft-parent-ref.test.ts
@@ -141,7 +141,7 @@ describe("[NFR-STABILITY-002-AC6] [Issue #302] draft 親子一括 push の paren
       ["--title", "子タスク B", "--type", "task", "--parent", "draft-1", "--json"],
       { from: "user" },
     );
-    await createTaskLinkCommand().parseAsync(["draft-3", "--blocked-by", "draft-2"], {
+    await createTaskLinkCommand().parseAsync(["draft-3", "--blocked-by", "draft-2", "--no-push"], {
       from: "user",
     });
     expect(process.exitCode).toBeUndefined();

--- a/packages/cli/src/__tests__/task-close-command.test.ts
+++ b/packages/cli/src/__tests__/task-close-command.test.ts
@@ -115,7 +115,7 @@ describe("[FR-CLI-016-AC1] close command の evidence warning", () => {
   it("空白だけの --evidence は実効証跡なしとして警告する", async () => {
     const cmd = createTaskCloseCommand();
 
-    await cmd.parseAsync(["close", "1", "--evidence", "   "], { from: "user" });
+    await cmd.parseAsync(["close", "1", "--evidence", "   ", "--no-push"], { from: "user" });
 
     expect(process.exitCode).toBeUndefined();
     expect(errorSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/__tests__/write-through-push.test.ts
+++ b/packages/cli/src/__tests__/write-through-push.test.ts
@@ -6,6 +6,7 @@ import type { Config, SyncState, Task, TasksFile } from "@gh-gantt/shared";
 import { createTaskCloseCommand } from "../commands/task/close.js";
 import { createTaskLinkCommand } from "../commands/task/link.js";
 import { createTaskUpdateCommand } from "../commands/task/update.js";
+import { executeWriteThroughPush } from "../commands/task/write-through-push.js";
 import { withProjectStorage } from "../store/project-storage.js";
 import { computeLocalDiff } from "../sync/diff.js";
 import { extractSyncFields, hashTask } from "../sync/hash.js";
@@ -83,9 +84,10 @@ function makeGraphQLClient(
     failIssueId?: string;
     failAddSubIssue?: boolean;
     updatedAtAfterMutation?: string;
+    initialUpdatedAtByIssueId?: Record<string, string>;
   } = {},
 ) {
-  let mutationObserved = false;
+  const mutatedIssueIds = new Set<string>();
   return vi.fn(async (query: string, variables?: Record<string, unknown>) => {
     if (query.includes("issue(number:") && !query.includes("mutation")) {
       const issueNumbers = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)].map((match) =>
@@ -98,9 +100,10 @@ function makeGraphQLClient(
             {
               number,
               updatedAt:
-                mutationObserved && options.updatedAtAfterMutation
+                mutatedIssueIds.has(`ISSUE_${number}`) && options.updatedAtAfterMutation
                   ? options.updatedAtAfterMutation
-                  : "2026-01-01T00:00:00Z",
+                  : (options.initialUpdatedAtByIssueId?.[`ISSUE_${number}`] ??
+                    "2026-01-01T00:00:00Z"),
               stateReason: null,
               closedAt: null,
             },
@@ -112,7 +115,7 @@ function makeGraphQLClient(
       throw new Error("外部 API エラー");
     }
     if (query.includes("updateIssue")) {
-      mutationObserved = true;
+      if (typeof variables?.issueId === "string") mutatedIssueIds.add(variables.issueId);
       return { updateIssue: { issue: { id: variables?.issueId } } };
     }
     if (query.includes("closeIssue")) {
@@ -156,14 +159,16 @@ async function initializeProject(
     last_synced_at: "2026-01-01T00:00:00Z",
     project_node_id: "PROJECT_1",
     id_map: Object.fromEntries(
-      tasks.map((task) => [
-        task.id,
-        {
-          issue_number: task.github_issue!,
-          issue_node_id: `ISSUE_${task.github_issue}`,
-          project_item_id: `ITEM_${task.github_issue}`,
-        },
-      ]),
+      tasks
+        .filter((task) => task.github_issue !== null)
+        .map((task) => [
+          task.id,
+          {
+            issue_number: task.github_issue!,
+            issue_node_id: `ISSUE_${task.github_issue}`,
+            project_item_id: `ITEM_${task.github_issue}`,
+          },
+        ]),
     ),
     field_ids: {},
     snapshots,
@@ -256,6 +261,60 @@ describe("[FR-SYNC-003-AC7] 変更系コマンドを write-through push でき�
       "owner/repo#2",
     ]);
     expect(syncState.last_synced_at).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("executeWriteThroughPush は永続化した最終 TasksFile を返す", async () => {
+    const baseTask = makeTask(1);
+    const dirtyTask = { ...baseTask, title: "変更後" };
+    await initializeProject(projectRoot, [dirtyTask], [baseTask]);
+    const gql = makeGraphQLClient({
+      updatedAtAfterMutation: "2026-01-02T00:00:00Z",
+    });
+
+    const writeThroughResult = await withProjectStorage(
+      projectRoot,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        const config = await storage.configStore.read();
+        const tasksFile = await storage.tasksStore.read();
+        return executeWriteThroughPush(storage, config, tasksFile, ["owner/repo#1"], {
+          createClient: async () => gql as never,
+        });
+      },
+    );
+
+    expect(writeThroughResult.tasksFile.tasks[0]).toMatchObject({
+      id: "owner/repo#1",
+      title: "変更後",
+      updated_at: "2026-01-02T00:00:00Z",
+    });
+    const persisted = await readProject(projectRoot);
+    expect(writeThroughResult.tasksFile).toEqual(persisted.tasksFile);
+  });
+
+  it("update --json は write-through 後の updated_at を出力する", async () => {
+    const task = makeTask(1);
+    await initializeProject(projectRoot, [task]);
+    createClientMock.mockResolvedValue(
+      makeGraphQLClient({
+        updatedAtAfterMutation: "2026-01-02T00:00:00Z",
+      }),
+    );
+
+    await createTaskUpdateCommand().parseAsync(["1", "--title", "JSON更新", "--json"], {
+      from: "user",
+    });
+
+    const jsonOutput = vi
+      .mocked(console.log)
+      .mock.calls.map(([value]) => value)
+      .find((value): value is string => typeof value === "string" && value.includes('"id"'));
+    expect(jsonOutput).toBeDefined();
+    expect(JSON.parse(jsonOutput!)).toMatchObject({
+      id: "owner/repo#1",
+      title: "JSON更新",
+      updated_at: "2026-01-02T00:00:00Z",
+    });
   });
 
   it("bulk update は実際に成功した task だけを同期する", async () => {
@@ -392,6 +451,64 @@ describe("[FR-SYNC-003-AC7] 変更系コマンドを write-through push でき�
     expect(syncState.snapshots["owner/repo#2"]?.syncFields?.title).toBe("タスク2");
   });
 
+  it("既存 task の後続 API 失敗時は先行成功の task と snapshot を永続化する", async () => {
+    const task1 = makeTask(1, { labels: ["対象"] });
+    const task2 = makeTask(2, { labels: ["対象"] });
+    await initializeProject(projectRoot, [task1, task2]);
+    const gql = makeGraphQLClient({
+      failIssueId: "ISSUE_2",
+      updatedAtAfterMutation: "2026-01-02T00:00:00Z",
+    });
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskUpdateCommand().parseAsync(["--filter-label", "対象", "--title", "一括変更"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(
+      gql.mock.calls
+        .filter(([query]) => (query as string).includes("updateIssue"))
+        .map(([, variables]) => variables?.issueId),
+    ).toEqual(["ISSUE_1", "ISSUE_2"]);
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#2",
+    ]);
+    expect(syncState.snapshots["owner/repo#1"]?.syncFields?.title).toBe("一括変更");
+    expect(syncState.snapshots["owner/repo#1"]?.updated_at).toBe("2026-01-02T00:00:00Z");
+    expect(syncState.snapshots["owner/repo#2"]?.syncFields?.title).toBe("タスク2");
+  });
+
+  it("draft target は client 生成前に拒否しローカル差分を保持する", async () => {
+    const baseDraft = makeTask(1, {
+      id: "owner/repo#draft-1",
+      github_issue: null,
+      title: "変更前 draft",
+    });
+    const dirtyDraft = { ...baseDraft, title: "変更後 draft" };
+    await initializeProject(projectRoot, [dirtyDraft], [baseDraft]);
+
+    await createTaskUpdateCommand().parseAsync(["draft-1", "--title", "コマンド更新 draft"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to update task:",
+      expect.stringContaining("既存 Issue"),
+    );
+    expect(tasksFile.tasks[0]).toMatchObject({
+      id: "owner/repo#draft-1",
+      title: "コマンド更新 draft",
+    });
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#draft-1",
+    ]);
+  });
+
   it("link group の child に marker があれば旧親と新親を含む全 target を送信しない", async () => {
     const baseChild = makeTask(1, { parent: "owner/repo#2" });
     const oldParent = makeTask(2, { sub_tasks: ["owner/repo#1"] });
@@ -454,7 +571,70 @@ describe("[FR-SYNC-003-AC7] 変更系コマンドを write-through push でき�
     expect(syncState.snapshots["owner/repo#1"]?.syncFields?.parent).toBeNull();
     expect(syncState.snapshots["owner/repo#2"]?.syncFields?.sub_tasks).toEqual([]);
     expect(syncState.snapshots["owner/repo#1"]?.updated_at).toBe("2026-01-02T00:00:00Z");
-    expect(syncState.snapshots["owner/repo#2"]?.updated_at).toBe("2026-01-02T00:00:00Z");
+    expect(syncState.snapshots["owner/repo#2"]?.updated_at).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("link group の後続 Issue 更新失敗時は先行成功の watermark を保って全差分を再送できる", async () => {
+    const child = makeTask(1);
+    const parent = makeTask(2);
+    await initializeProject(projectRoot, [child, parent]);
+    const gql = makeGraphQLClient({
+      failIssueId: "ISSUE_2",
+      updatedAtAfterMutation: "2026-01-02T00:00:00Z",
+    });
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskLinkCommand().parseAsync(["1", "--set-parent", "2"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(
+      gql.mock.calls
+        .filter(([query]) => (query as string).includes("updateIssue"))
+        .map(([, variables]) => variables?.issueId),
+    ).toEqual(["ISSUE_1", "ISSUE_2"]);
+    expect(
+      computeLocalDiff(tasksFile.tasks, syncState)
+        .map((diff) => diff.id)
+        .sort(),
+    ).toEqual(["owner/repo#1", "owner/repo#2"]);
+    expect(syncState.snapshots["owner/repo#1"]?.syncFields?.parent).toBeNull();
+    expect(syncState.snapshots["owner/repo#2"]?.syncFields?.sub_tasks).toEqual([]);
+    expect(syncState.snapshots["owner/repo#1"]?.updated_at).toBe("2026-01-02T00:00:00Z");
+    expect(syncState.snapshots["owner/repo#2"]?.updated_at).toBe("2026-01-01T00:00:00Z");
+
+    process.exitCode = undefined;
+    const retryGql = makeGraphQLClient({
+      initialUpdatedAtByIssueId: {
+        ISSUE_1: "2026-01-02T00:00:00Z",
+        ISSUE_2: "2026-01-01T00:00:00Z",
+      },
+      updatedAtAfterMutation: "2026-01-03T00:00:00Z",
+    });
+    await withProjectStorage(
+      projectRoot,
+      { mode: "write", scope: "shared-cache" },
+      async (storage) => {
+        const config = await storage.configStore.read();
+        const currentTasksFile = await storage.tasksStore.read();
+        await executeWriteThroughPush(
+          storage,
+          config,
+          currentTasksFile,
+          ["owner/repo#1", "owner/repo#2"],
+          {
+            createClient: async () => retryGql as never,
+            atomicTargetGroups: [["owner/repo#1", "owner/repo#2"]],
+          },
+        );
+      },
+    );
+
+    const retried = await readProject(projectRoot);
+    expect(process.exitCode).toBeUndefined();
+    expect(computeLocalDiff(retried.tasksFile.tasks, retried.syncState)).toEqual([]);
   });
 
   it("API 失敗時は exit code を失敗にし、ローカル差分を再送可能なまま保持する", async () => {

--- a/packages/cli/src/__tests__/write-through-push.test.ts
+++ b/packages/cli/src/__tests__/write-through-push.test.ts
@@ -1,0 +1,474 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config, SyncState, Task, TasksFile } from "@gh-gantt/shared";
+import { createTaskCloseCommand } from "../commands/task/close.js";
+import { createTaskLinkCommand } from "../commands/task/link.js";
+import { createTaskUpdateCommand } from "../commands/task/update.js";
+import { withProjectStorage } from "../store/project-storage.js";
+import { computeLocalDiff } from "../sync/diff.js";
+import { extractSyncFields, hashTask } from "../sync/hash.js";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}));
+
+vi.mock("../github/client.js", () => ({
+  createGraphQLClient: createClientMock,
+}));
+
+function makeConfig(autoPush = true): Config {
+  return {
+    version: "1",
+    project: {
+      name: "テスト",
+      github: { owner: "owner", repo: "repo", project_number: 1 },
+    },
+    sync: {
+      auto_create_issues: false,
+      auto_push: autoPush,
+      field_mapping: { start_date: "Start", end_date: "End" },
+    },
+    task_types: {
+      task: { label: "Task", display: "bar", color: "#000000", github_label: null },
+      feature: { label: "Feature", display: "bar", color: "#111111", github_label: null },
+    },
+    type_hierarchy: { task: [], feature: [] },
+    statuses: { field_name: "Status", values: {} },
+    gantt: {
+      default_view: "week",
+      working_days: [1, 2, 3, 4, 5],
+      colors: {
+        critical_path: "#ff0000",
+        on_track: "#00ff00",
+        at_risk: "#ffff00",
+        overdue: "#ff0000",
+      },
+    },
+  };
+}
+
+function makeTask(issueNumber: number, overrides: Partial<Task> = {}): Task {
+  return {
+    id: `owner/repo#${issueNumber}`,
+    type: "task",
+    github_issue: issueNumber,
+    github_repo: "owner/repo",
+    parent: null,
+    sub_tasks: [],
+    title: `タスク${issueNumber}`,
+    body: null,
+    acceptance_criteria: [],
+    state: "open",
+    state_reason: null,
+    assignees: [],
+    labels: [],
+    milestone: null,
+    linked_prs: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+    custom_fields: {},
+    start_date: null,
+    end_date: null,
+    date: null,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makeGraphQLClient(
+  options: {
+    failIssueId?: string;
+    failAddSubIssue?: boolean;
+    updatedAtAfterMutation?: string;
+  } = {},
+) {
+  let mutationObserved = false;
+  return vi.fn(async (query: string, variables?: Record<string, unknown>) => {
+    if (query.includes("issue(number:") && !query.includes("mutation")) {
+      const issueNumbers = [...query.matchAll(/issue\(number:\s*(\d+)\)/g)].map((match) =>
+        Number(match[1]),
+      );
+      return {
+        repository: Object.fromEntries(
+          issueNumbers.map((number, index) => [
+            `i${index}`,
+            {
+              number,
+              updatedAt:
+                mutationObserved && options.updatedAtAfterMutation
+                  ? options.updatedAtAfterMutation
+                  : "2026-01-01T00:00:00Z",
+              stateReason: null,
+              closedAt: null,
+            },
+          ]),
+        ),
+      };
+    }
+    if (query.includes("updateIssue") && variables?.issueId === options.failIssueId) {
+      throw new Error("外部 API エラー");
+    }
+    if (query.includes("updateIssue")) {
+      mutationObserved = true;
+      return { updateIssue: { issue: { id: variables?.issueId } } };
+    }
+    if (query.includes("closeIssue")) {
+      return { closeIssue: { issue: { id: variables?.issueId } } };
+    }
+    if (query.includes("reopenIssue")) {
+      return { reopenIssue: { issue: { id: variables?.issueId } } };
+    }
+    if (query.includes("addSubIssue")) {
+      if (options.failAddSubIssue) {
+        throw new Error("sub-issue API エラー");
+      }
+      return { addSubIssue: { issue: { id: variables?.issueId } } };
+    }
+    if (query.includes("addBlockedBy")) {
+      return { addIssueRelation: { issue: { id: variables?.issueId } } };
+    }
+    return {};
+  });
+}
+
+async function initializeProject(
+  root: string,
+  tasks: Task[],
+  snapshotTasks: Task[] = tasks,
+  config = makeConfig(),
+  tasksFileOverrides: Partial<TasksFile> = {},
+): Promise<void> {
+  const snapshots = Object.fromEntries(
+    snapshotTasks.map((task) => [
+      task.id,
+      {
+        hash: hashTask(task),
+        synced_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        syncFields: extractSyncFields(task),
+      },
+    ]),
+  );
+  const syncState: SyncState = {
+    last_synced_at: "2026-01-01T00:00:00Z",
+    project_node_id: "PROJECT_1",
+    id_map: Object.fromEntries(
+      tasks.map((task) => [
+        task.id,
+        {
+          issue_number: task.github_issue!,
+          issue_node_id: `ISSUE_${task.github_issue}`,
+          project_item_id: `ITEM_${task.github_issue}`,
+        },
+      ]),
+    ),
+    field_ids: {},
+    snapshots,
+  };
+
+  await withProjectStorage(root, { mode: "write", scope: "all" }, async (storage) => {
+    await storage.configStore.write(config);
+    await storage.tasksStore.write({
+      tasks,
+      cache: { comments: {}, reactions: {} },
+      ...tasksFileOverrides,
+    });
+    await storage.stateStore.write(syncState);
+    await storage.flush();
+  });
+}
+
+async function readProject(root: string) {
+  return withProjectStorage(root, { mode: "read", scope: "shared-cache" }, async (storage) => ({
+    tasksFile: await storage.tasksStore.read(),
+    syncState: await storage.stateStore.read(),
+  }));
+}
+
+async function updateProjectSyncState(
+  root: string,
+  update: (syncState: SyncState) => void,
+): Promise<void> {
+  await withProjectStorage(root, { mode: "write", scope: "shared-cache" }, async (storage) => {
+    const syncState = await storage.stateStore.read();
+    update(syncState);
+    await storage.stateStore.write(syncState);
+    await storage.flush();
+  });
+}
+
+describe("[FR-SYNC-003-AC7] 変更系コマンドを write-through push できる", () => {
+  let projectRoot: string;
+  let originalCwd: string;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    projectRoot = await mkdtemp(join(tmpdir(), "gh-gantt-write-through-"));
+    process.chdir(projectRoot);
+    createClientMock.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it("update は変更した task だけを同期し、無関係な dirty task を保持する", async () => {
+    const baseTask1 = makeTask(1);
+    const baseTask2 = makeTask(2);
+    const dirtyTask2 = {
+      ...baseTask2,
+      title: "未送信の変更",
+      title_current: "ローカル",
+      title_incoming: "リモート",
+    } as Task;
+    await initializeProject(
+      projectRoot,
+      [baseTask1, dirtyTask2],
+      [baseTask1, baseTask2],
+      makeConfig(),
+      { has_conflicts: true },
+    );
+    const gql = makeGraphQLClient();
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskUpdateCommand().parseAsync(["1", "--title", "write-through 後"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    const issueIds = gql.mock.calls
+      .filter(([query]) => (query as string).includes("updateIssue"))
+      .map(([, variables]) => variables?.issueId);
+    expect(issueIds).toEqual(["ISSUE_1"]);
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#2",
+    ]);
+    expect(syncState.last_synced_at).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("bulk update は実際に成功した task だけを同期する", async () => {
+    const task1 = makeTask(1, { labels: ["対象"] });
+    const task2 = makeTask(2, { type: "feature", labels: ["対象"] });
+    const config = {
+      ...makeConfig(),
+      require_review_for_types: ["feature"],
+    };
+    await initializeProject(projectRoot, [task1, task2], [task1, task2], config);
+    const gql = makeGraphQLClient();
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskUpdateCommand().parseAsync(["--filter-label", "対象", "--state", "closed"], {
+      from: "user",
+    });
+
+    const { tasksFile } = await readProject(projectRoot);
+    const issueIds = gql.mock.calls
+      .filter(([query]) => (query as string).includes("updateIssue"))
+      .map(([, variables]) => variables?.issueId);
+    expect(issueIds).toEqual(["ISSUE_1"]);
+    expect(tasksFile.tasks.find((task) => task.id === "owner/repo#1")?.state).toBe("closed");
+    expect(tasksFile.tasks.find((task) => task.id === "owner/repo#2")?.state).toBe("open");
+  });
+
+  it("close はローカル flush 後に閉じた task を同期する", async () => {
+    const task = makeTask(1);
+    await initializeProject(projectRoot, [task]);
+    const gql = makeGraphQLClient();
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskCloseCommand().parseAsync(["1"], { from: "user" });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(gql.mock.calls.some(([query]) => (query as string).includes("closeIssue"))).toBe(true);
+    expect(tasksFile.tasks[0].state).toBe("closed");
+    expect(computeLocalDiff(tasksFile.tasks, syncState)).toEqual([]);
+  });
+
+  it("link は source と親子 mirror の実変更 task だけを同期する", async () => {
+    const child = makeTask(1);
+    const parent = makeTask(2);
+    const unrelated = makeTask(3);
+    await initializeProject(projectRoot, [child, parent, unrelated]);
+    const gql = makeGraphQLClient();
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskLinkCommand().parseAsync(["1", "--set-parent", "2"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    const issueIds = gql.mock.calls
+      .filter(([query]) => (query as string).includes("updateIssue"))
+      .map(([, variables]) => variables?.issueId)
+      .sort();
+    expect(issueIds).toEqual(["ISSUE_1", "ISSUE_2"]);
+    expect(computeLocalDiff(tasksFile.tasks, syncState)).toEqual([]);
+  });
+
+  it("--no-push はローカル変更だけを flush し client を生成しない", async () => {
+    const task = makeTask(1);
+    await initializeProject(projectRoot, [task]);
+
+    await createTaskUpdateCommand().parseAsync(["1", "--title", "ローカルのみ", "--no-push"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(tasksFile.tasks[0].title).toBe("ローカルのみ");
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#1",
+    ]);
+  });
+
+  it("auto_push: false はローカル変更だけを flush し client を生成しない", async () => {
+    const task = makeTask(1);
+    await initializeProject(projectRoot, [task], [task], makeConfig(false));
+
+    await createTaskCloseCommand().parseAsync(["1"], { from: "user" });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(tasksFile.tasks[0].state).toBe("closed");
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#1",
+    ]);
+  });
+
+  it("未解決 marker がある対象だけを skip しローカル差分を保持する", async () => {
+    const task = makeTask(1) as Task & Record<string, unknown>;
+    task.title_current = "ローカル";
+    task.title_incoming = "リモート";
+    await initializeProject(projectRoot, [task], [makeTask(1)], makeConfig(), {
+      has_conflicts: true,
+    });
+
+    await createTaskUpdateCommand().parseAsync(["1", "--title", "競合中の変更"], { from: "user" });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(tasksFile.tasks[0].title).toBe("競合中の変更");
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#1",
+    ]);
+  });
+
+  it("複数 target の一部が skipped なら成功済み snapshot を保ち残存 ID をエラー通知する", async () => {
+    const task1 = makeTask(1, { labels: ["対象"] });
+    const task2 = makeTask(2, { labels: ["対象"] });
+    await initializeProject(projectRoot, [task1, task2]);
+    await updateProjectSyncState(projectRoot, (syncState) => {
+      delete syncState.id_map["owner/repo#2"];
+    });
+    const gql = makeGraphQLClient();
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskUpdateCommand().parseAsync(["--filter-label", "対象", "--title", "一括変更"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to update task:",
+      expect.stringContaining("owner/repo#2"),
+    );
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#2",
+    ]);
+    expect(syncState.snapshots["owner/repo#1"]?.syncFields?.title).toBe("一括変更");
+    expect(syncState.snapshots["owner/repo#2"]?.syncFields?.title).toBe("タスク2");
+  });
+
+  it("link group の child に marker があれば旧親と新親を含む全 target を送信しない", async () => {
+    const baseChild = makeTask(1, { parent: "owner/repo#2" });
+    const oldParent = makeTask(2, { sub_tasks: ["owner/repo#1"] });
+    const newParent = makeTask(3);
+    const conflictedChild = {
+      ...baseChild,
+      title_current: "ローカル",
+      title_incoming: "リモート",
+    } as Task;
+    await initializeProject(
+      projectRoot,
+      [conflictedChild, oldParent, newParent],
+      [baseChild, oldParent, newParent],
+      makeConfig(),
+      { has_conflicts: true },
+    );
+
+    await createTaskLinkCommand().parseAsync(["1", "--set-parent", "3"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+    expect(
+      computeLocalDiff(tasksFile.tasks, syncState)
+        .map((diff) => diff.id)
+        .sort(),
+    ).toEqual(["owner/repo#1", "owner/repo#2", "owner/repo#3"]);
+    expect(syncState.snapshots["owner/repo#1"]?.syncFields?.parent).toBe("owner/repo#2");
+    expect(syncState.snapshots["owner/repo#2"]?.syncFields?.sub_tasks).toEqual(["owner/repo#1"]);
+    expect(syncState.snapshots["owner/repo#3"]?.syncFields?.sub_tasks).toEqual([]);
+  });
+
+  it("link relation API 失敗時は group snapshot を前進させず新しい updated_at で再送できる", async () => {
+    const child = makeTask(1);
+    const parent = makeTask(2);
+    await initializeProject(projectRoot, [child, parent]);
+    const gql = makeGraphQLClient({
+      failAddSubIssue: true,
+      updatedAtAfterMutation: "2026-01-02T00:00:00Z",
+    });
+    createClientMock.mockResolvedValue(gql);
+
+    await createTaskLinkCommand().parseAsync(["1", "--set-parent", "2"], {
+      from: "user",
+    });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to link task:",
+      expect.stringContaining("owner/repo#1"),
+    );
+    expect(
+      computeLocalDiff(tasksFile.tasks, syncState)
+        .map((diff) => diff.id)
+        .sort(),
+    ).toEqual(["owner/repo#1", "owner/repo#2"]);
+    expect(syncState.snapshots["owner/repo#1"]?.syncFields?.parent).toBeNull();
+    expect(syncState.snapshots["owner/repo#2"]?.syncFields?.sub_tasks).toEqual([]);
+    expect(syncState.snapshots["owner/repo#1"]?.updated_at).toBe("2026-01-02T00:00:00Z");
+    expect(syncState.snapshots["owner/repo#2"]?.updated_at).toBe("2026-01-02T00:00:00Z");
+  });
+
+  it("API 失敗時は exit code を失敗にし、ローカル差分を再送可能なまま保持する", async () => {
+    const task = makeTask(1);
+    await initializeProject(projectRoot, [task]);
+    createClientMock.mockResolvedValue(makeGraphQLClient({ failIssueId: "ISSUE_1" }));
+
+    await createTaskUpdateCommand().parseAsync(["1", "--title", "再送する変更"], { from: "user" });
+
+    const { tasksFile, syncState } = await readProject(projectRoot);
+    expect(process.exitCode).toBe(1);
+    expect(tasksFile.tasks[0].title).toBe("再送する変更");
+    expect(computeLocalDiff(tasksFile.tasks, syncState).map((diff) => diff.id)).toEqual([
+      "owner/repo#1",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -200,6 +200,7 @@ export const initCommand = new Command("init")
       },
       sync: {
         auto_create_issues: false,
+        auto_push: true,
         conflict_policy: { ...DEFAULT_CONFLICT_POLICY },
         field_mapping: fieldMapping,
       },

--- a/packages/cli/src/commands/task/close.ts
+++ b/packages/cli/src/commands/task/close.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import { applyTaskUpdate, type TaskUpdateOptions } from "./update.js";
+import { executeWriteThroughPush } from "./write-through-push.js";
 
 export function createTaskCloseCommand(): Command {
   return new Command("close")
@@ -9,6 +10,7 @@ export function createTaskCloseCommand(): Command {
     .argument("<id>", "Task ID (e.g. 6, #6, owner/repo#6)")
     .option("--approve-review <login>", "Mark review as approved by the assigned reviewer")
     .option("--evidence <summary>", "Record close evidence in the issue body")
+    .option("--no-push", "Do not push this change to GitHub immediately")
     .option("--json", "Output closed task as JSON")
     .action(async (id: string, opts) => {
       try {
@@ -44,6 +46,9 @@ export function createTaskCloseCommand(): Command {
             tasksFile.tasks[taskIndex] = result.task;
             await tasksStore.write(tasksFile);
             await storage.flush();
+            await executeWriteThroughPush(storage, config, tasksFile, [resolvedId], {
+              push: opts.push,
+            });
 
             const evidence = typeof opts.evidence === "string" ? opts.evidence.trim() : "";
             if (evidence.length === 0 && config.require_close_evidence !== true) {

--- a/packages/cli/src/commands/task/close.ts
+++ b/packages/cli/src/commands/task/close.ts
@@ -46,9 +46,21 @@ export function createTaskCloseCommand(): Command {
             tasksFile.tasks[taskIndex] = result.task;
             await tasksStore.write(tasksFile);
             await storage.flush();
-            await executeWriteThroughPush(storage, config, tasksFile, [resolvedId], {
-              push: opts.push,
-            });
+            const writeThroughResult = await executeWriteThroughPush(
+              storage,
+              config,
+              tasksFile,
+              [resolvedId],
+              {
+                push: opts.push,
+              },
+            );
+            const persistedTask = writeThroughResult.tasksFile.tasks.find(
+              (task) => task.id === resolvedId,
+            );
+            if (!persistedTask) {
+              throw new Error(`Closed task was not persisted: ${resolvedId}`);
+            }
 
             const evidence = typeof opts.evidence === "string" ? opts.evidence.trim() : "";
             if (evidence.length === 0 && config.require_close_evidence !== true) {
@@ -56,9 +68,9 @@ export function createTaskCloseCommand(): Command {
             }
 
             if (opts.json) {
-              console.log(JSON.stringify(result.task, null, 2));
+              console.log(JSON.stringify(persistedTask, null, 2));
             } else {
-              console.log(`Closed task: ${resolvedId}`);
+              console.log(`Closed task: ${persistedTask.id}`);
             }
           },
         );

--- a/packages/cli/src/commands/task/link.ts
+++ b/packages/cli/src/commands/task/link.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import { withProjectStorage } from "../../store/project-storage.js";
+import { hashTask } from "../../sync/hash.js";
 import { resolveTaskId } from "../../util/task-id.js";
 import type { Task } from "@gh-gantt/shared";
+import { executeWriteThroughPush } from "./write-through-push.js";
 
 export function addDependency(task: Task, blockerTaskId: string): { task: Task; error?: string } {
   if (blockerTaskId === task.id) {
@@ -97,78 +99,94 @@ export function createTaskLinkCommand(): Command {
     .option("--unblock <id>", "Remove a blocking dependency")
     .option("--set-parent <id>", "Set parent task")
     .option("--remove-parent", "Remove parent task")
+    .option("--no-push", "Do not push this change to GitHub immediately")
     .option("--json", "Output updated task as JSON")
     .action(async (id: string, opts) => {
-      const projectRoot = process.cwd();
-      return withProjectStorage(
-        projectRoot,
-        { mode: "write", scope: "shared-cache" },
-        async (storage) => {
-          const { configStore, tasksStore } = storage;
-          const config = await configStore.read();
-          const tasksFile = await tasksStore.read();
-          const messages: string[] = [];
-
-          const resolvedId = resolveTaskId(id, config);
-          const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
-
-          if (taskIndex === -1) {
-            console.error(`Task not found: ${resolvedId}`);
-            process.exitCode = 1;
-            return;
-          }
-
-          if (opts.blockedBy) {
-            const blockerId = resolveTaskId(opts.blockedBy, config);
-            const depResult = addDependency(tasksFile.tasks[taskIndex], blockerId);
-            if (depResult.error) {
-              console.error(depResult.error);
-              process.exitCode = 1;
-              return;
-            }
-            tasksFile.tasks[taskIndex] = depResult.task;
-            messages.push(`Added dependency: ${resolvedId} blocked by ${blockerId}`);
-          }
-
-          if (opts.unblock) {
-            const blockerId = resolveTaskId(opts.unblock, config);
-            const unblockResult = removeDependency(
-              tasksFile.tasks[taskIndex],
-              blockerId,
-              opts.unblock,
+      try {
+        const projectRoot = process.cwd();
+        await withProjectStorage(
+          projectRoot,
+          { mode: "write", scope: "shared-cache" },
+          async (storage) => {
+            const { configStore, tasksStore } = storage;
+            const config = await configStore.read();
+            const tasksFile = await tasksStore.read();
+            const originalHashes = new Map(
+              tasksFile.tasks.map((task) => [task.id, hashTask(task)]),
             );
-            tasksFile.tasks[taskIndex] = unblockResult.task;
-            messages.push(`Removed dependency: ${resolvedId} no longer blocked by ${blockerId}`);
-          }
+            const messages: string[] = [];
 
-          if (opts.setParent) {
-            const parentId = resolveTaskId(opts.setParent, config);
-            const parentResult = setParent(tasksFile.tasks, resolvedId, parentId);
-            if (parentResult.error) {
-              console.error(parentResult.error);
+            const resolvedId = resolveTaskId(id, config);
+            const taskIndex = tasksFile.tasks.findIndex((t) => t.id === resolvedId);
+
+            if (taskIndex === -1) {
+              console.error(`Task not found: ${resolvedId}`);
               process.exitCode = 1;
               return;
             }
-            tasksFile.tasks = parentResult.tasks!;
-            messages.push(`Set parent: ${resolvedId} → ${parentId}`);
-          }
 
-          if (opts.removeParent) {
-            tasksFile.tasks = removeParent(tasksFile.tasks, resolvedId);
-            messages.push(`Removed parent from: ${resolvedId}`);
-          }
+            if (opts.blockedBy) {
+              const blockerId = resolveTaskId(opts.blockedBy, config);
+              const depResult = addDependency(tasksFile.tasks[taskIndex], blockerId);
+              if (depResult.error) {
+                console.error(depResult.error);
+                process.exitCode = 1;
+                return;
+              }
+              tasksFile.tasks[taskIndex] = depResult.task;
+              messages.push(`Added dependency: ${resolvedId} blocked by ${blockerId}`);
+            }
 
-          await tasksStore.write(tasksFile);
-          await storage.flush();
+            if (opts.unblock) {
+              const blockerId = resolveTaskId(opts.unblock, config);
+              const unblockResult = removeDependency(
+                tasksFile.tasks[taskIndex],
+                blockerId,
+                opts.unblock,
+              );
+              tasksFile.tasks[taskIndex] = unblockResult.task;
+              messages.push(`Removed dependency: ${resolvedId} no longer blocked by ${blockerId}`);
+            }
 
-          if (opts.json) {
-            const updated = tasksFile.tasks.find((t) => t.id === resolvedId);
-            console.log(JSON.stringify(updated, null, 2));
-          } else {
-            for (const message of messages) console.log(message);
-          }
-        },
-      );
+            if (opts.setParent) {
+              const parentId = resolveTaskId(opts.setParent, config);
+              const parentResult = setParent(tasksFile.tasks, resolvedId, parentId);
+              if (parentResult.error) {
+                console.error(parentResult.error);
+                process.exitCode = 1;
+                return;
+              }
+              tasksFile.tasks = parentResult.tasks!;
+              messages.push(`Set parent: ${resolvedId} → ${parentId}`);
+            }
+
+            if (opts.removeParent) {
+              tasksFile.tasks = removeParent(tasksFile.tasks, resolvedId);
+              messages.push(`Removed parent from: ${resolvedId}`);
+            }
+
+            await tasksStore.write(tasksFile);
+            await storage.flush();
+            const changedIds = tasksFile.tasks
+              .filter((task) => originalHashes.get(task.id) !== hashTask(task))
+              .map((task) => task.id);
+            await executeWriteThroughPush(storage, config, tasksFile, changedIds, {
+              push: opts.push,
+              atomicTargetGroups: [changedIds],
+            });
+
+            if (opts.json) {
+              const updated = tasksFile.tasks.find((t) => t.id === resolvedId);
+              console.log(JSON.stringify(updated, null, 2));
+            } else {
+              for (const message of messages) console.log(message);
+            }
+          },
+        );
+      } catch (err) {
+        console.error("Failed to link task:", err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
     });
 }
 

--- a/packages/cli/src/commands/task/link.ts
+++ b/packages/cli/src/commands/task/link.ts
@@ -170,13 +170,21 @@ export function createTaskLinkCommand(): Command {
             const changedIds = tasksFile.tasks
               .filter((task) => originalHashes.get(task.id) !== hashTask(task))
               .map((task) => task.id);
-            await executeWriteThroughPush(storage, config, tasksFile, changedIds, {
-              push: opts.push,
-              atomicTargetGroups: [changedIds],
-            });
+            const writeThroughResult = await executeWriteThroughPush(
+              storage,
+              config,
+              tasksFile,
+              changedIds,
+              {
+                push: opts.push,
+                atomicTargetGroups: [changedIds],
+              },
+            );
 
             if (opts.json) {
-              const updated = tasksFile.tasks.find((t) => t.id === resolvedId);
+              const updated = writeThroughResult.tasksFile.tasks.find(
+                (task) => task.id === resolvedId,
+              );
               console.log(JSON.stringify(updated, null, 2));
             } else {
               for (const message of messages) console.log(message);

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { withProjectStorage } from "../../store/project-storage.js";
 import { resolveTaskId } from "../../util/task-id.js";
+import { executeWriteThroughPush } from "./write-through-push.js";
 import type { Config, Task } from "@gh-gantt/shared";
 import {
   computeStatusDateUpdates,
@@ -358,6 +359,7 @@ export function createTaskUpdateCommand(): Command {
     .option("--filter-type <type>", "Bulk filter: match tasks by type")
     .option("--filter-milestone <name>", "Bulk filter: match tasks by milestone ('none' for unset)")
     .option("--filter-label <name>", "Bulk filter: match tasks by label")
+    .option("--no-push", "Do not push this change to GitHub immediately")
     .option("--json", "Output updated task(s) as JSON")
     .action(async (id: string | undefined, opts) => {
       try {
@@ -414,6 +416,9 @@ export function createTaskUpdateCommand(): Command {
               tasksFile.tasks[taskIndex] = result.task;
               await tasksStore.write(tasksFile);
               await storage.flush();
+              await executeWriteThroughPush(storage, config, tasksFile, [resolvedId], {
+                push: opts.push,
+              });
 
               if (opts.json) {
                 console.log(JSON.stringify(result.task, null, 2));
@@ -466,6 +471,13 @@ export function createTaskUpdateCommand(): Command {
 
               await tasksStore.write(tasksFile);
               await storage.flush();
+              await executeWriteThroughPush(
+                storage,
+                config,
+                tasksFile,
+                updatedTasks.map((task) => task.id),
+                { push: opts.push },
+              );
 
               if (opts.json) {
                 console.log(JSON.stringify({ updated: updatedTasks }, null, 2));

--- a/packages/cli/src/commands/task/update.ts
+++ b/packages/cli/src/commands/task/update.ts
@@ -416,14 +416,26 @@ export function createTaskUpdateCommand(): Command {
               tasksFile.tasks[taskIndex] = result.task;
               await tasksStore.write(tasksFile);
               await storage.flush();
-              await executeWriteThroughPush(storage, config, tasksFile, [resolvedId], {
-                push: opts.push,
-              });
+              const writeThroughResult = await executeWriteThroughPush(
+                storage,
+                config,
+                tasksFile,
+                [resolvedId],
+                {
+                  push: opts.push,
+                },
+              );
+              const persistedTask = writeThroughResult.tasksFile.tasks.find(
+                (task) => task.id === resolvedId,
+              );
+              if (!persistedTask) {
+                throw new Error(`Updated task was not persisted: ${resolvedId}`);
+              }
 
               if (opts.json) {
-                console.log(JSON.stringify(result.task, null, 2));
+                console.log(JSON.stringify(persistedTask, null, 2));
               } else {
-                console.log(`Updated task: ${resolvedId}`);
+                console.log(`Updated task: ${persistedTask.id}`);
               }
             } else {
               // 複数taskを一括更新する
@@ -471,19 +483,23 @@ export function createTaskUpdateCommand(): Command {
 
               await tasksStore.write(tasksFile);
               await storage.flush();
-              await executeWriteThroughPush(
+              const writeThroughResult = await executeWriteThroughPush(
                 storage,
                 config,
                 tasksFile,
                 updatedTasks.map((task) => task.id),
                 { push: opts.push },
               );
+              const updatedIds = new Set(updatedTasks.map((task) => task.id));
+              const persistedTasks = writeThroughResult.tasksFile.tasks.filter((task) =>
+                updatedIds.has(task.id),
+              );
 
               if (opts.json) {
-                console.log(JSON.stringify({ updated: updatedTasks }, null, 2));
+                console.log(JSON.stringify({ updated: persistedTasks }, null, 2));
               } else {
-                console.log(`Updated ${updatedTasks.length} task(s).`);
-                for (const t of updatedTasks) {
+                console.log(`Updated ${persistedTasks.length} task(s).`);
+                for (const t of persistedTasks) {
                   const shortId = t.id.includes("#") ? t.id.split("#")[1] : t.id;
                   console.log(`  ${shortId}: ${t.title}`);
                 }

--- a/packages/cli/src/commands/task/write-through-push.ts
+++ b/packages/cli/src/commands/task/write-through-push.ts
@@ -1,0 +1,144 @@
+import type { Config, SyncState, TasksFile } from "@gh-gantt/shared";
+import { createGraphQLClient } from "../../github/client.js";
+import type { ProjectStorageSession } from "../../store/project-storage.js";
+import { hasUnresolvedMarkers } from "../../sync/conflict-marker.js";
+import { computeLocalDiff } from "../../sync/diff.js";
+import { executePush, type PushResult } from "../../sync/push-executor.js";
+
+export interface WriteThroughPushOptions {
+  push?: boolean;
+  createClient?: typeof createGraphQLClient;
+  atomicTargetGroups?: readonly (readonly string[])[];
+}
+
+export interface WriteThroughPushResult {
+  status: "disabled" | "no-targets" | "pushed";
+  result?: PushResult;
+}
+
+function rollbackAtomicGroupSnapshots(
+  beforePush: SyncState,
+  afterPush: SyncState,
+  groupIds: readonly string[],
+): SyncState {
+  const snapshots = { ...afterPush.snapshots };
+  for (const id of groupIds) {
+    const beforeSnapshot = beforePush.snapshots[id];
+    if (!beforeSnapshot) {
+      delete snapshots[id];
+      continue;
+    }
+    const updatedAt = afterPush.snapshots[id]?.updated_at;
+    snapshots[id] = {
+      ...beforeSnapshot,
+      ...(updatedAt === undefined ? {} : { updated_at: updatedAt }),
+    };
+  }
+  return { ...afterPush, snapshots };
+}
+
+export async function executeWriteThroughPush(
+  storage: ProjectStorageSession,
+  config: Config,
+  tasksFile: TasksFile,
+  targetTaskIds: readonly string[],
+  options: WriteThroughPushOptions = {},
+): Promise<WriteThroughPushResult> {
+  if (options.push === false || config.sync.auto_push === false) {
+    return { status: "disabled" };
+  }
+
+  const targetIds = new Set(targetTaskIds);
+  const tasksById = new Map(tasksFile.tasks.map((task) => [task.id, task]));
+  const groupedIds = new Set<string>();
+  const eligibleIds = new Set<string>();
+  const eligibleAtomicGroups: string[][] = [];
+  for (const configuredGroup of options.atomicTargetGroups ?? []) {
+    const groupIds = [...new Set(configuredGroup.filter((id) => targetIds.has(id)))];
+    if (groupIds.length === 0) continue;
+    for (const id of groupIds) groupedIds.add(id);
+
+    const hasConflict = groupIds.some((id) => {
+      const task = tasksById.get(id);
+      return task && hasUnresolvedMarkers(task as unknown as Record<string, unknown>);
+    });
+    if (hasConflict) {
+      console.warn(
+        `未解決のコンフリクトがあるため atomic auto-push group をスキップしました: ${groupIds.join(", ")}`,
+      );
+      continue;
+    }
+
+    const existingGroupIds = groupIds.filter((id) => tasksById.has(id));
+    for (const id of existingGroupIds) eligibleIds.add(id);
+    if (existingGroupIds.length > 0) eligibleAtomicGroups.push(existingGroupIds);
+  }
+
+  for (const id of targetIds) {
+    if (groupedIds.has(id)) continue;
+    const task = tasksById.get(id);
+    if (!task) continue;
+    if (hasUnresolvedMarkers(task as unknown as Record<string, unknown>)) {
+      console.warn(`未解決のコンフリクトがあるため auto-push をスキップしました: ${task.id}`);
+      continue;
+    }
+    eligibleIds.add(task.id);
+  }
+
+  if (eligibleIds.size === 0) {
+    return { status: "no-targets" };
+  }
+
+  const syncState = await storage.stateStore.read();
+  const pendingIds = computeLocalDiff(tasksFile.tasks, syncState)
+    .map((diff) => diff.id)
+    .filter((id) => eligibleIds.has(id));
+  if (pendingIds.length === 0) {
+    return { status: "no-targets" };
+  }
+
+  const createClient = options.createClient ?? createGraphQLClient;
+  const gql = await createClient();
+  const {
+    result,
+    tasksFile: updatedTasksFile,
+    syncState: updatedSyncState,
+  } = await executePush(gql, config, tasksFile, syncState, {
+    targetTaskIds: pendingIds,
+    saveProgress: async (nextTasksFile, nextSyncState) => {
+      await storage.tasksStore.write(nextTasksFile);
+      await storage.stateStore.write(nextSyncState);
+      await storage.flush();
+    },
+  });
+
+  const pendingIdSet = new Set(pendingIds);
+  let finalSyncState = updatedSyncState;
+  let remainingIds = new Set(
+    computeLocalDiff(updatedTasksFile.tasks, finalSyncState)
+      .map((diff) => diff.id)
+      .filter((id) => pendingIdSet.has(id)),
+  );
+  for (const groupIds of eligibleAtomicGroups) {
+    const pendingGroupIds = groupIds.filter((id) => pendingIdSet.has(id));
+    if (!pendingGroupIds.some((id) => remainingIds.has(id))) continue;
+    finalSyncState = rollbackAtomicGroupSnapshots(syncState, finalSyncState, pendingGroupIds);
+  }
+  remainingIds = new Set(
+    computeLocalDiff(updatedTasksFile.tasks, finalSyncState)
+      .map((diff) => diff.id)
+      .filter((id) => pendingIdSet.has(id)),
+  );
+
+  await storage.tasksStore.write(updatedTasksFile);
+  await storage.stateStore.write(finalSyncState);
+  await storage.flush();
+
+  if (remainingIds.size > 0) {
+    throw new Error(
+      `auto-push 後もローカル差分が残っています: ${[...remainingIds].sort().join(", ")}`,
+    );
+  }
+
+  return { status: "pushed", result };
+}

--- a/packages/cli/src/commands/task/write-through-push.ts
+++ b/packages/cli/src/commands/task/write-through-push.ts
@@ -13,9 +13,11 @@ export interface WriteThroughPushOptions {
 
 export interface WriteThroughPushResult {
   status: "disabled" | "no-targets" | "pushed";
+  tasksFile: TasksFile;
   result?: PushResult;
 }
 
+/** atomic group 失敗時に同期内容を戻し、取得済みの remote watermark だけを維持する。 */
 function rollbackAtomicGroupSnapshots(
   beforePush: SyncState,
   afterPush: SyncState,
@@ -37,6 +39,10 @@ function rollbackAtomicGroupSnapshots(
   return { ...afterPush, snapshots };
 }
 
+/**
+ * update / close / link が変更した既存 Issue を即時同期する。
+ * draft の実体化は #298 の責務なので、remote API を呼ぶ前に fail-closed する。
+ */
 export async function executeWriteThroughPush(
   storage: ProjectStorageSession,
   config: Config,
@@ -45,7 +51,7 @@ export async function executeWriteThroughPush(
   options: WriteThroughPushOptions = {},
 ): Promise<WriteThroughPushResult> {
   if (options.push === false || config.sync.auto_push === false) {
-    return { status: "disabled" };
+    return { status: "disabled", tasksFile };
   }
 
   const targetIds = new Set(targetTaskIds);
@@ -86,7 +92,7 @@ export async function executeWriteThroughPush(
   }
 
   if (eligibleIds.size === 0) {
-    return { status: "no-targets" };
+    return { status: "no-targets", tasksFile };
   }
 
   const syncState = await storage.stateStore.read();
@@ -94,51 +100,88 @@ export async function executeWriteThroughPush(
     .map((diff) => diff.id)
     .filter((id) => eligibleIds.has(id));
   if (pendingIds.length === 0) {
-    return { status: "no-targets" };
+    return { status: "no-targets", tasksFile };
+  }
+
+  const unsupportedIds = pendingIds.filter((id) => tasksById.get(id)?.github_issue === null);
+  if (unsupportedIds.length > 0) {
+    throw new Error(
+      `write-through push は既存 Issue のみ対象です: ${unsupportedIds.sort().join(", ")}`,
+    );
   }
 
   const createClient = options.createClient ?? createGraphQLClient;
   const gql = await createClient();
-  const {
-    result,
-    tasksFile: updatedTasksFile,
-    syncState: updatedSyncState,
-  } = await executePush(gql, config, tasksFile, syncState, {
-    targetTaskIds: pendingIds,
-    saveProgress: async (nextTasksFile, nextSyncState) => {
-      await storage.tasksStore.write(nextTasksFile);
-      await storage.stateStore.write(nextSyncState);
-      await storage.flush();
-    },
-  });
-
   const pendingIdSet = new Set(pendingIds);
-  let finalSyncState = updatedSyncState;
-  let remainingIds = new Set(
-    computeLocalDiff(updatedTasksFile.tasks, finalSyncState)
-      .map((diff) => diff.id)
-      .filter((id) => pendingIdSet.has(id)),
-  );
+  const groupedPendingIds = new Set<string>();
+  const executionUnits: Array<{ ids: string[]; atomic: boolean }> = [];
   for (const groupIds of eligibleAtomicGroups) {
     const pendingGroupIds = groupIds.filter((id) => pendingIdSet.has(id));
-    if (!pendingGroupIds.some((id) => remainingIds.has(id))) continue;
-    finalSyncState = rollbackAtomicGroupSnapshots(syncState, finalSyncState, pendingGroupIds);
+    if (pendingGroupIds.length === 0) continue;
+    for (const id of pendingGroupIds) groupedPendingIds.add(id);
+    executionUnits.push({ ids: pendingGroupIds, atomic: true });
   }
-  remainingIds = new Set(
-    computeLocalDiff(updatedTasksFile.tasks, finalSyncState)
-      .map((diff) => diff.id)
-      .filter((id) => pendingIdSet.has(id)),
-  );
-
-  await storage.tasksStore.write(updatedTasksFile);
-  await storage.stateStore.write(finalSyncState);
-  await storage.flush();
-
-  if (remainingIds.size > 0) {
-    throw new Error(
-      `auto-push 後もローカル差分が残っています: ${[...remainingIds].sort().join(", ")}`,
-    );
+  for (const id of pendingIds) {
+    if (!groupedPendingIds.has(id)) executionUnits.push({ ids: [id], atomic: false });
   }
 
-  return { status: "pushed", result };
+  let currentTasksFile = tasksFile;
+  let currentSyncState = syncState;
+  const totalResult: PushResult = { created: 0, updated: 0, skipped: 0 };
+  // 各 target の成功直後に remote watermark を永続化する。
+  // link の mirror 群は後続失敗時に syncFields だけをまとめて戻し、全体を再送可能にする。
+  for (const unit of executionUnits) {
+    const beforeUnitSyncState = currentSyncState;
+    try {
+      for (const id of unit.ids) {
+        const {
+          result,
+          tasksFile: nextTasksFile,
+          syncState: nextSyncState,
+        } = await executePush(gql, config, currentTasksFile, currentSyncState, {
+          targetTaskIds: [id],
+          saveProgress: async (progressTasksFile, progressSyncState) => {
+            await storage.tasksStore.write(progressTasksFile);
+            await storage.stateStore.write(progressSyncState);
+            await storage.flush();
+          },
+        });
+
+        totalResult.created += result.created;
+        totalResult.updated += result.updated;
+        totalResult.skipped += result.skipped;
+        currentTasksFile = nextTasksFile;
+        currentSyncState = nextSyncState;
+
+        const remainingIds = new Set(
+          computeLocalDiff(currentTasksFile.tasks, currentSyncState)
+            .map((diff) => diff.id)
+            .filter((remainingId) => remainingId === id),
+        );
+        await storage.tasksStore.write(currentTasksFile);
+        await storage.stateStore.write(currentSyncState);
+        await storage.flush();
+
+        if (remainingIds.size > 0) {
+          throw new Error(
+            `auto-push 後もローカル差分が残っています: ${[...remainingIds].sort().join(", ")}`,
+          );
+        }
+      }
+    } catch (error) {
+      if (unit.atomic) {
+        currentSyncState = rollbackAtomicGroupSnapshots(
+          beforeUnitSyncState,
+          currentSyncState,
+          unit.ids,
+        );
+        await storage.tasksStore.write(currentTasksFile);
+        await storage.stateStore.write(currentSyncState);
+        await storage.flush();
+      }
+      throw error;
+    }
+  }
+
+  return { status: "pushed", tasksFile: currentTasksFile, result: totalResult };
 }

--- a/packages/cli/src/sync/push-executor.ts
+++ b/packages/cli/src/sync/push-executor.ts
@@ -124,9 +124,13 @@ export async function executePush(
   opts?: {
     force?: boolean;
     saveProgress?: (tasksFile: TasksFile, syncState: SyncState) => Promise<void>;
+    targetTaskIds?: readonly string[];
   },
 ): Promise<{ result: PushResult; tasksFile: TasksFile; syncState: SyncState }> {
-  const diffs = computeLocalDiff(tasksFile.tasks, syncState);
+  const allDiffs = computeLocalDiff(tasksFile.tasks, syncState);
+  const targetTaskIds = opts?.targetTaskIds === undefined ? undefined : new Set(opts.targetTaskIds);
+  const diffs =
+    targetTaskIds === undefined ? allDiffs : allDiffs.filter((diff) => targetTaskIds.has(diff.id));
   const result: PushResult = { created: 0, updated: 0, skipped: 0 };
 
   if (diffs.length === 0) {

--- a/packages/shared/src/__tests__/schema.test.ts
+++ b/packages/shared/src/__tests__/schema.test.ts
@@ -504,6 +504,32 @@ describe("[FR-CLI-016-AC2] close evidence requirement の設定検証", () => {
   });
 });
 
+describe("[FR-SYNC-003-AC7] write-through push の設定契約を検証できる", () => {
+  it("auto_push を省略した場合は true を補完する", () => {
+    const parsed = ConfigSchema.parse(validConfig);
+
+    expect(parsed.sync.auto_push).toBe(true);
+  });
+
+  it("auto_push に明示した false を保持する", () => {
+    const parsed = ConfigSchema.parse({
+      ...validConfig,
+      sync: { ...validConfig.sync, auto_push: false },
+    });
+
+    expect(parsed.sync.auto_push).toBe(false);
+  });
+
+  it("auto_push が boolean 以外の場合は拒否する", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        sync: { ...validConfig.sync, auto_push: "true" },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("TasksFileSchema", () => {
   it("[FR-CLI-011-AC1] acceptance_criteria 未指定の既存 task を空配列として受理する", () => {
     const data = {

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -183,6 +183,7 @@ export const ConfigSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z.object({
   sync: z
     .object({
       auto_create_issues: z.boolean(),
+      auto_push: z.boolean().default(true),
       conflict_policy: ConflictPolicySchema.optional(),
       field_mapping: z.object({
         start_date: z.string(),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -105,6 +105,7 @@ export interface GithubConfig {
 
 export interface SyncConfig {
   auto_create_issues: boolean;
+  auto_push?: boolean;
   conflict_policy?: ConflictPolicy;
   field_mapping: {
     start_date: string;


### PR DESCRIPTION
## Summary

- `sync.auto_push` を既定 ON とし、`update` / `close` / `link` が変更した task だけを write-through push する
- `--no-push` と task 単位の conflict skip を追加し、link の親子 mirror は atomic group として同期する
- 部分失敗時は未送信差分と整合した snapshot を保持し、従来の `gh-gantt push` で再送できる
- `FR-SYNC-003-AC7` と config・targeted push・CLI・障害耐性の回帰テストを追加する

Closes #297

## Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（122 files / 1,301 tests）
- `pnpm build`
- `pnpm req:trace`
- `git diff --exit-code docs/requirements.yaml`
- `pnpm req:validate`
- `pnpm docs:gen`
- Dev-Role reviewer pass 3: approve / findings 0
- betterleaks native 1.5.0: no leaks found
- pinned Docker betterleaks 1.1.2: no leaks found（pre-commit hook でも skip なし）
- pre-push hook: test / build / req-trace / req-validate / docs-gen 成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `update`、`close`、`link` 実行後、変更対象のタスクだけを自動同期できるようになりました。
  * 自動同期は既定で有効です。
  * `--no-push` または設定で自動同期を無効化できます。
  * 競合した対象はスキップし、未同期のローカル変更を保持します。

* **バグ修正**
  * 同期失敗時にローカル差分やスナップショットが不適切に失われないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->