### PR TITLE
feat(cli): ready frontier の安全な並列 dispatch を追加

### DIFF
--- a/.gantt-sync/gantt.config.json
+++ b/.gantt-sync/gantt.config.json
@@ -104,6 +104,15 @@
       }
     ]
   },
+  "dispatch": {
+    "max_concurrency": 2,
+    "state_concurrency": {
+      "In Progress": 2
+    },
+    "repository_concurrency": {
+      "stanah/gh-gantt": 2
+    }
+  },
   "run_graph": {
     "plan_id": "dev-role-fixed",
     "plan_version": "1",

--- a/.gantt-sync/workflow.md
+++ b/.gantt-sync/workflow.md
@@ -94,6 +94,39 @@ resume は外部副作用の状態を必須入力とし、`unknown` は自動再
 `run observe-pr` は live `closingIssuesReferences` で Run 対象 Issue への exact linkage を確認し、
 未結線または取得不完全の PR では Run を完了しない。
 
+## Bounded dispatch
+
+この repository は `.gantt-sync/gantt.config.json` の `dispatch.max_concurrency` を global 上限、
+`dispatch.state_concurrency` と `dispatch.repository_concurrency` を追加上限として使う。
+gh-gantt は次の lifecycle を control plane の公開 CLI contract として提供する。
+
+1. `gh-gantt pull` で GitHub Projects 由来の Work Graph を更新し、dependency readiness と同期状態を確認する。
+2. `gh-gantt run dispatch --workspace-map <path> --gate-snapshot <path>` で Config の global / state / repository 上限内にある ready frontier の dispatch plan をファイルへ保存する。gate snapshot は strict JSON の `schemaVersion` / `sourceRevision` / `observedAt` / review/human IDs を持つ。plan は shared strict schema の `planVersion: "1"`、`planId`、`registryEntityVersion`、`generatedAt`、候補、除外理由、capacity と Work Graph/gate/combined fingerprint を持つ。
+3. dispatch plan の各 task に `gh-gantt run claim --plan-file <path> --gate-snapshot <path>` を実行する。claim は Work Graph read lease 内で current Work Graph、loop、sync、current gate snapshot、registry を再計算し、selected task の repository / state / workspace、Run Graph の task binding、plan lineage / version / fingerprint を検証してから、独立した registry CAS で claim receipt を確定する。固定 lock order は Work Graph read lease → claim registry lock とし、Work Graph lease を registry storage に流用しない。
+4. 外部 runner が task ごとに別の isolated workspace を用意する。同じ workspace を複数 claim で共有しない。
+5. 実行中は lease が失効する前に `gh-gantt run heartbeat` を送り、current owner と fencing version を更新する。
+6. completion fencing として、registry lock 内で current claim proof と Run / task / actor lineage を検証し、Run Graph の transition、attempt、artifact、evidence を明示的な副作用なしの domain validation seam で検証する。reject では registry と journal を変更せず、同じ current proof で修正 event を retry できる。dispatch Config が有効なら proof なしの completion/outcome は一律に拒否する。
+7. validation 後、event ID / payload fingerprint / current claim lineage と dispatch authorization binding を repository-shared pending authorization として先に永続化する。pending 中の heartbeat / release / 別 event は `authorization_pending` で拒否する。同じ event ID / payload / binding の retry だけが binding 付き Run Graph event を append でき、append 成功後だけ durable receipt が entity version と fencing token を進め、claim を維持したまま更新 proof を返す。sequence 競合では pending を解除して original proof を維持する。
+8. pending publish 後・append 前、または append 後・receipt publish 前に中断した場合、exact retry だけを reconciliation する。claim が current なら receipt と更新 proof を回収する。先に expired / owner_stopped reclaim された場合は pending を terminalize し、既存 event だけを historical audit できるが新規 event と継続 proof は受け取れない。receipt publish 後は stored receipt に収束する。
+9. task / Run の正常終了または中止時は `gh-gantt run release` で claim を明示解放する。中間 event の認可は release ではない。期限切れ claim の release は `lease_expired` で拒否し、expired reclaim を使う。
+10. owner 停止を evidence ID で確認した場合、または lease が失効した場合だけ、別 owner が `gh-gantt run reclaim` を実行する。旧 owner の heartbeat、release、event authorization は stale として拒否される。
+11. accepted outcome event、release、reclaim の後は共有 Work Graph Cache を読み直し、dependency を再評価して fan-in を解く。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
+
+claim lifecycle は `claim_acquired` / `claim_heartbeat` / `claim_released` / `claim_reclaimed` / `claim_event_authorized` として
+workspace-local の Run Graph audit へ記録する。audit は event ID、fingerprint、entity version、run / task lineage を
+repository-shared durable registry receipt と照合し、偽造・stale receipt は `stale_claim` で拒否する。audit event ID は
+`audit:${receipt.eventId}` に固定し、同じ registry event の別 ID 追記を拒否する。receipt 確定後、
+local audit の追記前に中断した場合は、同じ event ID で command を再実行して reconciliation する。
+`gh-gantt run show` は `claimAudits` の total / limit / truncated / bounded items を JSON と人間表示で公開する。
+
+sync conflict、open iteration、review gate、human gate のいずれかがある task は dispatch しない。
+Work Graph に存在しない task ID を含む不明な gate snapshot は `gate_snapshot_inconsistent` で frontier 全体を停止する。
+claim registry の不整合、Config にない status、plan 生成後に変化した dependency / gate / claim も fail-closed とする。
+
+gh-gantt が提供するのは schema-validated な dispatch plan と event contract だけである。
+agent/provider/shell runner を内蔵しないほか、workspace を作成しない。外部 runner が isolated workspace の
+作成、process の起動、成果物の生成を担当し、gh-gantt は GitHub task status を暗黙更新しない。
+
 ## Dev-Role Config
 
 `gh-gantt-dev-role` スキル用の設定。orchestrator / planner / implementer / executor / reviewer の各ロールが参照する。

--- a/.gantt-sync/workflow.md
+++ b/.gantt-sync/workflow.md
@@ -110,7 +110,7 @@ gh-gantt は次の lifecycle を control plane の公開 CLI contract として�
 8. pending publish 後・append 前、または append 後・receipt publish 前に中断した場合、exact retry だけを reconciliation する。claim が current なら receipt と更新 proof を回収する。先に expired / owner_stopped reclaim された場合は pending を terminalize し、既存 event だけを historical audit できるが新規 event と継続 proof は受け取れない。receipt publish 後は stored receipt に収束する。
 9. task / Run の正常終了または中止時は `gh-gantt run release` で claim を明示解放する。中間 event の認可は release ではない。期限切れ claim の release は `lease_expired` で拒否し、expired reclaim を使う。
 10. owner 停止を evidence ID で確認した場合、または lease が失効した場合だけ、別 owner が `gh-gantt run reclaim` を実行する。旧 owner の heartbeat、release、event authorization は stale として拒否される。
-11. accepted outcome event、release、reclaim の後は共有 Work Graph Cache を読み直し、dependency を再評価して fan-in を解く。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
+11. accepted outcome event、release、reclaim の後は `gh-gantt pull` で GitHub 由来の Work Graph を更新し、`gh-gantt list` で dependency readiness を再評価して fan-in を解く。共有 Work Graph Cache の内部ファイルは直接読み書きしない。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
 
 claim lifecycle は `claim_acquired` / `claim_heartbeat` / `claim_released` / `claim_reclaimed` / `claim_event_authorized` として
 workspace-local の Run Graph audit へ記録する。audit は event ID、fingerprint、entity version、run / task lineage を

--- a/docs/adr/ADR-024-ready-frontier-claim-coordination.md
+++ b/docs/adr/ADR-024-ready-frontier-claim-coordination.md
@@ -1,0 +1,181 @@
+---
+id: ADR-024
+title: ready frontier の claim coordination と Run Graph audit を分離する
+date: 2026-08-02
+status: accepted
+related_requirements:
+  - NFR-STABILITY-014
+---
+
+## Context
+
+ADR-021 は Plan Graph、Work Graph、Org Graph、Run Graph の正本を分離し、ADR-022 は fixed dev-role
+Run Graph の accepted event journal を workspace-local に置いた。ADR-023 は GitHub Projects 由来の
+Work Graph Cache だけを git-common-dir 配下へ共有し、その repository lease と snapshot-set を
+`withProjectStorage` に閉じ込めた。
+
+複数 worktree から dependency 解決済み task を並列 dispatch するには、同じ task または workspace の
+二重 dispatch を防ぐ repository-shared coordination が必要である。一方、Work Graph Cache の長時間 lease を
+claim の heartbeat に使うと pull / push / status を阻害し、Run Graph journal 全体を共有すると #328 までの
+workspace-local な accepted lineage を暗黙に移動してしまう。さらに lease 失効後に旧 runner が完了 outcome を
+返せるなら、reclaim した新 owner の結果を stale owner が上書きできる。
+
+## Decision
+
+### ready frontier は Work Graph から純粋に導出する
+
+ready frontier と dispatch plan は GitHub Projects 由来の Work Graph、明示的な現在時刻、Config、gate snapshot、
+claim snapshot から純粋に導出する。未完了 dependency、親コンテナ、sync conflict、open iteration、review gate、
+human gate、active claim を持つ task は除外し、候補と除外理由を stable ID と安定順で返す。不明な status、
+不整合な claim snapshot は fail-closed とする。gate snapshot に Work Graph 上に存在しない task ID が一つでも
+あれば `gate_snapshot_inconsistent` として frontier 全体を停止し、部分的な候補を返さない。
+
+gate snapshot は `schemaVersion`、外部正本の `sourceRevision`、`observedAt`、review/human gate task ID を持つ
+strict JSON file とし、dispatch/claim の双方で `--gate-snapshot <path>` を必須にする。gh-gantt は外部 gate の
+正本を発明せず、canonical fingerprint と source revision を lineage として照合する。
+
+dispatch plan は shared の単一 strict schema で `planVersion: "1"`、stable な `planId`、`registryEntityVersion`、
+`generatedAt`、候補、除外理由、capacity と、sync conflict、open iteration、review gate、human gate、task ごとの
+workspace、Work Graph/gate/combined snapshot fingerprint を含む再検証可能な context を返す。この plan lineage は候補を
+表示するだけの advisory output ではなく、後続 claim の authorization input とする。
+
+Config は global 上限を必須とし、任意の state 上限と repository 上限を追加する。active lease を各使用数へ数え、
+三つの残 slot の交差だけを dispatch plan に含める。同じ task と isolated workspace は同時に一つの active claim
+だけを持てる。
+
+### claim registry だけを repository-shared にする
+
+claim registry は次の独立した versioned namespace に置く。
+
+```text
+<git-common-dir>/gh-gantt/coordination/v1/<project-key>/
+```
+
+registry は claim、heartbeat、release、reclaim、event authorization を expected entity version、opaque claim ID、
+fencing token、event ID、owner identity、workspace ID、run ID、取得時刻、失効時刻とともに compare-and-set する。
+同じ event ID と payload の再実行は同じ receipt に収束し、payload mismatch、stale version、期限前 reclaim、
+active claim と競合する task / workspace は state unchanged で拒否する。
+期限前に停止 owner を reclaim する場合は、停止を確認した evidence ID を receipt と audit に残す。
+期限切れ claim の release は ownership を解放したことにせず、`lease_expired` で拒否して expired reclaim の
+理由を保持する。
+
+claim は `run dispatch` が返した strict plan file と current gate snapshot file を必須入力とする。claim は
+Work Graph read lease を保持した callback 内で current Work Graph、loop、sync、gate snapshot、claim registry を
+読み直して dispatch plan を再計算し、選択 task の repository / state / workspace、Run Graph の
+task binding、`planId` / `planVersion` / `registryEntityVersion` を一致検証する。plan 生成後に dependency や gate、
+claim、status が変化した場合と、直接指定された blocked / unknown task は registry mutation 前に fail-closed で
+拒否する。固定 lock order は claim 時だけ Work Graph read lease → 独立した claim registry lock とし、registry CAS
+直前にも combined snapshot fingerprint を再照合する。Work Graph lease を registry storage として流用しない。
+
+coordination namespace は claim 専用の短時間 filesystem lease と atomic publish を所有する。dead owner recovery は
+観測した owner nonce に bind した `recovery-claim.json` を exclusive create し、owner/recovery nonce の再照合後だけ
+active lock directory を atomic retire する。別 process が回復後に取得した live lock を古い観測で削除しない。
+completion の critical
+section では current proof 検証、workspace-local Run Graph の domain validation / append、registry publish だけを行い、
+GitHub I/O、runner、worktree 操作、長時間 task を実行しない。lock order は registry lock から Run Graph journal lock の
+順に固定し、heartbeat / release / reclaim は Run Graph lock を取得しない。
+completion の lock order は registry lock → Run Graph journal lock とする。ADR-023 の Work Graph Cache lease、
+snapshot-set、workspace-local fallback は claim registry の lease/storage として流用しない。
+
+### pending authorization を先に永続化し、Run Graph event と receipt を確定する
+
+claim proof 付き `attempt_finished` / `node_outcome_submitted` は、registry lock 内で current proof と Run / task / actor
+lineage を検証してから、Run Graph の transition、active attempt、artifact、evidence を明示的な副作用なしの seam で
+検証する。domain reject では repository registry と Run Graph journal のどちらも変更せず、caller は同じ current
+proof を使って修正 event を retry できる。暗黙の async-local preparation state は使用しない。
+
+validation 成功後、event ID、payload fingerprint、claim lineage と、claim ID、旧 fencing token、owner / run / task、
+command fingerprint の `dispatchAuthorization` binding を repository-shared registry の pending authorization として
+先に永続化する。pending 中の heartbeat、release、別 event authorization は `authorization_pending` で fail-closed に
+する。同一 event ID / payload / binding の exact retry だけが処理を再開できる。その後 binding 付き event を
+workspace-local Run Graph へ append し、append 成功後だけ registry
+の entity version と fencing token を進め、operation-discriminated receipt を publish する。task / Run claim 自体は
+維持し、receipt は更新 proof を public JSON result に含めるため、同じ claim で
+`attempt_finished`、`node_outcome_submitted`、次 node の event を順次認可できるようにする。task / Run の終端または
+中止で owner が `run release` を明示実行したときだけ claim を解放する。
+
+両 store を一つの atomic filesystem transaction にはしない。crash が pending publish 後・Run Graph append 前なら
+pending だけが残り、exact retry が append を再開する。append 後・receipt publish 前なら pending と immutable binding
+付き event が残る。claim が current の間の exact retry はその event を検証して receipt と更新 proof を publish する。
+先に expired/owner_stopped reclaim された場合は pending を terminalize し、旧 owner は同じ binding を持つ既存 event
+だけを historical reconciliation/audit できるが、新規 event の append と claim 継続用 proof は受け取れない。
+registry publish 後の retry は stored
+receipt に収束する。続けて `claim_acquired`、`claim_heartbeat`、`claim_released`、`claim_reclaimed`、
+`claim_event_authorized` の audit event を追記し、receipt 後・audit 前の停止は同じ event ID で reconciliation する。
+
+validation と append の間に別 event が入り sequence が競合した場合、prepared event と registry receipt は受理せず、
+pending を atomic に解除して original proof と active claim を維持する。caller は current Run Graph view に対する修正
+event を同じ proof で送る。
+authorization commit と heartbeat / reclaim は同じ registry lock の勝者だけを受理する。
+
+`recordClaimAudit` の event ID は内部規則 `audit:${receipt.eventId}` に固定する。同じ receipt/registry event を別の
+audit event ID で再追記できない。schema-valid な入力だけでは受理せず、fingerprint、entity version、run / task
+lineage を repository-shared registry の durable receipt と照合する。照合できない偽造・stale receipt は
+`stale_claim` として state unchanged で拒否する。`RunGraphView.claimAudits` と `run show` は audit の total、
+limit、truncated、bounded items を公開し、operator が claim / release / reclaim / event authorization の理由と lineage を
+無制限 journal dump なしで確認できるようにする。
+
+Run Graph の fixed dev-role node / edge / current node は変更しない。claim audit は owner / workspace / run / task
+lineage と fencing proof を追加する versioned extension であり、既存 accepted segment、terminal attempt、stable ID、
+event lineage を上書きしない。Run Graph journal は workspace-local のままとし、repository 共有へ移動しない。
+
+heartbeat と release は current claim ID と fencing version の一致を要求する。event authorization は current claim
+proof、Run / task / actor lineage、command fingerprint を registry transaction 内で検証するたびに version と token を
+進め、claim を維持した更新 proof を返す。これにより event authorization と heartbeat / reclaim の勝者を一意にする。
+lease 失効後の reclaim で fencing version を進め、旧 owner の heartbeat、release、event authorization を
+state unchanged で拒否する。
+
+dispatch Config が有効な repository では、raw `applyEvent` による `attempt_finished` / `node_outcome_submitted` を
+Run 単位の過去 read に依存せず一律に拒否する。proof 付き commit だけを許可するため、raw guard と claim 取得の
+check-then-append race は存在しない。
+
+### gh-gantt は control plane に限定する
+
+公開 CLI は `run dispatch`、`run claim --plan-file <path>`、`run heartbeat`、`run release`、`run reclaim` と、claim
+proof 付き `run event` の schema-validated JSON contract を提供する。gh-gantt は agent/provider/shell runner、
+workspace / worktree 作成、process 起動を内蔵せず、GitHub task status を暗黙更新しない。外部 runner が claim
+receipt に対応する isolated workspace を用意し、実行と outcome 提出を担当する。
+
+completion、release、reclaim の後は GitHub Projects 由来の Work Graph Cache を読み直して dependency readiness を
+再評価する。全 upstream task が完了した downstream task だけを次の frontier に入れる。この fan-in のために
+fixed dev-role Graph Contract を fork / join DAG に変更しない。
+
+approval-gated proposal と Work Graph mutation、新しい plan version は Issue #331 の責務とする。本決定だけでは、
+bounded parallelism と approval-gated mutation の両方を要求する `NFR-STABILITY-014-AC8` を covered にしない。
+
+## Alternatives
+
+### Run Graph journal 全体を repository-shared にする
+
+一つの journal で claim と実行履歴を監査できるが、ADR-022/023 の workspace-local 正本を暗黙に変更し、
+multi-writer compare-and-append、migration、compaction の境界まで同時に広げるため採用しない。共有するのは
+短命な claim coordination に必要な registry だけとする。
+
+### Work Graph Cache の repository lease を claim に流用する
+
+既存 lock を再利用できるが、heartbeat や task 実行が pull / push / status と競合し、長時間保持または頻繁な
+lock contention を生む。異なる正本と critical section を同じ lease に束ねるため採用しない。
+
+### GitHub Issue status を claim として使う
+
+遠隔の可視性は得られるが、status update は task state と実行 ownership を混同し、offline race、workspace 排他、
+短い heartbeat、fencing token を表せない。GitHub Projects は Work Graph の正本に維持する。
+
+### 外部 runner に排他と上限管理を委ねる
+
+gh-gantt の実装は小さくなるが、runner ごとに gate、capacity、lease、stale completion の意味が分岐し、複数
+worktree の二重 dispatch を control plane で検証できないため採用しない。
+
+## Consequences
+
+- 同一 repository の linked worktree は同じ claim registry を観測し、task と workspace の二重 dispatch を防げる。
+- Work Graph Cache、claim registry、Run Graph journal は別 namespace、別 lease、別正本を維持する。
+- Run Graph event と registry receipt / local audit の間には一時的不一致が起こり得るため、immutable authorization
+  binding と event ID による reconciliation が必須になる。
+- event authorization receipt は Run Graph append 後だけ claim を維持したまま version と token を進めるため、複数
+  event と heartbeat / reclaim の勝者は registry 上で一意になり、append conflict は original proof を消費しない。
+- clock skew の影響を完全には除けないため、期限だけでなく単調な fencing version を completion まで検証する。
+- operator-visible audit は bounded view のため全履歴 export ではなく、必要な lineage を上限付きで観測する。
+- runner は isolated workspace の作成と process lifecycle を実装する必要があるが、provider 固有機能は gh-gantt に入らない。
+- fan-in は Work Graph の再評価で解決し、fixed dev-role Run Graph の topology と既存 event lineage を維持する。
+- network filesystem の分散 lock、無制限 concurrency、orphan generation compaction、#331 の Work Graph mutation は対象外とする。

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1584,6 +1584,32 @@ areas:
               stable ID と event lineage を壊さない versioned extension として追加できる
             status: uncovered
             tests: []
+          - id: NFR-STABILITY-014-AC9
+            description: |
+              ready frontier は global/state/repository 上限内で isolated workspace を claim/lease し、shared strict dispatch
+              plan schema と schema-validated current gate snapshot の source revision / canonical fingerprint を持つ。claim は
+              Work Graph read lease 内で current Work Graph/loop/sync/gate/registry/Run binding を再検証し、独立した registry
+              CAS 直前にも combined snapshot fingerprint を照合する。claim registry lock の dead owner recovery は観測した
+              owner nonce に bind した exclusive recovery claim と atomic retire を使う。completion fencing は副作用なし
+              domain validation 後、event/payload/binding/current claim lineage の repository-shared pending authorization を
+              append 前に永続化する。pending 中の heartbeat/release/別 event は fail-closed、exact retry だけが append と
+              receipt publish を再開し、claim 継続時は更新 proof を返す。heartbeat、明示 release/reclaim を current proof
+              で統制する。domain reject / append 競合は pending を解除して original proof の修正 retry を
+              許可する。append 後 crash / expired または owner_stopped reclaim は既存 binding event だけを historical
+              reconciliation/audit し継続 proof を返さない。proof なし raw completion と stale owner の新規 append は拒否する。
+              audit event ID は receipt event ID から一意に導出し durable registry receipt と照合する。不明な停止 gate は
+              全 frontier を fail-closed、operator-visible bounded Run Graph audit、fan-in 再評価、期限切れ release 拒否を持つ
+            status: covered
+            tests:
+              - packages/cli/src/__tests__/dispatch-claim-store.test.ts
+              - packages/cli/src/__tests__/regressions/issue-329-ready-frontier.test.ts
+              - packages/cli/src/__tests__/run-command.test.ts
+              - packages/cli/src/__tests__/run-graph-control-plane.test.ts
+              - packages/shared/src/__tests__/dispatch-plan.test.ts
+              - packages/shared/src/__tests__/run-graph.test.ts
+              - packages/shared/src/__tests__/schema.test.ts
+              - tests/workflow/gh-gantt-workflow-skill.test.ts
+              - tests/workflow/project-config.test.ts
       - id: NFR-STABILITY-015
         summary: Work Graph Cache のsnapshot整合性とrepository lease
         acceptance_criteria:

--- a/packages/cli/src/__tests__/dispatch-claim-store.test.ts
+++ b/packages/cli/src/__tests__/dispatch-claim-store.test.ts
@@ -1,0 +1,1197 @@
+import { execFile, fork, type ChildProcess } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { gitFixtureEnvironment } from "./git-fixture.js";
+import {
+  DispatchClaimStore,
+  createDispatchClaimStoreDependencies,
+} from "../store/dispatch-claims.js";
+
+const execFileAsync = promisify(execFile);
+const CONFIG = `${JSON.stringify(
+  {
+    version: "1",
+    project: {
+      name: "fixture",
+      github: { owner: "fixture", repo: "repository", project_number: 1 },
+    },
+    sync: { auto_create_issues: false, field_mapping: { start_date: "Start", end_date: "End" } },
+    task_types: { task: { label: "Task", display: "bar", color: "#000", github_label: null } },
+    type_hierarchy: { task: [] },
+    statuses: { field_name: "Status", values: { Todo: { color: "#000", done: false } } },
+    gantt: {
+      default_view: "month",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "#000", on_track: "#000", at_risk: "#000", overdue: "#000" },
+    },
+    dispatch: { max_concurrency: 2 },
+  },
+  null,
+  2,
+)}\n`;
+
+async function repository(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "gh-gantt-dispatch-"));
+  await execFileAsync("git", ["init", root], { env: gitFixtureEnvironment() });
+  await mkdir(join(root, ".gantt-sync"), { recursive: true });
+  await writeFile(join(root, ".gantt-sync", "gantt.config.json"), CONFIG);
+  return root;
+}
+
+async function coordinationLockPath(root: string, version = "v1"): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", root, "rev-parse", "--git-common-dir"], {
+    env: gitFixtureEnvironment(),
+  });
+  const common = await realpath(resolve(root, stdout.trim()));
+  const projectKey = createHash("sha256")
+    .update(JSON.stringify("fixture/repository#1"))
+    .digest("hex")
+    .slice(0, 32);
+  return join(common, "gh-gantt", "coordination", version, projectKey, "LOCK");
+}
+
+function waitForChildMessage<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolveMessage, rejectMessage) => {
+    const onMessage = (message: unknown) => {
+      if (message && typeof message === "object" && "type" in message && message.type === type) {
+        cleanup();
+        resolveMessage(message as T);
+      }
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      rejectMessage(new Error(`child process が ${type} 前に終了しました: ${code}`));
+    };
+    const cleanup = () => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.on("message", onMessage);
+    child.on("exit", onExit);
+  });
+}
+
+function store(root: string, now: () => string, ids: string[] = ["claim-1", "claim-2"]) {
+  let index = 0;
+  return new DispatchClaimStore(
+    root,
+    createDispatchClaimStoreDependencies({
+      now,
+      nextId: () => ids[index++] ?? `claim-${index}`,
+      readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+    }),
+  );
+}
+
+function acquire(eventId = "event-claim-1") {
+  return {
+    schemaVersion: "1" as const,
+    eventId,
+    expectedEntityVersion: 0,
+    taskId: "fixture/repository#1",
+    repository: "fixture/repository",
+    state: "Todo",
+    ownerId: "owner:1",
+    workspaceId: "workspace:1",
+    runId: "run:1",
+    leaseDurationSeconds: 60,
+    dispatchPlanId: "dispatch-plan:test",
+    dispatchPlanVersion: "1" as const,
+    snapshotFingerprint: "d".repeat(64),
+  };
+}
+
+describe("[NFR-STABILITY-014-AC9] repository coordination claim registry", () => {
+  it("coordination namespace は v1 を使用し、旧 1 namespace へ fallback しない", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+
+    await expect(claims.claim(acquire())).resolves.toMatchObject({ accepted: true });
+
+    const currentRegistry = join(dirname(await coordinationLockPath(root, "v1")), "registry.json");
+    const legacyRegistry = join(dirname(await coordinationLockPath(root, "1")), "registry.json");
+    await expect(readFile(currentRegistry, "utf8")).resolves.toContain('"schemaVersion": "1"');
+    await expect(readFile(legacyRegistry, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("claim を CAS し、同じ eventId は同じ receipt に収束する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+
+    const first = await claims.claim(acquire());
+    const replay = await new DispatchClaimStore(root).claim(acquire());
+
+    expect(first).toMatchObject({
+      accepted: true,
+      operation: "claim",
+      eventId: "event-claim-1",
+      entityVersion: 1,
+      claim: { claimId: "claim-1", fencingToken: 1, expiresAt: "2026-08-02T00:01:00.000Z" },
+    });
+    if (!first.accepted) throw new Error("claim が必要です");
+    expect(replay).toEqual(first);
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: [first.claim],
+    });
+  });
+
+  it("同じ eventId の異なる payload と stale version は state unchanged で拒否する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    await claims.claim(acquire());
+
+    await expect(claims.claim({ ...acquire(), ownerId: "owner:other" })).resolves.toMatchObject({
+      accepted: false,
+      code: "event_payload_mismatch",
+      stateUnchanged: true,
+      entityVersion: 1,
+    });
+    await expect(claims.claim(acquire("event-claim-2"))).resolves.toMatchObject({
+      accepted: false,
+      code: "stale_entity_version",
+      stateUnchanged: true,
+      entityVersion: 1,
+    });
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 1 });
+  });
+
+  it("registry CAS 直前の snapshot fingerprint 変化を拒否する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+
+    await expect(
+      claims.claim(acquire("snapshot-race"), async () => "e".repeat(64)),
+    ).resolves.toMatchObject({
+      accepted: false,
+      code: "snapshot_mismatch",
+      stateUnchanged: true,
+      entityVersion: 0,
+    });
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 0, claims: [] });
+  });
+
+  it("同一 task と workspace の二重 claim は同じ generation 内で拒否する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    const first = await claims.claim(acquire());
+    const taskDuplicate = await claims.claim({
+      ...acquire("event-task-duplicate"),
+      expectedEntityVersion: first.entityVersion,
+      ownerId: "owner:2",
+      workspaceId: "workspace:2",
+      runId: "run:2",
+    });
+    const workspaceDuplicate = await claims.claim({
+      ...acquire("event-workspace-duplicate"),
+      expectedEntityVersion: first.entityVersion,
+      taskId: "fixture/repository#2",
+      ownerId: "owner:2",
+      runId: "run:2",
+    });
+
+    expect(taskDuplicate).toMatchObject({ accepted: false, code: "task_already_claimed" });
+    expect(workspaceDuplicate).toMatchObject({
+      accepted: false,
+      code: "workspace_already_claimed",
+    });
+  });
+
+  it("claim transaction 自体が global/state/repository capacity を再検証する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    const first = await claims.claim(acquire());
+    if (!first.accepted) throw new Error(first.message);
+    const second = await claims.claim({
+      ...acquire("event-capacity-2"),
+      expectedEntityVersion: 1,
+      taskId: "fixture/repository#2",
+      workspaceId: "workspace:2",
+      runId: "run:2",
+    });
+    if (!second.accepted) throw new Error(second.message);
+
+    await expect(
+      claims.claim({
+        ...acquire("event-capacity-3"),
+        expectedEntityVersion: 2,
+        taskId: "fixture/repository#3",
+        workspaceId: "workspace:3",
+        runId: "run:3",
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "global_capacity", stateUnchanged: true });
+  });
+
+  it("heartbeat・release は current proof を要求し、reclaim 後の旧 owner を fence する", async () => {
+    let current = "2026-08-02T00:00:00.000Z";
+    const root = await repository();
+    const claims = store(root, () => current);
+    const claimed = await claims.claim(acquire());
+    if (!claimed.accepted) throw new Error("claim が必要です");
+
+    const heartbeat = await claims.heartbeat({
+      schemaVersion: "1",
+      eventId: "event-heartbeat-1",
+      expectedEntityVersion: 1,
+      proof: {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      },
+      leaseDurationSeconds: 120,
+    });
+    expect(heartbeat).toMatchObject({
+      accepted: true,
+      entityVersion: 2,
+      claim: { fencingToken: 2 },
+    });
+
+    current = "2026-08-02T00:03:00.000Z";
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "event-reclaim-1",
+      expectedEntityVersion: 2,
+      claimId: claimed.claim.claimId,
+      reason: "expired",
+    });
+    expect(reclaimed).toMatchObject({ accepted: true, entityVersion: 3 });
+    await expect(
+      claims.release({
+        schemaVersion: "1",
+        eventId: "event-release-stale",
+        expectedEntityVersion: 3,
+        proof: {
+          claimId: claimed.claim.claimId,
+          fencingToken: 1,
+          ownerId: claimed.claim.ownerId,
+          runId: claimed.claim.runId,
+        },
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+  });
+
+  it("期限切れ owner の release を拒否して reclaim 理由を保持する", async () => {
+    let current = "2026-08-02T00:00:00.000Z";
+    const root = await repository();
+    const claims = store(root, () => current);
+    const claimed = await claims.claim(acquire());
+    if (!claimed.accepted) throw new Error(claimed.message);
+    current = "2026-08-02T00:02:00.000Z";
+
+    await expect(
+      claims.release({
+        schemaVersion: "1",
+        eventId: "event-expired-release",
+        expectedEntityVersion: 1,
+        proof: {
+          claimId: claimed.claim.claimId,
+          fencingToken: claimed.claim.fencingToken,
+          ownerId: claimed.claim.ownerId,
+          runId: claimed.claim.runId,
+        },
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "lease_expired", stateUnchanged: true });
+  });
+
+  it("completion と reclaim/heartbeat は同じ registry CAS の勝者だけを受理する", async () => {
+    const race = async (competitor: "reclaim" | "heartbeat") => {
+      const root = await repository();
+      const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+      const claimed = await claims.claim(acquire(`event-race-claim-${competitor}`));
+      if (!claimed.accepted) throw new Error(claimed.message);
+      const proof = {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      };
+      const completion = claims.commitAuthorizedEvent(
+        {
+          schemaVersion: "1",
+          eventId: `event-race-complete-${competitor}`,
+          expectedEntityVersion: 1,
+          proof,
+          runId: claimed.claim.runId,
+          taskId: claimed.claim.taskId,
+          actorId: claimed.claim.ownerId,
+          commandFingerprint: "a".repeat(64),
+        },
+        async () => undefined,
+      );
+      const competing =
+        competitor === "reclaim"
+          ? claims.reclaim({
+              schemaVersion: "1",
+              eventId: "event-race-reclaim",
+              expectedEntityVersion: 1,
+              claimId: claimed.claim.claimId,
+              reason: "owner_stopped" as const,
+              ownerStoppedEvidenceId: "process-exit:owner-1",
+            })
+          : claims.heartbeat({
+              schemaVersion: "1",
+              eventId: "event-race-heartbeat",
+              expectedEntityVersion: 1,
+              proof,
+              leaseDurationSeconds: 120,
+            });
+      return Promise.all([completion, competing]);
+    };
+
+    for (const competitor of ["reclaim", "heartbeat"] as const) {
+      const results = await race(competitor);
+      expect(results.filter((result) => result.accepted)).toHaveLength(1);
+      expect(results.filter((result) => !result.accepted)).toMatchObject([
+        { code: "stale_entity_version", stateUnchanged: true },
+      ]);
+    }
+  });
+
+  it("event authorization は claim を維持して fencing proof を更新する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    const claimed = await claims.claim(acquire());
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const authorized = await claims.commitAuthorizedEvent(
+      {
+        schemaVersion: "1",
+        eventId: "event-authorized-1",
+        expectedEntityVersion: claimed.entityVersion,
+        proof: {
+          claimId: claimed.claim.claimId,
+          fencingToken: claimed.claim.fencingToken,
+          ownerId: claimed.claim.ownerId,
+          runId: claimed.claim.runId,
+        },
+        runId: claimed.claim.runId,
+        taskId: claimed.claim.taskId,
+        actorId: claimed.claim.ownerId,
+        commandFingerprint: "c".repeat(64),
+      },
+      async () => undefined,
+    );
+
+    expect(authorized).toMatchObject({
+      accepted: true,
+      operation: "authorize_event",
+      entityVersion: 2,
+      claim: {
+        claimId: claimed.claim.claimId,
+        entityVersion: 2,
+        fencingToken: 2,
+      },
+    });
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 2,
+      claims: [{ claimId: claimed.claim.claimId, entityVersion: 2, fencingToken: 2 }],
+    });
+  });
+
+  it("pending authorization を owner_stopped reclaim で terminalize し新規 append を拒否する", async () => {
+    const root = await repository();
+    let interrupt = true;
+    const claims = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-pending-owner-stopped",
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        afterAuthorizationPendingPublish: async () => {
+          if (interrupt) throw new Error("pending persisted");
+        },
+      }),
+    );
+    const claimed = await claims.claim(acquire("pending-owner-stopped-claim"));
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const authorization = {
+      schemaVersion: "1" as const,
+      eventId: "pending-owner-stopped-event",
+      expectedEntityVersion: 1,
+      proof: {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      },
+      runId: claimed.claim.runId,
+      taskId: claimed.claim.taskId,
+      actorId: claimed.claim.ownerId,
+      commandFingerprint: "f".repeat(64),
+    };
+    await expect(
+      claims.commitAuthorizedEvent(authorization, async () => undefined),
+    ).rejects.toThrow("pending persisted");
+    interrupt = false;
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      pendingAuthorizations: [{ eventId: authorization.eventId, claimId: claimed.claim.claimId }],
+    });
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "pending-owner-stopped-reclaim",
+      expectedEntityVersion: 1,
+      claimId: claimed.claim.claimId,
+      reason: "owner_stopped",
+      ownerStoppedEvidenceId: "process-exit:pending-owner",
+    });
+    expect(reclaimed).toMatchObject({ accepted: true, entityVersion: 2 });
+    await expect(
+      claims.commitAuthorizedEvent(authorization, async () => undefined),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+  });
+
+  it("abort は exact pending だけを解除し、receipt 確定済みと reclaim 済み marker を変更しない", async () => {
+    const root = await repository();
+    let interrupt = true;
+    const claims = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-abort-pending",
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        afterAuthorizationPendingPublish: async () => {
+          if (interrupt) throw new Error("pending abort fixture");
+        },
+      }),
+    );
+    const claimed = await claims.claim(acquire("abort-pending-claim"));
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const authorization = {
+      schemaVersion: "1" as const,
+      eventId: "abort-pending-authorization",
+      expectedEntityVersion: claimed.entityVersion,
+      proof: {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      },
+      runId: claimed.claim.runId,
+      taskId: claimed.claim.taskId,
+      actorId: claimed.claim.ownerId,
+      commandFingerprint: "7".repeat(64),
+    };
+    await expect(
+      claims.commitAuthorizedEvent(authorization, async () => undefined),
+    ).rejects.toThrow("pending abort fixture");
+    const pending = await claims.snapshot();
+
+    await expect(
+      claims.abortPendingAuthorization(
+        { ...authorization, eventId: "abort-other-event" },
+        async () => "absent",
+      ),
+    ).resolves.toEqual({ status: "absent" });
+    await expect(
+      claims.abortPendingAuthorization(
+        { ...authorization, commandFingerprint: "8".repeat(64) },
+        async () => "absent",
+      ),
+    ).resolves.toEqual({ status: "conflict" });
+    await expect(
+      claims.abortPendingAuthorization(
+        {
+          ...authorization,
+          proof: { ...authorization.proof, fencingToken: authorization.proof.fencingToken + 1 },
+        },
+        async () => "absent",
+      ),
+    ).resolves.toEqual({ status: "conflict" });
+    await expect(claims.snapshot()).resolves.toEqual(pending);
+
+    await expect(
+      claims.abortPendingAuthorization(authorization, async () => "absent"),
+    ).resolves.toEqual({ status: "aborted" });
+    await expect(claims.snapshot()).resolves.toMatchObject({ pendingAuthorizations: [] });
+    interrupt = false;
+    const finalized = await claims.commitAuthorizedEvent(authorization, async () => undefined);
+    if (!finalized.accepted) throw new Error(finalized.message);
+    await expect(
+      claims.abortPendingAuthorization(authorization, async () => "absent"),
+    ).resolves.toEqual({ status: "conflict" });
+    await expect(claims.verifyReceipt(finalized)).resolves.toBe(true);
+
+    const reclaimedAuthorization = {
+      ...authorization,
+      eventId: "abort-reclaimed-authorization",
+      expectedEntityVersion: finalized.entityVersion,
+      proof: {
+        claimId: finalized.claim.claimId,
+        fencingToken: finalized.claim.fencingToken,
+        ownerId: finalized.claim.ownerId,
+        runId: finalized.claim.runId,
+      },
+      commandFingerprint: "9".repeat(64),
+    };
+    interrupt = true;
+    await expect(
+      claims.commitAuthorizedEvent(reclaimedAuthorization, async () => undefined),
+    ).rejects.toThrow("pending abort fixture");
+    interrupt = false;
+    await expect(
+      claims.reclaim({
+        schemaVersion: "1",
+        eventId: "abort-pending-reclaim",
+        expectedEntityVersion: finalized.entityVersion,
+        claimId: finalized.claim.claimId,
+        reason: "owner_stopped",
+        ownerStoppedEvidenceId: "process-exit:abort-pending",
+      }),
+    ).resolves.toMatchObject({ accepted: true });
+    await expect(
+      claims.abortPendingAuthorization(reclaimedAuthorization, async () => "absent"),
+    ).resolves.toEqual({ status: "absent" });
+    await expect(
+      claims.commitAuthorizedEvent(reclaimedAuthorization, async () => undefined),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim" });
+  });
+
+  it("pending 中も heartbeat/release の stored receipt exact replay を優先する", async () => {
+    const root = await repository();
+    let interrupt = true;
+    const claims = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-pending-replay",
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        afterAuthorizationPendingPublish: async () => {
+          if (interrupt) throw new Error("pending replay fixture");
+        },
+      }),
+    );
+    const claimed = await claims.claim(acquire("pending-replay-claim"));
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const heartbeatInput = {
+      schemaVersion: "1" as const,
+      eventId: "pending-replay-heartbeat",
+      expectedEntityVersion: 1,
+      proof: {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      },
+      leaseDurationSeconds: 120,
+    };
+    const heartbeat = await claims.heartbeat(heartbeatInput);
+    if (!heartbeat.accepted) throw new Error(heartbeat.message);
+    const rejectedReleaseInput = {
+      schemaVersion: "1" as const,
+      eventId: "pending-replay-rejected-release",
+      expectedEntityVersion: 2,
+      proof: heartbeatInput.proof,
+    };
+    const rejectedRelease = await claims.release(rejectedReleaseInput);
+    expect(rejectedRelease).toMatchObject({ accepted: false, code: "stale_claim" });
+
+    const authorization = {
+      schemaVersion: "1" as const,
+      eventId: "pending-replay-authorization",
+      expectedEntityVersion: 2,
+      proof: {
+        claimId: heartbeat.claim.claimId,
+        fencingToken: heartbeat.claim.fencingToken,
+        ownerId: heartbeat.claim.ownerId,
+        runId: heartbeat.claim.runId,
+      },
+      runId: heartbeat.claim.runId,
+      taskId: heartbeat.claim.taskId,
+      actorId: heartbeat.claim.ownerId,
+      commandFingerprint: "9".repeat(64),
+    };
+    await expect(
+      claims.commitAuthorizedEvent(authorization, async () => undefined),
+    ).rejects.toThrow("pending replay fixture");
+    interrupt = false;
+    const beforeReplay = await claims.snapshot();
+    expect(beforeReplay).toMatchObject({
+      entityVersion: 2,
+      pendingAuthorizations: [{ eventId: authorization.eventId, claimId: heartbeat.claim.claimId }],
+    });
+
+    await expect(claims.heartbeat(heartbeatInput)).resolves.toEqual(heartbeat);
+    await expect(claims.release(rejectedReleaseInput)).resolves.toEqual(rejectedRelease);
+    await expect(claims.snapshot()).resolves.toEqual(beforeReplay);
+    const pendingHeartbeatInput = {
+      ...heartbeatInput,
+      eventId: "pending-replay-new-heartbeat",
+      expectedEntityVersion: 2,
+      proof: authorization.proof,
+    };
+    const pendingHeartbeat = await claims.heartbeat(pendingHeartbeatInput);
+    expect(pendingHeartbeat).toMatchObject({ accepted: false, code: "authorization_pending" });
+    await expect(claims.snapshot()).resolves.toEqual(beforeReplay);
+
+    const finalized = await claims.commitAuthorizedEvent(authorization, async () => undefined);
+    if (!finalized.accepted) throw new Error(finalized.message);
+    await expect(claims.heartbeat(pendingHeartbeatInput)).resolves.toEqual(pendingHeartbeat);
+    await expect(
+      claims.heartbeat({
+        ...pendingHeartbeatInput,
+        eventId: "pending-replay-corrected-heartbeat",
+        expectedEntityVersion: finalized.entityVersion,
+        proof: {
+          claimId: finalized.claim.claimId,
+          fencingToken: finalized.claim.fencingToken,
+          ownerId: finalized.claim.ownerId,
+          runId: finalized.claim.runId,
+        },
+      }),
+    ).resolves.toMatchObject({ accepted: true, entityVersion: finalized.entityVersion + 1 });
+  });
+
+  it("pending 中の新規 release 拒否は rollback 後も exact replay し claim を変更しない", async () => {
+    const root = await repository();
+    const claims = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-pending-rollback",
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        afterAuthorizationPendingPublish: async () => {
+          throw new Error("pending rollback fixture");
+        },
+      }),
+    );
+    const claimed = await claims.claim(acquire("pending-rollback-claim"));
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId: claimed.claim.runId,
+    };
+    const authorization = {
+      schemaVersion: "1" as const,
+      eventId: "pending-rollback-authorization",
+      expectedEntityVersion: claimed.entityVersion,
+      proof,
+      runId: claimed.claim.runId,
+      taskId: claimed.claim.taskId,
+      actorId: claimed.claim.ownerId,
+      commandFingerprint: "6".repeat(64),
+    };
+    await expect(
+      claims.commitAuthorizedEvent(authorization, async () => undefined),
+    ).rejects.toThrow("pending rollback fixture");
+    const beforeRejection = await claims.snapshot();
+    const releaseInput = {
+      schemaVersion: "1" as const,
+      eventId: "pending-rollback-release",
+      expectedEntityVersion: claimed.entityVersion,
+      proof,
+    };
+
+    const rejection = await claims.release(releaseInput);
+    expect(rejection).toMatchObject({ accepted: false, code: "authorization_pending" });
+    await expect(claims.snapshot()).resolves.toEqual(beforeRejection);
+    await expect(
+      claims.abortPendingAuthorization(authorization, async () => "absent"),
+    ).resolves.toEqual({ status: "aborted" });
+    await expect(claims.release(releaseInput)).resolves.toEqual(rejection);
+    await expect(
+      claims.heartbeat({
+        schemaVersion: "1",
+        eventId: "pending-rollback-corrected-heartbeat",
+        expectedEntityVersion: claimed.entityVersion,
+        proof,
+        leaseDurationSeconds: 120,
+      }),
+    ).resolves.toMatchObject({ accepted: true, entityVersion: claimed.entityVersion + 1 });
+  });
+
+  it("completion authorization を claim の run/task/actor lineage に binding する", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    const claimed = await claims.claim(acquire());
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const base = {
+      schemaVersion: "1" as const,
+      expectedEntityVersion: 1,
+      proof: {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId: claimed.claim.runId,
+      },
+      runId: claimed.claim.runId,
+      taskId: claimed.claim.taskId,
+      actorId: claimed.claim.ownerId,
+      commandFingerprint: "b".repeat(64),
+    };
+
+    await expect(
+      claims.commitAuthorizedEvent(
+        { ...base, eventId: "complete-wrong-run", runId: "run:other" },
+        async () => undefined,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+    await expect(
+      claims.commitAuthorizedEvent(
+        { ...base, eventId: "complete-wrong-task", taskId: "fixture/repository#2" },
+        async () => undefined,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+    await expect(
+      claims.commitAuthorizedEvent(
+        { ...base, eventId: "complete-wrong-actor", actorId: "owner:other" },
+        async () => undefined,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 1, claims: [{}] });
+  });
+
+  it("期限前 reclaim を拒否し、停止 owner は明示理由で回収できる", async () => {
+    const root = await repository();
+    const claims = store(root, () => "2026-08-02T00:00:00.000Z");
+    const claimed = await claims.claim(acquire());
+    if (!claimed.accepted) throw new Error("claim が必要です");
+    await expect(
+      claims.reclaim({
+        schemaVersion: "1",
+        eventId: "event-reclaim-early",
+        expectedEntityVersion: 1,
+        claimId: claimed.claim.claimId,
+        reason: "expired",
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "lease_not_expired" });
+    await expect(
+      claims.reclaim({
+        schemaVersion: "1",
+        eventId: "event-reclaim-stopped-without-evidence",
+        expectedEntityVersion: 1,
+        claimId: claimed.claim.claimId,
+        reason: "owner_stopped",
+      }),
+    ).rejects.toThrow(/evidence/i);
+    await expect(
+      claims.reclaim({
+        schemaVersion: "1",
+        eventId: "event-reclaim-stopped",
+        expectedEntityVersion: 1,
+        claimId: claimed.claim.claimId,
+        reason: "owner_stopped",
+        ownerStoppedEvidenceId: "process-exit:owner-1",
+      }),
+    ).resolves.toMatchObject({
+      accepted: true,
+      entityVersion: 2,
+      reclaimReason: "owner_stopped",
+      evidenceId: "process-exit:owner-1",
+    });
+  });
+
+  it("競合する別 instance の CAS は一方だけを受理する", async () => {
+    const root = await repository();
+    const first = store(root, () => "2026-08-02T00:00:00.000Z", ["claim-a"]);
+    const second = store(root, () => "2026-08-02T00:00:00.000Z", ["claim-b"]);
+    const results = await Promise.all([
+      first.claim(acquire("event-a")),
+      second.claim({
+        ...acquire("event-b"),
+        taskId: "fixture/repository#2",
+        workspaceId: "workspace:2",
+      }),
+    ]);
+
+    expect(results.filter((result) => result.accepted)).toHaveLength(1);
+    expect(results.filter((result) => !result.accepted)).toMatchObject([
+      { code: "stale_entity_version" },
+    ]);
+  });
+
+  it("dead owner を同時観測しても nonce-bound recovery claim の勝者だけが lock を retire する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+
+    let observed = 0;
+    let releaseBarrier!: () => void;
+    const barrier = new Promise<void>((resolveBarrier) => {
+      releaseBarrier = resolveBarrier;
+    });
+    const afterDeadOwnerObserved = async (ownerNonce: string) => {
+      expect(ownerNonce).toBe(deadNonce);
+      observed += 1;
+      if (observed === 2) releaseBarrier();
+      await barrier;
+    };
+    const contender = (claimId: string) =>
+      new DispatchClaimStore(
+        root,
+        createDispatchClaimStoreDependencies({
+          now: () => "2026-08-02T00:00:00.000Z",
+          nextId: () => claimId,
+          waitTimeoutMs: 2_000,
+          isProcessAlive: (pid) => pid !== deadPid,
+          afterDeadOwnerObserved,
+          readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        }),
+      );
+    const results = await Promise.all([
+      contender("claim-recovery-a").claim(acquire("recovery-a")),
+      contender("claim-recovery-b").claim({
+        ...acquire("recovery-b"),
+        taskId: "fixture/repository#2",
+        workspaceId: "workspace:2",
+      }),
+    ]);
+
+    expect(observed).toBe(2);
+    expect(results.filter((result) => result.accepted)).toHaveLength(1);
+    expect(results.filter((result) => !result.accepted)).toMatchObject([
+      { code: "stale_entity_version", stateUnchanged: true },
+    ]);
+    await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: [{}],
+    });
+  });
+
+  it("O1 用 recovery marker が残って O2 が crash しても O3 が復旧して single CAS に収束する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+
+    let resumeOld!: () => void;
+    let oldWasResumed = false;
+    const oldResumeBarrier = new Promise<void>((resolveBarrier) => {
+      resumeOld = () => {
+        oldWasResumed = true;
+        resolveBarrier();
+      };
+    });
+    let oldObserved!: () => void;
+    const oldObservedBarrier = new Promise<void>((resolveObserved) => {
+      oldObserved = resolveObserved;
+    });
+    let liveOwnerObserved!: (pid: number) => void;
+    const liveOwnerObservedBarrier = new Promise<number>((resolveObserved) => {
+      liveOwnerObserved = resolveObserved;
+    });
+    const oldContender = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-old-contender",
+        waitTimeoutMs: 5_000,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        isProcessAlive: (pid) => {
+          if (pid === deadPid) return false;
+          liveOwnerObserved(pid);
+          return true;
+        },
+        afterDeadOwnerObserved: async (ownerNonce) => {
+          expect(ownerNonce).toBe(deadNonce);
+          oldObserved();
+          await oldResumeBarrier;
+        },
+      }),
+    );
+    let oldSettled = false;
+    const oldResultPromise = oldContender
+      .claim({
+        ...acquire("old-recovery-race"),
+        expectedEntityVersion: 99,
+        taskId: "fixture/repository#2",
+        workspaceId: "workspace:old-contender",
+      })
+      .finally(() => {
+        oldSettled = true;
+      });
+    await oldObservedBarrier;
+
+    const workerPath = join(root, "lock-recovery-worker.ts");
+    await writeFile(
+      workerPath,
+      `void (async () => {
+const [moduleUrl, projectRoot, rawInput] = process.argv.slice(2);
+const { DispatchClaimStore, createDispatchClaimStoreDependencies } = await import(moduleUrl);
+const store = new DispatchClaimStore(projectRoot, createDispatchClaimStoreDependencies({
+  now: () => "2026-08-02T00:00:00.000Z",
+  nextId: () => "claim-child-process",
+  readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+  beforeRegistryPublish: async () => {
+    process.send?.({ type: "lock_acquired" });
+    await new Promise((resolveRelease) => process.once("message", resolveRelease));
+  },
+}));
+const result = await store.claim(JSON.parse(rawInput));
+process.send?.({ type: "result", result });
+process.disconnect?.();
+})().catch((error) => {
+  process.send?.({ type: "error", message: error instanceof Error ? error.message : String(error) });
+  process.exitCode = 1;
+});
+`,
+    );
+    const moduleUrl = pathToFileURL(
+      resolve(import.meta.dirname, "../store/dispatch-claims.ts"),
+    ).href;
+    const childInput = acquire("child-recovery-race");
+    const child = fork(workerPath, [moduleUrl, root, JSON.stringify(childInput)], {
+      execArgv: ["--import", "tsx"],
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    });
+    const childExit = new Promise<number | null>((resolveExit) => child.once("exit", resolveExit));
+    try {
+      await waitForChildMessage(child, "lock_acquired");
+      const liveOwner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as {
+        pid: number;
+        nonce: string;
+      };
+      expect(liveOwner).toMatchObject({ pid: child.pid });
+      expect(liveOwner.nonce).not.toBe(deadNonce);
+
+      resumeOld();
+      await expect(liveOwnerObservedBarrier).resolves.toBe(child.pid);
+
+      const ownerAfterOldRecovery = JSON.parse(
+        await readFile(join(lockPath, "owner.json"), "utf8"),
+      ) as { pid: number; nonce: string };
+      expect(ownerAfterOldRecovery).toEqual(liveOwner);
+      await expect(
+        readFile(join(lockPath, `recovery-claim-${deadNonce}.json`), "utf8"),
+      ).resolves.toContain(deadNonce);
+      await new Promise<void>((resolveImmediate) => setImmediate(resolveImmediate));
+      expect(oldSettled).toBe(false);
+
+      child.kill();
+      await childExit;
+      const recovered = new DispatchClaimStore(
+        root,
+        createDispatchClaimStoreDependencies({
+          now: () => "2026-08-02T00:00:00.000Z",
+          nextId: () => "claim-recovery-after-child-crash",
+          waitTimeoutMs: 2_000,
+          readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        }),
+      );
+      await expect(recovered.claim(childInput)).resolves.toMatchObject({
+        accepted: true,
+        entityVersion: 1,
+      });
+
+      await expect(oldResultPromise).resolves.toMatchObject({
+        accepted: false,
+        code: "stale_entity_version",
+        stateUnchanged: true,
+      });
+      await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+        entityVersion: 1,
+        claims: [{ claimId: "claim-recovery-after-child-crash" }],
+      });
+    } finally {
+      if (!oldWasResumed) resumeOld();
+      if (child.connected) child.send("release");
+      if (child.exitCode === null) child.kill();
+      await oldResultPromise.catch(() => undefined);
+    }
+  }, 10_000);
+
+  it("recovery claimant が candidate 書込後・publish 前に crash しても後続 process が復旧する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+
+    const workerPath = join(root, "recovery-claimant-crash-worker.ts");
+    await writeFile(
+      workerPath,
+      `void (async () => {
+const [moduleUrl, projectRoot, rawInput] = process.argv.slice(2);
+const { DispatchClaimStore, createDispatchClaimStoreDependencies } = await import(moduleUrl);
+const store = new DispatchClaimStore(projectRoot, createDispatchClaimStoreDependencies({
+  now: () => "2026-08-02T00:00:00.000Z",
+  nextId: () => "claim-crashed-recovery",
+  readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+  afterRecoveryClaimCandidateWritten: async (expectedOwnerNonce, claimantNonce) => {
+    process.send?.({ type: "recovery_candidate_written", expectedOwnerNonce, claimantNonce });
+    await new Promise(() => undefined);
+  },
+}));
+await store.claim(JSON.parse(rawInput));
+})().catch((error) => {
+  process.send?.({ type: "error", message: error instanceof Error ? error.message : String(error) });
+  process.exitCode = 1;
+});
+`,
+    );
+    const moduleUrl = pathToFileURL(
+      resolve(import.meta.dirname, "../store/dispatch-claims.ts"),
+    ).href;
+    const child = fork(workerPath, [moduleUrl, root, JSON.stringify(acquire("crashed-recovery"))], {
+      execArgv: ["--import", "tsx"],
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    });
+    const childExit = new Promise<number | null>((resolveExit) => child.once("exit", resolveExit));
+    try {
+      const created = await waitForChildMessage<{
+        type: "recovery_candidate_written";
+        expectedOwnerNonce: string;
+        claimantNonce: string;
+      }>(child, "recovery_candidate_written");
+      expect(created.expectedOwnerNonce).toBe(deadNonce);
+      const markerPath = join(lockPath, `recovery-claim-${deadNonce}.json`);
+      const candidatePath = `${markerPath}.candidate-${created.claimantNonce}`;
+      await expect(readFile(candidatePath, "utf8")).resolves.toContain(created.claimantNonce);
+      await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+      child.kill();
+      await childExit;
+      const recovered = new DispatchClaimStore(
+        root,
+        createDispatchClaimStoreDependencies({
+          now: () => "2026-08-02T00:00:00.000Z",
+          nextId: () => "claim-after-recovery-crash",
+          waitTimeoutMs: 2_000,
+          readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        }),
+      );
+      await expect(recovered.claim(acquire("after-recovery-crash"))).resolves.toMatchObject({
+        accepted: true,
+        entityVersion: 1,
+      });
+      await expect(recovered.snapshot()).resolves.toMatchObject({
+        entityVersion: 1,
+        claims: [{ claimId: "claim-after-recovery-crash" }],
+      });
+    } finally {
+      if (child.exitCode === null) child.kill();
+    }
+  }, 10_000);
+
+  it("dead owner 配下の malformed final marker は owner再検証後に安全に retire する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    await writeFile(join(lockPath, `recovery-claim-${deadNonce}.json`), '{"schemaVersion":');
+
+    const recovered = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-after-malformed-marker",
+        waitTimeoutMs: 2_000,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+      }),
+    );
+    await expect(recovered.claim(acquire("after-malformed-marker"))).resolves.toMatchObject({
+      accepted: true,
+      entityVersion: 1,
+      claim: { claimId: "claim-after-malformed-marker" },
+    });
+  });
+
+  it("dead owner 配下の zero-byte final marker も malformed として安全に retire する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    await writeFile(join(lockPath, `recovery-claim-${deadNonce}.json`), "");
+
+    const recovered = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-after-zero-byte-marker",
+        waitTimeoutMs: 500,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+      }),
+    );
+    await expect(recovered.claim(acquire("after-zero-byte-marker"))).resolves.toMatchObject({
+      accepted: true,
+      entityVersion: 1,
+      claim: { claimId: "claim-after-zero-byte-marker" },
+    });
+  });
+
+  it("atomic publish 前の crash は registry state を変更せず lock を解放する", async () => {
+    const root = await repository();
+    const interrupted = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-crash",
+        beforeRegistryPublish: async () => {
+          throw new Error("simulated crash");
+        },
+      }),
+    );
+
+    await expect(interrupted.claim(acquire("event-crash"))).rejects.toThrow("simulated crash");
+    await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+      entityVersion: 0,
+      claims: [],
+      history: [],
+    });
+    await expect(
+      store(root, () => "2026-08-02T00:00:00.000Z").claim(acquire("event-after-crash")),
+    ).resolves.toMatchObject({ accepted: true, entityVersion: 1 });
+  });
+});

--- a/packages/cli/src/__tests__/dispatch-claim-store.test.ts
+++ b/packages/cli/src/__tests__/dispatch-claim-store.test.ts
@@ -55,6 +55,25 @@ async function coordinationLockPath(root: string, version = "v1"): Promise<strin
   return join(common, "gh-gantt", "coordination", version, projectKey, "LOCK");
 }
 
+function recoveryPathKey(value: string): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function recoveryClaimMarkerPath(lockPath: string, ownerNonce: string): string {
+  return join(lockPath, `recovery-claim-${recoveryPathKey(ownerNonce)}.json`);
+}
+
+function recoverySuccessorMarkerPath(
+  lockPath: string,
+  ownerNonce: string,
+  predecessorNonce: string,
+): string {
+  return join(
+    lockPath,
+    `recovery-successor-${recoveryPathKey(ownerNonce)}-${recoveryPathKey(predecessorNonce)}.json`,
+  );
+}
+
 function waitForChildMessage<T>(child: ChildProcess, type: string): Promise<T> {
   return new Promise((resolveMessage, rejectMessage) => {
     const onMessage = (message: unknown) => {
@@ -104,6 +123,18 @@ function acquire(eventId = "event-claim-1") {
     dispatchPlanVersion: "1" as const,
     snapshotFingerprint: "d".repeat(64),
   };
+}
+
+function reverseObjectKeyOrder(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reverseObjectKeyOrder);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .reverse()
+        .map(([key, item]) => [key, reverseObjectKeyOrder(item)]),
+    );
+  }
+  return value;
 }
 
 describe("[NFR-STABILITY-014-AC9] repository coordination claim registry", () => {
@@ -387,10 +418,16 @@ describe("[NFR-STABILITY-014-AC9] repository coordination claim registry", () =>
         fencingToken: 2,
       },
     });
+    if (!authorized.accepted || authorized.operation !== "authorize_event") {
+      throw new Error("authorize_event receipt が必要です");
+    }
     await expect(claims.snapshot()).resolves.toMatchObject({
       entityVersion: 2,
       claims: [{ claimId: claimed.claim.claimId, entityVersion: 2, fencingToken: 2 }],
     });
+    const reordered = reverseObjectKeyOrder(authorized) as typeof authorized;
+    await expect(claims.verifyReceipt(reordered)).resolves.toBe(true);
+    await expect(claims.isReceiptClaimCurrent(reordered)).resolves.toBe(true);
   });
 
   it("pending authorization を owner_stopped reclaim で terminalize し新規 append を拒否する", async () => {
@@ -867,6 +904,84 @@ describe("[NFR-STABILITY-014-AC9] repository coordination claim registry", () =>
     });
   });
 
+  it("最終検証後に停止した live recovery claimant を年齢だけで takeover して successor LOCK を消去しない", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+
+    let resumeFirst!: () => void;
+    const firstResumeBarrier = new Promise<void>((resolveResume) => {
+      resumeFirst = resolveResume;
+    });
+    let firstValidated!: () => void;
+    const firstValidatedBarrier = new Promise<void>((resolveValidated) => {
+      firstValidated = resolveValidated;
+    });
+    const first = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:00:00.000Z",
+        nextId: () => "claim-paused-recovery",
+        waitTimeoutMs: 2_000,
+        isProcessAlive: (pid) => pid !== deadPid,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        afterRecoveryClaimValidated: async (expectedOwnerNonce) => {
+          expect(expectedOwnerNonce).toBe(deadNonce);
+          firstValidated();
+          await firstResumeBarrier;
+        },
+      }),
+    );
+    const firstResult = first.claim({
+      ...acquire("paused-recovery"),
+      expectedEntityVersion: 99,
+      taskId: "fixture/repository#2",
+      workspaceId: "workspace:paused-recovery",
+    });
+    await firstValidatedBarrier;
+
+    let successorReachedRegistry = false;
+    const successor = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => "2026-08-02T00:01:01.000Z",
+        nextId: () => "claim-successor-recovery",
+        waitTimeoutMs: 300,
+        isProcessAlive: (pid) => pid !== deadPid,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        beforeRegistryPublish: async () => {
+          successorReachedRegistry = true;
+        },
+      }),
+    );
+    const successorResult = successor.claim(acquire("successor-recovery"));
+
+    try {
+      await expect(successorResult).rejects.toThrow("dispatch claim registry は使用中です");
+      expect(successorReachedRegistry).toBe(false);
+      resumeFirst();
+      await expect(firstResult).resolves.toMatchObject({
+        accepted: false,
+        code: "stale_entity_version",
+      });
+    } finally {
+      resumeFirst();
+      await Promise.allSettled([firstResult, successorResult]);
+    }
+  }, 10_000);
+
   it("O1 用 recovery marker が残って O2 が crash しても O3 が復旧して single CAS に収束する", async () => {
     const root = await repository();
     const lockPath = await coordinationLockPath(root);
@@ -982,7 +1097,7 @@ process.disconnect?.();
       ) as { pid: number; nonce: string };
       expect(ownerAfterOldRecovery).toEqual(liveOwner);
       await expect(
-        readFile(join(lockPath, `recovery-claim-${deadNonce}.json`), "utf8"),
+        readFile(recoveryClaimMarkerPath(lockPath, deadNonce), "utf8"),
       ).resolves.toContain(deadNonce);
       await new Promise<void>((resolveImmediate) => setImmediate(resolveImmediate));
       expect(oldSettled).toBe(false);
@@ -1074,8 +1189,10 @@ await store.claim(JSON.parse(rawInput));
         claimantNonce: string;
       }>(child, "recovery_candidate_written");
       expect(created.expectedOwnerNonce).toBe(deadNonce);
-      const markerPath = join(lockPath, `recovery-claim-${deadNonce}.json`);
-      const candidatePath = `${markerPath}.candidate-${created.claimantNonce}`;
+      const markerPath = recoveryClaimMarkerPath(lockPath, deadNonce);
+      const candidatePath = `${markerPath}.candidate-${recoveryPathKey(created.claimantNonce)}`;
+      expect(markerPath).not.toContain(deadNonce);
+      expect(candidatePath).not.toContain(created.claimantNonce);
       await expect(readFile(candidatePath, "utf8")).resolves.toContain(created.claimantNonce);
       await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 
@@ -1119,7 +1236,7 @@ await store.claim(JSON.parse(rawInput));
         startedAt: "2026-08-02T00:00:00.000Z",
       })}\n`,
     );
-    await writeFile(join(lockPath, `recovery-claim-${deadNonce}.json`), '{"schemaVersion":');
+    await writeFile(recoveryClaimMarkerPath(lockPath, deadNonce), '{"schemaVersion":');
 
     const recovered = new DispatchClaimStore(
       root,
@@ -1134,6 +1251,221 @@ await store.claim(JSON.parse(rawInput));
       accepted: true,
       entityVersion: 1,
       claim: { claimId: "claim-after-malformed-marker" },
+    });
+  });
+
+  it("foreign host の recovery claimant は生死を推測せず fail-closed にする", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    const foreignRecoveryNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    await writeFile(
+      recoveryClaimMarkerPath(lockPath, deadNonce),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        expectedOwnerNonce: deadNonce,
+        claimant: {
+          pid: deadPid - 1,
+          hostname: "foreign.example.invalid",
+          nonce: foreignRecoveryNonce,
+          claimedAt: "2026-08-02T00:00:00.000Z",
+        },
+      })}\n`,
+    );
+
+    const contender = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        waitTimeoutMs: 30,
+        isProcessAlive: (pid) => pid !== deadPid,
+      }),
+    );
+    await expect(contender.claim(acquire("foreign-recovery"))).rejects.toThrow(
+      "dispatch claim registry は使用中です",
+    );
+    await expect(readFile(join(lockPath, "owner.json"), "utf8")).resolves.toContain(deadNonce);
+  });
+
+  it("recovery generation chain は最大 hop を超えたら fail-closed にする", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadOwnerPid = 2_147_483_647;
+    const deadNonce = randomUUID();
+    const generationNonces = Array.from({ length: 65 }, () => randomUUID());
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadOwnerPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    const marker = (index: number) => ({
+      schemaVersion: "1",
+      expectedOwnerNonce: deadNonce,
+      claimant: {
+        pid: deadOwnerPid - index - 1,
+        hostname: hostname(),
+        nonce: generationNonces[index]!,
+        claimedAt: "2026-08-02T00:00:00.000Z",
+      },
+    });
+    await writeFile(recoveryClaimMarkerPath(lockPath, deadNonce), `${JSON.stringify(marker(0))}\n`);
+    for (let index = 0; index < 64; index += 1) {
+      const successorPath = recoverySuccessorMarkerPath(
+        lockPath,
+        deadNonce,
+        generationNonces[index]!,
+      );
+      expect(successorPath).not.toContain(deadNonce);
+      expect(successorPath).not.toContain(generationNonces[index]!);
+      await writeFile(successorPath, `${JSON.stringify(marker(index + 1))}\n`);
+    }
+
+    const contender = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        waitTimeoutMs: 30,
+        isProcessAlive: () => false,
+      }),
+    );
+    await expect(contender.claim(acquire("overlong-recovery-chain"))).rejects.toThrow(
+      "dispatch claim registry は使用中です",
+    );
+    await expect(readFile(join(lockPath, "owner.json"), "utf8")).resolves.toContain(deadNonce);
+  });
+
+  it("dead recovery claimant への複数 successor は一つだけが CAS を確定する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadOwnerPid = 2_147_483_647;
+    const deadRecoveryPid = deadOwnerPid - 1;
+    const deadNonce = randomUUID();
+    const deadRecoveryNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadOwnerPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    await writeFile(
+      recoveryClaimMarkerPath(lockPath, deadNonce),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        expectedOwnerNonce: deadNonce,
+        claimant: {
+          pid: deadRecoveryPid,
+          hostname: hostname(),
+          nonce: deadRecoveryNonce,
+          claimedAt: "2026-08-02T00:00:00.000Z",
+        },
+      })}\n`,
+    );
+    const contender = (pid: number, claimId: string) =>
+      new DispatchClaimStore(
+        root,
+        createDispatchClaimStoreDependencies({
+          processIdentity: { pid, hostname: hostname() },
+          isProcessAlive: (observedPid) =>
+            observedPid !== deadOwnerPid && observedPid !== deadRecoveryPid,
+          nextId: () => claimId,
+          waitTimeoutMs: 2_000,
+          readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        }),
+      );
+
+    const results = await Promise.all([
+      contender(41_001, "claim-successor-a").claim(acquire("successor-a")),
+      contender(41_002, "claim-successor-b").claim({
+        ...acquire("successor-b"),
+        taskId: "fixture/repository#2",
+        workspaceId: "workspace:2",
+      }),
+    ]);
+
+    expect(results.filter((result) => result.accepted)).toHaveLength(1);
+    expect(results.filter((result) => !result.accepted)).toMatchObject([
+      { code: "stale_entity_version", stateUnchanged: true },
+    ]);
+    await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: expect.any(Array),
+    });
+  });
+
+  it("successor recovery claimant も crash 済みなら次 generation が復旧する", async () => {
+    const root = await repository();
+    const lockPath = await coordinationLockPath(root);
+    const deadOwnerPid = 2_147_483_647;
+    const firstRecoveryPid = deadOwnerPid - 1;
+    const successorRecoveryPid = deadOwnerPid - 2;
+    const deadNonce = randomUUID();
+    const firstRecoveryNonce = randomUUID();
+    const successorRecoveryNonce = randomUUID();
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        schemaVersion: "1",
+        pid: deadOwnerPid,
+        hostname: hostname(),
+        nonce: deadNonce,
+        startedAt: "2026-08-02T00:00:00.000Z",
+      })}\n`,
+    );
+    const recoveryClaim = (pid: number, nonce: string) => ({
+      schemaVersion: "1",
+      expectedOwnerNonce: deadNonce,
+      claimant: {
+        pid,
+        hostname: hostname(),
+        nonce,
+        claimedAt: "2026-08-02T00:00:00.000Z",
+      },
+    });
+    await writeFile(
+      recoveryClaimMarkerPath(lockPath, deadNonce),
+      `${JSON.stringify(recoveryClaim(firstRecoveryPid, firstRecoveryNonce))}\n`,
+    );
+    await writeFile(
+      recoverySuccessorMarkerPath(lockPath, deadNonce, firstRecoveryNonce),
+      `${JSON.stringify(recoveryClaim(successorRecoveryPid, successorRecoveryNonce))}\n`,
+    );
+
+    const recovered = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        isProcessAlive: (pid) =>
+          ![deadOwnerPid, firstRecoveryPid, successorRecoveryPid].includes(pid),
+        nextId: () => "claim-after-successor-crash",
+        waitTimeoutMs: 2_000,
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+      }),
+    );
+    await expect(recovered.claim(acquire("after-successor-crash"))).resolves.toMatchObject({
+      accepted: true,
+      entityVersion: 1,
+      claim: { claimId: "claim-after-successor-crash" },
     });
   });
 
@@ -1153,7 +1485,7 @@ await store.claim(JSON.parse(rawInput));
         startedAt: "2026-08-02T00:00:00.000Z",
       })}\n`,
     );
-    await writeFile(join(lockPath, `recovery-claim-${deadNonce}.json`), "");
+    await writeFile(recoveryClaimMarkerPath(lockPath, deadNonce), "");
 
     const recovered = new DispatchClaimStore(
       root,

--- a/packages/cli/src/__tests__/git-fixture.ts
+++ b/packages/cli/src/__tests__/git-fixture.ts
@@ -1,0 +1,13 @@
+const REPOSITORY_SELECTION_VARIABLES = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_COMMON_DIR",
+] as const;
+
+/** raw Git fixture を指定した repository へ隔離し、hook の他環境は維持する。 */
+export function gitFixtureEnvironment(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const environment = { ...source };
+  for (const name of REPOSITORY_SELECTION_VARIABLES) delete environment[name];
+  return environment;
+}

--- a/packages/cli/src/__tests__/regressions/issue-329-ready-frontier.test.ts
+++ b/packages/cli/src/__tests__/regressions/issue-329-ready-frontier.test.ts
@@ -1,0 +1,683 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { FIXED_DEV_ROLE_GRAPH_CONTRACT } from "@gh-gantt/shared";
+import { gitFixtureEnvironment } from "../git-fixture.js";
+import { RunGraphControlPlane } from "../../run-graph/control-plane.js";
+import {
+  DispatchClaimStore,
+  createDispatchClaimStoreDependencies,
+} from "../../store/dispatch-claims.js";
+import { GraphContractStore } from "../../store/graph-contract.js";
+
+const execFileAsync = promisify(execFile);
+const CONFIG = `${JSON.stringify(
+  {
+    version: "1",
+    project: {
+      name: "fixture",
+      github: { owner: "fixture", repo: "repository", project_number: 1 },
+    },
+    sync: { auto_create_issues: false, field_mapping: { start_date: "Start", end_date: "End" } },
+    task_types: { task: { label: "Task", display: "bar", color: "#000", github_label: null } },
+    type_hierarchy: { task: [] },
+    statuses: {
+      field_name: "Status",
+      values: {
+        Todo: { color: "#000", done: false },
+        Doing: { color: "#111", done: false },
+      },
+    },
+    gantt: {
+      default_view: "month",
+      working_days: [1, 2, 3, 4, 5],
+      colors: { critical_path: "#000", on_track: "#000", at_risk: "#000", overdue: "#000" },
+    },
+    dispatch: {
+      max_concurrency: 3,
+      state_concurrency: { Todo: 1, Doing: 2 },
+      repository_concurrency: { "fixture/repository": 1 },
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+describe("[NFR-STABILITY-014-AC9][Issue #329] linked-worktree 間の claim coordination", () => {
+  it("raw Git fixture は repository-selection 変数だけを除去する", () => {
+    const environment = gitFixtureEnvironment({
+      GIT_DIR: "foreign-git-dir",
+      GIT_WORK_TREE: "foreign-work-tree",
+      GIT_INDEX_FILE: "foreign-index",
+      GIT_COMMON_DIR: "foreign-common-dir",
+      LEFTHOOK: "1",
+      FIXTURE_SENTINEL: "preserved",
+    });
+
+    expect(environment).toEqual({ LEFTHOOK: "1", FIXTURE_SENTINEL: "preserved" });
+  });
+
+  it("別 OS process から同じ registry を観測しつつ Run Graph journal は workspace-local に保つ", async () => {
+    const scratch = await mkdtemp(join(tmpdir(), "gh-gantt-issue-329-"));
+    const repository = join(scratch, "repository");
+    const linked = join(scratch, "linked");
+    try {
+      await execFileAsync("git", ["init", repository], { env: gitFixtureEnvironment() });
+      await execFileAsync(
+        "git",
+        ["-C", repository, "config", "user.email", "fixture@example.invalid"],
+        { env: gitFixtureEnvironment() },
+      );
+      await execFileAsync("git", ["-C", repository, "config", "user.name", "Fixture"], {
+        env: gitFixtureEnvironment(),
+      });
+      await mkdir(join(repository, ".gantt-sync"), { recursive: true });
+      await writeFile(join(repository, ".gantt-sync", "gantt.config.json"), CONFIG);
+      await execFileAsync("git", ["-C", repository, "add", ".gantt-sync/gantt.config.json"], {
+        env: gitFixtureEnvironment(),
+      });
+      await execFileAsync("git", ["-C", repository, "commit", "-m", "fixture"], {
+        env: gitFixtureEnvironment(),
+      });
+      await execFileAsync("git", ["-C", repository, "worktree", "add", linked, "-b", "linked"], {
+        env: gitFixtureEnvironment(),
+      });
+
+      await new GraphContractStore(repository).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+      const started = await new RunGraphControlPlane(repository).start({
+        schemaVersion: "1",
+        eventId: "run-start",
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        task: { owner: "fixture", repo: "repository", issueNumber: 1 },
+        contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+      });
+      if (!started.accepted) throw new Error(started.message);
+      const currentNode = started.view.currentNode;
+      if (!currentNode) throw new Error("current node が必要です");
+      const attemptStarted = await new RunGraphControlPlane(repository).applyEvent({
+        schemaVersion: "1",
+        eventId: "attempt-start",
+        runId: started.view.runId,
+        actor: { id: "planner-1", role: "planner" },
+        command: {
+          type: "attempt_started",
+          nodeId: currentNode.id,
+          attemptId: "attempt-planner-1",
+        },
+      });
+      if (!attemptStarted.accepted) throw new Error(attemptStarted.message);
+
+      const claims = new DispatchClaimStore(
+        repository,
+        createDispatchClaimStoreDependencies({
+          now: () => "2026-08-02T00:00:00.000Z",
+          nextId: () => "claim-linked",
+          readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+        }),
+      );
+      const claimed = await claims.claim({
+        schemaVersion: "1",
+        eventId: "claim-main",
+        expectedEntityVersion: 0,
+        taskId: "fixture/repository#1",
+        repository: "fixture/repository",
+        state: "Todo",
+        ownerId: "owner-main",
+        workspaceId: "workspace-shared",
+        runId: started.view.runId,
+        leaseDurationSeconds: 300,
+        dispatchPlanId: "dispatch-plan:test-main",
+        dispatchPlanVersion: "1",
+        snapshotFingerprint: "d".repeat(64),
+      });
+      if (!claimed.accepted) throw new Error(claimed.message);
+
+      const childScript = join(scratch, "linked-observer.ts");
+      await writeFile(
+        childScript,
+        `void (async () => {
+const [moduleUrl, root] = process.argv.slice(2);
+const { DispatchClaimStore, createDispatchClaimStoreDependencies } = await import(moduleUrl);
+let current = "2026-08-02T00:01:00.000Z";
+const store = new DispatchClaimStore(root, createDispatchClaimStoreDependencies({
+  now: () => current,
+  nextId: () => "claim-linked-process-new",
+  readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+}));
+const snapshot = await store.snapshot();
+const workspaceDuplicate = await store.claim({
+  schemaVersion: "1",
+  eventId: "claim-linked-workspace-duplicate",
+  expectedEntityVersion: snapshot.entityVersion,
+  taskId: "fixture/repository#2",
+  repository: "fixture/repository",
+  state: "Todo",
+  ownerId: "owner-linked",
+  workspaceId: "workspace-shared",
+  runId: "run-linked",
+  leaseDurationSeconds: 300,
+  dispatchPlanId: "dispatch-plan:test-duplicate",
+  dispatchPlanVersion: "1",
+  snapshotFingerprint: "d".repeat(64),
+});
+const capacity = await store.claim({
+  schemaVersion: "1",
+  eventId: "claim-linked-capacity",
+  expectedEntityVersion: snapshot.entityVersion,
+  taskId: "fixture/repository#2",
+  repository: "fixture/repository",
+  state: "Todo",
+  ownerId: "owner-linked",
+  workspaceId: "workspace-linked",
+  runId: "run-linked",
+  leaseDurationSeconds: 300,
+  dispatchPlanId: "dispatch-plan:test-capacity",
+  dispatchPlanVersion: "1",
+  snapshotFingerprint: "d".repeat(64),
+});
+const first = snapshot.claims[0];
+const heartbeat = await store.heartbeat({
+  schemaVersion: "1",
+  eventId: "heartbeat-linked",
+  expectedEntityVersion: snapshot.entityVersion,
+  proof: {
+    claimId: first.claimId,
+    fencingToken: first.fencingToken,
+    ownerId: first.ownerId,
+    runId: first.runId,
+  },
+  leaseDurationSeconds: 300,
+});
+const release = await store.release({
+  schemaVersion: "1",
+  eventId: "release-linked",
+  expectedEntityVersion: heartbeat.entityVersion,
+  proof: {
+    claimId: heartbeat.claim.claimId,
+    fencingToken: heartbeat.claim.fencingToken,
+    ownerId: heartbeat.claim.ownerId,
+    runId: heartbeat.claim.runId,
+  },
+});
+current = "2026-08-02T00:02:00.000Z";
+const reclaimedClaim = await store.claim({
+  schemaVersion: "1",
+  eventId: "claim-before-reclaim",
+  expectedEntityVersion: release.entityVersion,
+  taskId: "fixture/repository#2",
+  repository: "fixture/repository",
+  state: "Todo",
+  ownerId: "owner-linked",
+  workspaceId: "workspace-linked",
+  runId: first.runId,
+  leaseDurationSeconds: 60,
+  dispatchPlanId: "dispatch-plan:test-reclaim",
+  dispatchPlanVersion: "1",
+  snapshotFingerprint: "d".repeat(64),
+});
+current = "2026-08-02T00:04:00.000Z";
+const reclaim = await store.reclaim({
+  schemaVersion: "1",
+  eventId: "reclaim-linked-expired",
+  expectedEntityVersion: reclaimedClaim.entityVersion,
+  claimId: reclaimedClaim.claim.claimId,
+  reason: "expired",
+});
+process.stdout.write(JSON.stringify({
+  snapshot,
+  workspaceDuplicate,
+  capacity,
+  heartbeat,
+  release,
+  reclaimedClaim,
+  reclaim,
+}));
+})();
+`,
+      );
+      const moduleUrl = pathToFileURL(
+        resolve(import.meta.dirname, "../../store/dispatch-claims.ts"),
+      ).href;
+      const observed = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", childScript, moduleUrl, linked],
+        { encoding: "utf8" },
+      );
+      const result = JSON.parse(observed.stdout) as {
+        snapshot: {
+          entityVersion: number;
+          claims: Array<{
+            claimId: string;
+            fencingToken: number;
+            ownerId: string;
+            runId: string;
+          }>;
+        };
+        workspaceDuplicate: { accepted: boolean; code: string };
+        capacity: { accepted: boolean; code: string };
+        heartbeat: {
+          accepted: boolean;
+          entityVersion: number;
+          claim: { fencingToken: number };
+        };
+        release: { accepted: boolean; entityVersion: number };
+        reclaimedClaim: {
+          accepted: boolean;
+          entityVersion: number;
+          claim: { claimId: string; fencingToken: number; ownerId: string; runId: string };
+        };
+        reclaim: { accepted: boolean; entityVersion: number; reclaimReason: string };
+      };
+      expect(result).toMatchObject({
+        snapshot: { entityVersion: 1, claims: [{ claimId: "claim-linked" }] },
+        workspaceDuplicate: { accepted: false, code: "workspace_already_claimed" },
+        capacity: { accepted: false, code: "state_capacity" },
+        heartbeat: { accepted: true, entityVersion: 2, claim: { fencingToken: 2 } },
+        release: { accepted: true, entityVersion: 3 },
+        reclaimedClaim: { accepted: true, entityVersion: 4 },
+        reclaim: { accepted: true, entityVersion: 5, reclaimReason: "expired" },
+      });
+      const staleCompletion = await new RunGraphControlPlane(
+        repository,
+        undefined,
+        new DispatchClaimStore(
+          repository,
+          createDispatchClaimStoreDependencies({ now: () => "2026-08-02T00:04:00.000Z" }),
+        ),
+      ).applyClaimedEvent(
+        {
+          schemaVersion: "1" as const,
+          eventId: "stale-completion-after-reclaim",
+          runId: started.view.runId,
+          actor: { id: "planner-1", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId: currentNode.id,
+            attemptId: "attempt-planner-1",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["stale-reclaimed-evidence"],
+          },
+          evidence: [
+            {
+              id: "stale-reclaimed-evidence",
+              kind: "command_execution",
+              artifactIds: [],
+              provenance: "stale-reclaimed-runner",
+              reference: {
+                kind: "command",
+                uri: "command://stale-reclaimed",
+                sha256: `sha256:${"b".repeat(64)}`,
+                byteLength: 1,
+              },
+            },
+          ],
+        },
+        {
+          claimId: result.reclaimedClaim.claim.claimId,
+          fencingToken: result.reclaimedClaim.claim.fencingToken,
+          ownerId: result.reclaimedClaim.claim.ownerId,
+          runId: result.reclaimedClaim.claim.runId,
+        },
+        result.reclaimedClaim.entityVersion,
+      );
+      expect(staleCompletion).toMatchObject({
+        accepted: false,
+        code: "stale_claim",
+        stateUnchanged: true,
+        view: { revision: 2, activeAttempt: { state: "running" } },
+      });
+
+      const raceWorker = join(scratch, "race-worker.ts");
+      await writeFile(
+        raceWorker,
+        `void (async () => {
+const [moduleUrl, root, operation, rawInput] = process.argv.slice(2);
+const { DispatchClaimStore, createDispatchClaimStoreDependencies } = await import(moduleUrl);
+const store = new DispatchClaimStore(root, createDispatchClaimStoreDependencies({
+  now: () => "2026-08-02T00:06:00.000Z",
+  readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+}));
+const input = JSON.parse(rawInput);
+const result = operation === "commitAuthorizedEvent"
+  ? await store.commitAuthorizedEvent(input, async () => undefined)
+  : await store[operation](input);
+process.stdout.write(JSON.stringify(result));
+})();
+`,
+      );
+      const raceStore = (id: string) =>
+        new DispatchClaimStore(
+          repository,
+          createDispatchClaimStoreDependencies({
+            now: () => "2026-08-02T00:05:00.000Z",
+            nextId: () => id,
+            readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+          }),
+        );
+      const runCapacityRace = async (
+        label: "state" | "repository",
+        candidates: Array<{
+          taskId: string;
+          repository: string;
+          state: string;
+          workspaceId: string;
+        }>,
+        expectedCode: "state_capacity" | "repository_capacity",
+      ) => {
+        const before = await raceStore("unused").snapshot();
+        const inputs = candidates.map((candidate, index) => ({
+          schemaVersion: "1" as const,
+          eventId: `process-${label}-claim-${index}`,
+          expectedEntityVersion: before.entityVersion,
+          ...candidate,
+          ownerId: `owner-${label}-${index}`,
+          runId: `run-${label}-${index}`,
+          leaseDurationSeconds: 300,
+          dispatchPlanId: `dispatch-plan:${label}-${index}`,
+          dispatchPlanVersion: "1" as const,
+          snapshotFingerprint: "d".repeat(64),
+        }));
+        const results = await Promise.all(
+          inputs.map((input) =>
+            execFileAsync(
+              process.execPath,
+              ["--import", "tsx", raceWorker, moduleUrl, linked, "claim", JSON.stringify(input)],
+              { encoding: "utf8" },
+            ).then((output) => JSON.parse(output.stdout) as { accepted: boolean; code?: string }),
+          ),
+        );
+        expect(results.filter((item) => item.accepted)).toHaveLength(1);
+        const current = await raceStore("unused").snapshot();
+        const losingIndex = results.findIndex((item) => !item.accepted);
+        await expect(
+          raceStore("unused").claim({
+            ...inputs[losingIndex]!,
+            eventId: `process-${label}-claim-retry`,
+            expectedEntityVersion: current.entityVersion,
+          }),
+        ).resolves.toMatchObject({ accepted: false, code: expectedCode });
+        await raceStore("unused").reclaim({
+          schemaVersion: "1",
+          eventId: `cleanup-${label}-capacity-race`,
+          expectedEntityVersion: current.entityVersion,
+          claimId: current.claims[0]!.claimId,
+          reason: "owner_stopped",
+          ownerStoppedEvidenceId: "process-exit:capacity-race",
+        });
+      };
+
+      await runCapacityRace(
+        "state",
+        [
+          {
+            taskId: "fixture/repository#state-a",
+            repository: "fixture/repository",
+            state: "Todo",
+            workspaceId: "workspace-state-a",
+          },
+          {
+            taskId: "other/repository#state-b",
+            repository: "other/repository",
+            state: "Todo",
+            workspaceId: "workspace-state-b",
+          },
+        ],
+        "state_capacity",
+      );
+      await runCapacityRace(
+        "repository",
+        [
+          {
+            taskId: "fixture/repository#repo-a",
+            repository: "fixture/repository",
+            state: "Doing",
+            workspaceId: "workspace-repo-a",
+          },
+          {
+            taskId: "fixture/repository#repo-b",
+            repository: "fixture/repository",
+            state: "Doing",
+            workspaceId: "workspace-repo-b",
+          },
+        ],
+        "repository_capacity",
+      );
+      const runRace = async (
+        operation: "heartbeat" | "reclaim",
+        claim: {
+          claimId: string;
+          fencingToken: number;
+          ownerId: string;
+          runId: string;
+          taskId: string;
+          entityVersion: number;
+        },
+      ) => {
+        const proof = {
+          claimId: claim.claimId,
+          fencingToken: claim.fencingToken,
+          ownerId: claim.ownerId,
+          runId: claim.runId,
+        };
+        const command = {
+          type: "attempt_finished" as const,
+          nodeId: currentNode.id,
+          attemptId: "attempt-planner-1",
+          outcome: "succeeded" as const,
+          artifactIds: [],
+          evidenceIds: [],
+        };
+        const completeInput = {
+          schemaVersion: "1",
+          eventId: `process-complete-vs-${operation}`,
+          expectedEntityVersion: claim.entityVersion,
+          proof,
+          runId: claim.runId,
+          taskId: claim.taskId,
+          actorId: claim.ownerId,
+          commandFingerprint: createHash("sha256").update(JSON.stringify(command)).digest("hex"),
+        };
+        const competingInput =
+          operation === "heartbeat"
+            ? {
+                schemaVersion: "1",
+                eventId: "process-heartbeat-race",
+                expectedEntityVersion: claim.entityVersion,
+                proof,
+                leaseDurationSeconds: 300,
+              }
+            : {
+                schemaVersion: "1",
+                eventId: "process-reclaim-race",
+                expectedEntityVersion: claim.entityVersion,
+                claimId: claim.claimId,
+                reason: "owner_stopped",
+                ownerStoppedEvidenceId: "process-exit:race-owner",
+              };
+        const [completion, competing] = await Promise.all([
+          execFileAsync(
+            process.execPath,
+            [
+              "--import",
+              "tsx",
+              raceWorker,
+              moduleUrl,
+              linked,
+              "commitAuthorizedEvent",
+              JSON.stringify(completeInput),
+            ],
+            { encoding: "utf8" },
+          ),
+          execFileAsync(
+            process.execPath,
+            [
+              "--import",
+              "tsx",
+              raceWorker,
+              moduleUrl,
+              linked,
+              operation,
+              JSON.stringify(competingInput),
+            ],
+            { encoding: "utf8" },
+          ),
+        ]);
+        return [JSON.parse(completion.stdout), JSON.parse(competing.stdout)] as Array<{
+          accepted: boolean;
+          code?: string;
+        }>;
+      };
+
+      for (const operation of ["heartbeat", "reclaim"] as const) {
+        const before = await raceStore(`claim-process-${operation}`).snapshot();
+        if (before.claims[0]) {
+          await raceStore("unused").reclaim({
+            schemaVersion: "1",
+            eventId: `cleanup-before-${operation}`,
+            expectedEntityVersion: before.entityVersion,
+            claimId: before.claims[0].claimId,
+            reason: "owner_stopped",
+            ownerStoppedEvidenceId: "process-exit:cleanup",
+          });
+        }
+        const clean = await raceStore(`claim-process-${operation}`).snapshot();
+        const acquired = await raceStore(`claim-process-${operation}`).claim({
+          schemaVersion: "1",
+          eventId: `claim-process-${operation}`,
+          expectedEntityVersion: clean.entityVersion,
+          taskId: "fixture/repository#1",
+          repository: "fixture/repository",
+          state: "Todo",
+          ownerId: "planner-1",
+          workspaceId: `workspace-process-${operation}`,
+          runId: started.view.runId,
+          leaseDurationSeconds: 300,
+          dispatchPlanId: `dispatch-plan:process-${operation}`,
+          dispatchPlanVersion: "1",
+          snapshotFingerprint: "d".repeat(64),
+        });
+        if (!acquired.accepted || !acquired.claim) throw new Error("race claim が必要です");
+        const raceResults = await runRace(operation, acquired.claim);
+        expect(raceResults.filter((item) => item.accepted)).toHaveLength(1);
+        expect(raceResults.filter((item) => !item.accepted)).toMatchObject([
+          { code: "stale_entity_version" },
+        ]);
+      }
+
+      const beforeCrashClaim = await raceStore("claim-crash-reconcile").snapshot();
+      if (beforeCrashClaim.claims[0]) {
+        await raceStore("unused").reclaim({
+          schemaVersion: "1",
+          eventId: "cleanup-before-crash-reconcile",
+          expectedEntityVersion: beforeCrashClaim.entityVersion,
+          claimId: beforeCrashClaim.claims[0].claimId,
+          reason: "owner_stopped",
+          ownerStoppedEvidenceId: "process-exit:cleanup",
+        });
+      }
+      const cleanBeforeCrash = await raceStore("claim-crash-reconcile").snapshot();
+      const crashClaim = await raceStore("claim-crash-reconcile").claim({
+        schemaVersion: "1",
+        eventId: "claim-crash-reconcile",
+        expectedEntityVersion: cleanBeforeCrash.entityVersion,
+        taskId: "fixture/repository#1",
+        repository: "fixture/repository",
+        state: "Todo",
+        ownerId: "planner-1",
+        workspaceId: "workspace-crash-reconcile",
+        runId: started.view.runId,
+        leaseDurationSeconds: 300,
+        dispatchPlanId: "dispatch-plan:crash-reconcile",
+        dispatchPlanVersion: "1",
+        snapshotFingerprint: "d".repeat(64),
+      });
+      if (!crashClaim.accepted || !crashClaim.claim) throw new Error("crash claim が必要です");
+      const completionCommand = {
+        type: "attempt_finished" as const,
+        nodeId: currentNode.id,
+        attemptId: "attempt-planner-1",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["completion-command-evidence"],
+      };
+      const proof = {
+        claimId: crashClaim.claim.claimId,
+        fencingToken: crashClaim.claim.fencingToken,
+        ownerId: crashClaim.claim.ownerId,
+        runId: crashClaim.claim.runId,
+      };
+      const completionInput = {
+        schemaVersion: "1" as const,
+        eventId: "receipt-before-local-append-crash",
+        runId: started.view.runId,
+        actor: { id: "planner-1", role: "planner" as const },
+        command: completionCommand,
+        evidence: [
+          {
+            id: "completion-command-evidence",
+            kind: "command_execution",
+            artifactIds: [],
+            provenance: "linked-process-race",
+            reference: {
+              kind: "command" as const,
+              uri: "command://linked-process-race",
+              sha256: `sha256:${"a".repeat(64)}`,
+              byteLength: 1,
+            },
+          },
+        ],
+      };
+      const replayCompletion = () =>
+        new RunGraphControlPlane(repository, undefined, raceStore("unused")).applyClaimedEvent(
+          completionInput,
+          proof,
+          crashClaim.entityVersion,
+        );
+      await expect(replayCompletion()).resolves.toMatchObject({
+        accepted: true,
+        claimAuthorization: {
+          receipt: { entityVersion: crashClaim.entityVersion + 1 },
+          proof: { fencingToken: crashClaim.entityVersion + 1 },
+        },
+      });
+      await expect(replayCompletion()).resolves.toMatchObject({
+        accepted: true,
+        claimAuthorization: {
+          receipt: { entityVersion: crashClaim.entityVersion + 1 },
+          proof: { fencingToken: crashClaim.entityVersion + 1 },
+        },
+        view: {
+          claimAudits: { total: 1, items: [{ command: { type: "claim_event_authorized" } }] },
+        },
+      });
+      await expect(raceStore("unused").snapshot()).resolves.toMatchObject({
+        entityVersion: crashClaim.entityVersion + 1,
+        claims: [
+          {
+            claimId: crashClaim.claim.claimId,
+            entityVersion: crashClaim.entityVersion + 1,
+            fencingToken: crashClaim.entityVersion + 1,
+          },
+        ],
+      });
+      await expect(new RunGraphControlPlane(linked).inspect(started.view.runId)).rejects.toThrow(
+        /見つかりません/,
+      );
+      await expect(
+        new RunGraphControlPlane(repository).inspect(started.view.runId),
+      ).resolves.toMatchObject({
+        runId: started.view.runId,
+        revision: 4,
+        activeAttempt: { state: "succeeded" },
+      });
+    } finally {
+      await rm(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -12,16 +12,31 @@ import {
 } from "@gh-gantt/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { gitFixtureEnvironment } from "./git-fixture.js";
-import { createRunCommand } from "../commands/run.js";
+import { canonicalFingerprint, createRunCommand } from "../commands/run.js";
 import { buildProgram } from "../program.js";
 import type { RunGraphPrObservation } from "../loop/pr-evidence.js";
 import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 import { ConfigStore } from "../store/config.js";
+import { DispatchClaimStore } from "../store/dispatch-claims.js";
 import { GraphContractStore } from "../store/graph-contract.js";
 import { withProjectStorage } from "../store/project-storage.js";
 import { TasksStore } from "../store/tasks.js";
 
 const execFileAsync = promisify(execFile);
+
+describe("canonical dispatch fingerprint", () => {
+  it("mixed-case key を locale ではなく code unit 順で固定する", () => {
+    const expected = createHash("sha256")
+      .update(JSON.stringify({ Z: 1, a: 2 }))
+      .digest("hex");
+    const localeLike = createHash("sha256")
+      .update(JSON.stringify({ a: 2, Z: 1 }))
+      .digest("hex");
+
+    expect(canonicalFingerprint({ a: 2, Z: 1 })).toBe(expected);
+    expect(canonicalFingerprint({ a: 2, Z: 1 })).not.toBe(localeLike);
+  });
+});
 
 function makeConfig(): Config {
   return {
@@ -184,6 +199,88 @@ describe("[NFR-STABILITY-014-AC9] run bounded dispatch CLI contract", () => {
         capacity: { global: { limit: 2, used: 0 } },
       });
       await writeFile(dispatchPlanPath, `${JSON.stringify(initialPlan)}\n`);
+
+      await createRunCommand().parseAsync(
+        [
+          "claim",
+          "--event-id",
+          "claim-invalid-repository",
+          "--expected-version",
+          "0",
+          "--task",
+          "stanah/gh-gantt#328",
+          "--repository",
+          "stanah",
+          "--state",
+          "Todo",
+          "--owner",
+          "planner-2",
+          "--workspace",
+          "workspace:328",
+          "--run",
+          started.view.runId,
+          "--plan-file",
+          dispatchPlanPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--actor",
+          "orchestrator-1",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: false,
+        code: "invalid_input",
+        stateUnchanged: true,
+      });
+      await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+        entityVersion: 0,
+        claims: [],
+      });
+      process.exitCode = undefined;
+
+      for (const emptyVersion of ["", "   "]) {
+        await createRunCommand().parseAsync(
+          [
+            "claim",
+            "--event-id",
+            `claim-empty-version-${emptyVersion.length}`,
+            "--expected-version",
+            emptyVersion,
+            "--task",
+            "stanah/gh-gantt#328",
+            "--repository",
+            "stanah/gh-gantt",
+            "--state",
+            "Todo",
+            "--owner",
+            "planner-2",
+            "--workspace",
+            "workspace:328",
+            "--run",
+            started.view.runId,
+            "--plan-file",
+            dispatchPlanPath,
+            "--gate-snapshot",
+            gateSnapshotPath,
+            "--actor",
+            "orchestrator-1",
+            "--json",
+          ],
+          { from: "user" },
+        );
+        expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+          accepted: false,
+          code: "invalid_input",
+          stateUnchanged: true,
+        });
+        await expect(new DispatchClaimStore(root).snapshot()).resolves.toMatchObject({
+          entityVersion: 0,
+          claims: [],
+        });
+        process.exitCode = undefined;
+      }
 
       await writeFile(
         gateSnapshotPath,

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   type Config,
@@ -9,12 +11,17 @@ import {
   type TasksFile,
 } from "@gh-gantt/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { gitFixtureEnvironment } from "./git-fixture.js";
 import { createRunCommand } from "../commands/run.js";
 import { buildProgram } from "../program.js";
 import type { RunGraphPrObservation } from "../loop/pr-evidence.js";
 import { RunGraphControlPlane } from "../run-graph/control-plane.js";
 import { ConfigStore } from "../store/config.js";
+import { GraphContractStore } from "../store/graph-contract.js";
+import { withProjectStorage } from "../store/project-storage.js";
 import { TasksStore } from "../store/tasks.js";
+
+const execFileAsync = promisify(execFile);
 
 function makeConfig(): Config {
   return {
@@ -78,6 +85,531 @@ const reference = (name: string) => ({
   uri: `.dev-flow/328/${name}.json`,
   sha256: `sha256:${"d".repeat(64)}`,
   byteLength: 256,
+});
+
+describe("[NFR-STABILITY-014-AC9] run bounded dispatch CLI contract", () => {
+  it("dispatch/claim/heartbeat/release/reclaim を JSON-first public command として公開する", async () => {
+    const originalExitCode = process.exitCode;
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-run-dispatch-command-"));
+    const workspaceMapPath = join(root, "workspace-map.json");
+    const gateSnapshotPath = join(root, "gate-snapshot.json");
+    const dispatchPlanPath = join(root, "dispatch-plan.json");
+    await execFileAsync("git", ["init", root], { env: gitFixtureEnvironment() });
+    await mkdir(join(root, ".gantt-sync"), { recursive: true });
+    const config: Config = {
+      ...makeConfig(),
+      statuses: {
+        field_name: "Status",
+        values: { Todo: { color: "#000", done: false, category: "todo" } },
+      },
+      dispatch: { max_concurrency: 2 },
+    };
+    await new ConfigStore(root).write(config);
+    await withProjectStorage(
+      root,
+      { mode: "write", scope: "all" },
+      async ({ tasksStore, stateStore }) => {
+        await tasksStore.write({
+          tasks: [makeTask({ custom_fields: { Status: "Todo" } })],
+          cache: { comments: {}, reactions: {} },
+        });
+        await stateStore.write({
+          last_synced_at: "2026-08-02T00:00:00.000Z",
+          project_node_id: "PVT_fixture",
+          id_map: {},
+          field_ids: {},
+          snapshots: {},
+        });
+      },
+    );
+    await writeFile(
+      workspaceMapPath,
+      `${JSON.stringify({ "stanah/gh-gantt#328": "workspace:328" })}\n`,
+    );
+    await writeFile(
+      gateSnapshotPath,
+      `${JSON.stringify({
+        schemaVersion: "1",
+        sourceRevision: "review-system:1",
+        observedAt: "2026-08-02T00:00:00.000Z",
+        reviewGateTaskIds: [],
+        humanGateTaskIds: [],
+      })}\n`,
+    );
+    await new GraphContractStore(root).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+    const started = await new RunGraphControlPlane(root).start({
+      schemaVersion: "1",
+      eventId: "dispatch-run-start",
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      task: { owner: "stanah", repo: "gh-gantt", issueNumber: 328 },
+      contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+    });
+    if (!started.accepted) throw new Error(started.message);
+    const currentNodeId = started.view.currentNode?.id;
+    if (!currentNodeId) throw new Error("current node が必要です");
+    await new RunGraphControlPlane(root).applyEvent({
+      schemaVersion: "1",
+      eventId: "dispatch-attempt-start",
+      runId: started.view.runId,
+      actor: { id: "planner-2", role: "planner" },
+      command: { type: "attempt_started", nodeId: currentNodeId, attemptId: "dispatch-attempt" },
+    });
+
+    const logs: string[] = [];
+    vi.spyOn(process, "cwd").mockReturnValue(root);
+    vi.spyOn(console, "log").mockImplementation((value) => logs.push(String(value)));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const names = createRunCommand().commands.map((item) => item.name());
+      expect(names).toEqual(
+        expect.arrayContaining(["dispatch", "claim", "heartbeat", "release", "reclaim"]),
+      );
+
+      await createRunCommand().parseAsync(
+        [
+          "dispatch",
+          "--workspace-map",
+          workspaceMapPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--json",
+        ],
+        { from: "user" },
+      );
+      const initialPlan = JSON.parse(logs.at(-1)!);
+      expect(initialPlan).toMatchObject({
+        planVersion: "1",
+        registryEntityVersion: 0,
+        selected: [{ taskId: "stanah/gh-gantt#328", workspaceId: "workspace:328" }],
+        capacity: { global: { limit: 2, used: 0 } },
+      });
+      await writeFile(dispatchPlanPath, `${JSON.stringify(initialPlan)}\n`);
+
+      await writeFile(
+        gateSnapshotPath,
+        `${JSON.stringify({
+          schemaVersion: "1",
+          sourceRevision: "review-system:2",
+          observedAt: "2026-08-02T00:01:00.000Z",
+          reviewGateTaskIds: ["stanah/gh-gantt#328"],
+          humanGateTaskIds: [],
+        })}\n`,
+      );
+      await createRunCommand().parseAsync(
+        [
+          "claim",
+          "--event-id",
+          "claim-stale-gate-snapshot",
+          "--expected-version",
+          "0",
+          "--task",
+          "stanah/gh-gantt#328",
+          "--repository",
+          "stanah/gh-gantt",
+          "--state",
+          "Todo",
+          "--owner",
+          "planner-2",
+          "--workspace",
+          "workspace:328",
+          "--run",
+          started.view.runId,
+          "--plan-file",
+          dispatchPlanPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--actor",
+          "orchestrator-1",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: false,
+        code: "stale_entity_version",
+      });
+      await writeFile(
+        gateSnapshotPath,
+        `${JSON.stringify({
+          schemaVersion: "1",
+          sourceRevision: "review-system:1",
+          observedAt: "2026-08-02T00:00:00.000Z",
+          reviewGateTaskIds: [],
+          humanGateTaskIds: [],
+        })}\n`,
+      );
+
+      await withProjectStorage(root, { mode: "write", scope: "all" }, async ({ tasksStore }) => {
+        const current = await tasksStore.read();
+        await tasksStore.write({ ...current, has_conflicts: true });
+      });
+      await createRunCommand().parseAsync(
+        [
+          "claim",
+          "--event-id",
+          "claim-stale-work-graph",
+          "--expected-version",
+          "0",
+          "--task",
+          "stanah/gh-gantt#328",
+          "--repository",
+          "stanah/gh-gantt",
+          "--state",
+          "Todo",
+          "--owner",
+          "planner-2",
+          "--workspace",
+          "workspace:328",
+          "--run",
+          started.view.runId,
+          "--plan-file",
+          dispatchPlanPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--actor",
+          "orchestrator-1",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: false,
+        code: "stale_entity_version",
+      });
+      await withProjectStorage(root, { mode: "write", scope: "all" }, async ({ tasksStore }) => {
+        const current = await tasksStore.read();
+        await tasksStore.write({ ...current, has_conflicts: false });
+      });
+
+      await createRunCommand().parseAsync(
+        [
+          "claim",
+          "--event-id",
+          "claim-cli-1",
+          "--expected-version",
+          "0",
+          "--task",
+          "stanah/gh-gantt#328",
+          "--repository",
+          "stanah/gh-gantt",
+          "--state",
+          "Todo",
+          "--owner",
+          "planner-2",
+          "--workspace",
+          "workspace:328",
+          "--run",
+          started.view.runId,
+          "--plan-file",
+          dispatchPlanPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--actor",
+          "orchestrator-1",
+          "--lease-seconds",
+          "60",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      const claimed = JSON.parse(logs.at(-1)!) as {
+        accepted: true;
+        entityVersion: number;
+        claim: { claimId: string; fencingToken: number; ownerId: string; runId: string };
+        audit: { recorded: boolean };
+      };
+      expect(claimed).toMatchObject({
+        accepted: true,
+        entityVersion: 1,
+        audit: { recorded: true },
+      });
+
+      await createRunCommand().parseAsync(
+        [
+          "heartbeat",
+          "--event-id",
+          "heartbeat-cli-1",
+          "--expected-version",
+          "1",
+          "--claim",
+          claimed.claim.claimId,
+          "--fencing-token",
+          String(claimed.claim.fencingToken),
+          "--owner",
+          claimed.claim.ownerId,
+          "--run",
+          claimed.claim.runId,
+          "--actor",
+          "orchestrator-1",
+          "--lease-seconds",
+          "60",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      const heartbeat = JSON.parse(logs.at(-1)!) as { claim: { fencingToken: number } };
+      expect(heartbeat).toMatchObject({
+        accepted: true,
+        entityVersion: 2,
+        audit: { recorded: true },
+      });
+
+      const authorizedEventPath = join(root, "authorized-event.json");
+      await writeFile(
+        authorizedEventPath,
+        `${JSON.stringify({
+          schemaVersion: "1",
+          eventId: "authorized-cli-finish",
+          actor: { id: "planner-2", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId: currentNodeId,
+            attemptId: "dispatch-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["authorized-cli-command"],
+          },
+          evidence: [
+            {
+              id: "authorized-cli-command",
+              kind: "command_execution",
+              artifactIds: [],
+              provenance: "authorized-cli-runner",
+              reference: {
+                kind: "command",
+                uri: "command://authorized-cli",
+                sha256: `sha256:${"a".repeat(64)}`,
+                byteLength: 1,
+              },
+            },
+          ],
+          claim: {
+            expectedEntityVersion: 2,
+            proof: {
+              claimId: claimed.claim.claimId,
+              fencingToken: heartbeat.claim.fencingToken,
+              ownerId: claimed.claim.ownerId,
+              runId: claimed.claim.runId,
+            },
+          },
+        })}\n`,
+      );
+      await createRunCommand().parseAsync(
+        ["event", started.view.runId, "--file", authorizedEventPath, "--json"],
+        { from: "user" },
+      );
+      const authorized = JSON.parse(logs.at(-1)!) as {
+        claimAuthorization: {
+          receipt: { entityVersion: number; operation: string };
+          proof: { claimId: string; fencingToken: number; ownerId: string; runId: string };
+        };
+      };
+      expect(authorized).toMatchObject({
+        accepted: true,
+        claimAuthorization: {
+          receipt: { operation: "authorize_event", entityVersion: 3 },
+          proof: { fencingToken: 3 },
+          audit: { recorded: true },
+        },
+      });
+
+      await createRunCommand().parseAsync(
+        [
+          "release",
+          "--event-id",
+          "release-cli-1",
+          "--expected-version",
+          "3",
+          "--claim",
+          authorized.claimAuthorization.proof.claimId,
+          "--fencing-token",
+          String(authorized.claimAuthorization.proof.fencingToken),
+          "--owner",
+          authorized.claimAuthorization.proof.ownerId,
+          "--run",
+          authorized.claimAuthorization.proof.runId,
+          "--actor",
+          "orchestrator-1",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: true,
+        entityVersion: 4,
+        audit: { recorded: true },
+      });
+
+      await createRunCommand().parseAsync(
+        [
+          "dispatch",
+          "--workspace-map",
+          workspaceMapPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--json",
+        ],
+        { from: "user" },
+      );
+      const secondPlan = JSON.parse(logs.at(-1)!);
+      expect(secondPlan).toMatchObject({ registryEntityVersion: 4 });
+      await writeFile(dispatchPlanPath, `${JSON.stringify(secondPlan)}\n`);
+
+      await createRunCommand().parseAsync(
+        [
+          "claim",
+          "--event-id",
+          "claim-cli-2",
+          "--expected-version",
+          "4",
+          "--task",
+          "stanah/gh-gantt#328",
+          "--repository",
+          "stanah/gh-gantt",
+          "--state",
+          "Todo",
+          "--owner",
+          "planner-2",
+          "--workspace",
+          "workspace:328",
+          "--run",
+          started.view.runId,
+          "--plan-file",
+          dispatchPlanPath,
+          "--gate-snapshot",
+          gateSnapshotPath,
+          "--actor",
+          "orchestrator-1",
+          "--lease-seconds",
+          "60",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      const claimedAgain = JSON.parse(logs.at(-1)!) as {
+        claim: { claimId: string; fencingToken: number; ownerId: string; runId: string };
+      };
+      await createRunCommand().parseAsync(
+        [
+          "reclaim",
+          "--event-id",
+          "reclaim-cli-1",
+          "--expected-version",
+          "5",
+          "--claim",
+          claimedAgain.claim.claimId,
+          "--reason",
+          "owner_stopped",
+          "--owner-stopped-evidence",
+          "process-exit:planner-2",
+          "--actor",
+          "orchestrator-1",
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: true,
+        entityVersion: 6,
+        audit: { recorded: true },
+      });
+
+      const staleEventPath = join(root, "stale-completion.json");
+      await writeFile(
+        staleEventPath,
+        `${JSON.stringify({
+          schemaVersion: "1",
+          eventId: "stale-cli-completion",
+          actor: { id: "planner-2", role: "planner" },
+          command: {
+            type: "node_outcome_submitted",
+            nodeId: currentNodeId,
+            attemptId: "dispatch-attempt",
+            outcome: "plan_valid",
+            artifactIds: ["stale-cli-plan"],
+            evidenceIds: ["stale-cli-plan-validation"],
+          },
+          artifacts: [
+            {
+              id: "stale-cli-plan",
+              schemaId: "dev-role.plan",
+              schemaVersion: "1",
+              derivedFromArtifactIds: [],
+              reference: {
+                kind: "workspace",
+                uri: ".dev-flow/328/stale-cli-plan.json",
+                sha256: `sha256:${"b".repeat(64)}`,
+                byteLength: 1,
+              },
+            },
+          ],
+          evidence: [
+            {
+              id: "stale-cli-plan-validation",
+              kind: "artifact_validation",
+              artifactIds: ["stale-cli-plan"],
+              provenance: "stale-cli-runner",
+              reference: {
+                kind: "workspace",
+                uri: ".dev-flow/328/stale-cli-plan-validation.json",
+                sha256: `sha256:${"a".repeat(64)}`,
+                byteLength: 1,
+              },
+            },
+          ],
+          claim: {
+            expectedEntityVersion: 6,
+            proof: {
+              claimId: claimedAgain.claim.claimId,
+              fencingToken: claimedAgain.claim.fencingToken,
+              ownerId: claimedAgain.claim.ownerId,
+              runId: claimedAgain.claim.runId,
+            },
+          },
+        })}\n`,
+      );
+      await createRunCommand().parseAsync(
+        ["event", started.view.runId, "--file", staleEventPath, "--json"],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: false,
+        code: "stale_claim",
+        stateUnchanged: true,
+      });
+
+      const missingProofPath = join(root, "missing-claim-proof.json");
+      await writeFile(
+        missingProofPath,
+        `${JSON.stringify({
+          schemaVersion: "1",
+          eventId: "missing-cli-proof",
+          actor: { id: "planner-2", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId: currentNodeId,
+            attemptId: "dispatch-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: [],
+          },
+        })}\n`,
+      );
+      await createRunCommand().parseAsync(
+        ["event", started.view.runId, "--file", missingProofPath, "--json"],
+        { from: "user" },
+      );
+      expect(JSON.parse(logs.at(-1)!)).toMatchObject({
+        accepted: false,
+        code: "stale_claim",
+        stateUnchanged: true,
+      });
+    } finally {
+      process.exitCode = originalExitCode;
+      vi.restoreAllMocks();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
 
 function expectedBoundedReference(kind: "command" | "github", uri: string, value: unknown) {
@@ -275,6 +807,11 @@ describe("[NFR-STABILITY-014-AC1] run CLI は durable control plane を操作す
   it("run group を登録し、OPEN Issue から exact-bound run を開始して bounded view を表示する", async () => {
     const runGroup = buildProgram().commands.find((command) => command.name() === "run");
     expect(runGroup?.commands.map((command) => command.name())).toEqual([
+      "dispatch",
+      "claim",
+      "heartbeat",
+      "release",
+      "reclaim",
       "start",
       "event",
       "show",

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -24,7 +24,7 @@ import { TasksStore } from "../store/tasks.js";
 
 const execFileAsync = promisify(execFile);
 
-describe("canonical dispatch fingerprint", () => {
+describe("dispatch fingerprint を正規化する", () => {
   it("mixed-case key を locale ではなく code unit 順で固定する", () => {
     const expected = createHash("sha256")
       .update(JSON.stringify({ Z: 1, a: 2 }))

--- a/packages/cli/src/__tests__/run-graph-control-plane.test.ts
+++ b/packages/cli/src/__tests__/run-graph-control-plane.test.ts
@@ -479,6 +479,60 @@ describe("[NFR-STABILITY-014-AC2] RunGraphControlPlane は start/applyEvent/insp
 });
 
 describe("[NFR-STABILITY-014-AC6] fixed dev-role transition は accepted outcome event だけで進む", () => {
+  it("non-Git standalone completion は process locale に依存せず従来動作を保つ", async () => {
+    const previousLocale = process.env.LC_ALL;
+    process.env.LC_ALL = "ja_JP.UTF-8";
+    try {
+      const { control } = await createControlPlane();
+      const started = await control.start({
+        schemaVersion: "1",
+        eventId: "standalone-locale-start",
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        task: { owner: "stanah", repo: "gh-gantt", issueNumber: 328 },
+        contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
+      });
+      if (!started.accepted || !started.view.currentNode) throw new Error("start failure");
+      const runId = started.view.runId;
+      const nodeId = started.view.currentNode.id;
+      await control.applyEvent({
+        schemaVersion: "1",
+        eventId: "standalone-locale-attempt-start",
+        runId,
+        actor: { id: "planner-1", role: "planner" },
+        command: { type: "attempt_started", nodeId, attemptId: "standalone-locale-attempt" },
+      });
+
+      await expect(
+        control.applyEvent({
+          schemaVersion: "1",
+          eventId: "standalone-locale-attempt-finish",
+          runId,
+          actor: { id: "planner-1", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId,
+            attemptId: "standalone-locale-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["standalone-locale-evidence"],
+          },
+          evidence: [
+            {
+              id: "standalone-locale-evidence",
+              kind: "command_execution",
+              artifactIds: [],
+              provenance: "external-runner",
+              reference: reference("standalone-locale-command"),
+            },
+          ],
+        }),
+      ).resolves.toMatchObject({ accepted: true });
+    } finally {
+      if (previousLocale === undefined) delete process.env.LC_ALL;
+      else process.env.LC_ALL = previousLocale;
+    }
+  });
+
   it("planner の schema-valid outcome から新しい implementer Run Node を作る", async () => {
     const { root, control } = await createControlPlane();
     const started = await control.start({

--- a/packages/cli/src/__tests__/run-graph-control-plane.test.ts
+++ b/packages/cli/src/__tests__/run-graph-control-plane.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { gitFixtureEnvironment } from "./git-fixture.js";
 import { execFile } from "node:child_process";
@@ -6,10 +7,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import {
+  canonicalJsonStringify,
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   GANTT_DIR,
   RUN_GRAPH_DIR,
   RUN_GRAPH_RUNS_DIR,
+  type RunGraphRunnerCommandInput,
 } from "@gh-gantt/shared";
 import { RunGraphControlPlane, type DispatchClaimAuthority } from "../run-graph/control-plane.js";
 import { GraphContractStore } from "../store/graph-contract.js";
@@ -3103,6 +3106,75 @@ describe("[NFR-STABILITY-014-AC9] claim lifecycle audit と completion fencing",
       },
     });
     await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 2, claims: [{}] });
+  });
+
+  it("key 順を変えた claimed completion の exact retry を canonical binding に収束させる", async () => {
+    const { root, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "canonical-key-order-completion",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["canonical-key-order-evidence"],
+      },
+      evidence: [commandEvidence("canonical-key-order-evidence")],
+    } satisfies RunGraphRunnerCommandInput;
+    const evidence = completion.evidence[0]!;
+    const reordered = {
+      evidence: [
+        {
+          reference: {
+            byteLength: evidence.reference.byteLength,
+            sha256: evidence.reference.sha256,
+            uri: evidence.reference.uri,
+            kind: evidence.reference.kind,
+          },
+          provenance: evidence.provenance,
+          artifactIds: evidence.artifactIds,
+          kind: evidence.kind,
+          id: evidence.id,
+        },
+      ],
+      command: {
+        evidenceIds: completion.command.evidenceIds,
+        artifactIds: completion.command.artifactIds,
+        outcome: completion.command.outcome,
+        attemptId: completion.command.attemptId,
+        nodeId: completion.command.nodeId,
+        type: completion.command.type,
+      },
+      actor: { role: completion.actor.role, id: completion.actor.id },
+      runId: completion.runId,
+      eventId: completion.eventId,
+      schemaVersion: completion.schemaVersion,
+    } satisfies RunGraphRunnerCommandInput;
+    const expectedFingerprint = createHash("sha256")
+      .update(canonicalJsonStringify(completion))
+      .digest("hex");
+
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: true });
+    await expect(
+      control.applyClaimedEvent(reordered, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: true });
+
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    const accepted = journal.acceptedEvents.filter((event) => event.eventId === completion.eventId);
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0]?.dispatchAuthorization?.commandFingerprint).toBe(expectedFingerprint);
   });
 
   it("receipt publish 後に reclaim された exact retry は旧 claim 継続 proof を返さない", async () => {

--- a/packages/cli/src/__tests__/run-graph-control-plane.test.ts
+++ b/packages/cli/src/__tests__/run-graph-control-plane.test.ts
@@ -1,16 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { gitFixtureEnvironment } from "./git-fixture.js";
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   GANTT_DIR,
   RUN_GRAPH_DIR,
   RUN_GRAPH_RUNS_DIR,
 } from "@gh-gantt/shared";
-import { RunGraphControlPlane } from "../run-graph/control-plane.js";
+import { RunGraphControlPlane, type DispatchClaimAuthority } from "../run-graph/control-plane.js";
 import { GraphContractStore } from "../store/graph-contract.js";
 import { RunGraphEventStore } from "../store/run-graph.js";
+import {
+  DispatchClaimStore,
+  createDispatchClaimStoreDependencies,
+  type DispatchClaimStoreDependencies,
+} from "../store/dispatch-claims.js";
+
+const execFileAsync = promisify(execFile);
 
 const timestamp = "2026-07-30T00:00:00.000Z";
 
@@ -38,6 +48,102 @@ const reference = (name: string) => ({
   sha256: `sha256:${"d".repeat(64)}`,
   byteLength: 256,
 });
+
+async function createClaimedControlPlane(
+  storeOverrides: Partial<DispatchClaimStoreDependencies> = {},
+) {
+  const root = await mkdtemp(join(tmpdir(), "gh-gantt-claimed-control-"));
+  await execFileAsync("git", ["init", root], { env: gitFixtureEnvironment() });
+  await mkdir(join(root, GANTT_DIR), { recursive: true });
+  await writeFile(
+    join(root, GANTT_DIR, "gantt.config.json"),
+    `${JSON.stringify({
+      version: "1",
+      project: {
+        name: "fixture",
+        github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+      },
+      sync: {
+        auto_create_issues: false,
+        field_mapping: { start_date: "Start", end_date: "End" },
+      },
+      task_types: {
+        task: { label: "Task", display: "bar", color: "#000", github_label: null },
+      },
+      type_hierarchy: { task: [] },
+      statuses: { field_name: "Status", values: { Todo: { color: "#000", done: false } } },
+      gantt: {
+        default_view: "month",
+        working_days: [1, 2, 3, 4, 5],
+        colors: { critical_path: "#000", on_track: "#000", at_risk: "#000", overdue: "#000" },
+      },
+      dispatch: { max_concurrency: 1 },
+    })}\n`,
+  );
+  await new GraphContractStore(root).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+  const claims = new DispatchClaimStore(
+    root,
+    createDispatchClaimStoreDependencies({
+      now: () => "2026-08-02T00:00:00.000Z",
+      nextId: () => "claim-ready-frontier",
+      readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+      ...storeOverrides,
+    }),
+  );
+  const control = new RunGraphControlPlane(root, deterministicDependencies(), claims);
+  const runId = await startRun(control, "claimed-fixture-start");
+  const started = await control.inspect(runId);
+  const nodeId = started.currentNode?.id;
+  if (!nodeId) throw new Error("current node が必要です");
+  await control.applyEvent({
+    schemaVersion: "1",
+    eventId: "claimed-fixture-attempt-start",
+    runId,
+    actor: { id: "task-runner", role: "planner" },
+    command: { type: "attempt_started", nodeId, attemptId: "planner-attempt" },
+  });
+  const claimed = await claims.claim({
+    schemaVersion: "1",
+    eventId: "claimed-fixture-claim",
+    expectedEntityVersion: 0,
+    taskId: "stanah/gh-gantt#328",
+    repository: "stanah/gh-gantt",
+    state: "Todo",
+    ownerId: "task-runner",
+    workspaceId: "workspace:ready-frontier",
+    runId,
+    leaseDurationSeconds: 300,
+    dispatchPlanId: "dispatch-plan:ready-frontier",
+    dispatchPlanVersion: "1",
+    snapshotFingerprint: "d".repeat(64),
+  });
+  if (!claimed.accepted) throw new Error(claimed.message);
+  return { root, claims, control, runId, nodeId, claimed };
+}
+
+function commandEvidence(id: string) {
+  return {
+    id,
+    kind: "command_execution" as const,
+    artifactIds: [],
+    provenance: "task-runner",
+    reference: reference(id),
+  };
+}
+
+function withClaimAuthorityOverrides(
+  claims: DispatchClaimStore,
+  overrides: Partial<DispatchClaimAuthority>,
+): DispatchClaimAuthority {
+  return new Proxy(claims, {
+    get(target, property) {
+      const override = overrides[property as keyof DispatchClaimAuthority];
+      if (override) return override;
+      const value = Reflect.get(target, property, target) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as DispatchClaimAuthority;
+}
 
 type ExecutionRole = "planner" | "implementer" | "executor" | "reviewer";
 
@@ -2167,5 +2273,1429 @@ describe("[NFR-STABILITY-014-AC7] 旧 PR observation は未証明 linkage とし
         contract: { planId: "dev-role-fixed", planVersion: "1", schemaVersion: "1" },
       }),
     ).resolves.toMatchObject({ accepted: true, view: { state: "running", revision: 1 } });
+  });
+});
+
+describe("[NFR-STABILITY-014-AC9] claim lifecycle audit と completion fencing", () => {
+  it("claim audit は fixed dev-role topology を変えず、reclaim 後の旧 completion を拒否する", async () => {
+    let now = "2026-08-02T00:00:00.000Z";
+    const root = await mkdtemp(join(tmpdir(), "gh-gantt-claimed-control-"));
+    await execFileAsync("git", ["init", root], { env: gitFixtureEnvironment() });
+    await mkdir(join(root, GANTT_DIR), { recursive: true });
+    await writeFile(
+      join(root, GANTT_DIR, "gantt.config.json"),
+      `${JSON.stringify(
+        {
+          version: "1",
+          project: {
+            name: "fixture",
+            github: { owner: "stanah", repo: "gh-gantt", project_number: 1 },
+          },
+          sync: {
+            auto_create_issues: false,
+            field_mapping: { start_date: "Start", end_date: "End" },
+          },
+          task_types: {
+            task: { label: "Task", display: "bar", color: "#000", github_label: null },
+          },
+          type_hierarchy: { task: [] },
+          statuses: { field_name: "Status", values: { Todo: { color: "#000", done: false } } },
+          gantt: {
+            default_view: "month",
+            working_days: [1, 2, 3, 4, 5],
+            colors: { critical_path: "#000", on_track: "#000", at_risk: "#000", overdue: "#000" },
+          },
+          dispatch: { max_concurrency: 1 },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await new GraphContractStore(root).install(FIXED_DEV_ROLE_GRAPH_CONTRACT);
+    const claims = new DispatchClaimStore(
+      root,
+      createDispatchClaimStoreDependencies({
+        now: () => now,
+        nextId: () => "claim-329",
+        readCurrentSnapshotFingerprint: async () => "d".repeat(64),
+      }),
+    );
+    const control = new RunGraphControlPlane(root, deterministicDependencies(), claims);
+    const runId = await startRun(control, "claimed-run-start");
+    const started = await control.inspect(runId);
+    const nodeId = started.currentNode?.id;
+    if (!nodeId) throw new Error("current node が必要です");
+    await control.applyEvent({
+      schemaVersion: "1",
+      eventId: "claimed-attempt-start",
+      runId,
+      actor: { id: "planner-claimed", role: "planner" },
+      command: { type: "attempt_started", nodeId, attemptId: "attempt-claimed" },
+    });
+
+    const claimed = await claims.claim({
+      schemaVersion: "1",
+      eventId: "registry-claim",
+      expectedEntityVersion: 0,
+      taskId: "stanah/gh-gantt#328",
+      repository: "stanah/gh-gantt",
+      state: "Todo",
+      ownerId: "planner-claimed",
+      workspaceId: "workspace:claimed",
+      runId,
+      leaseDurationSeconds: 60,
+      dispatchPlanId: "dispatch-plan:test",
+      dispatchPlanVersion: "1",
+      snapshotFingerprint: "d".repeat(64),
+    });
+    if (!claimed.accepted) throw new Error(claimed.message);
+    const audit = await control.recordClaimAudit({
+      schemaVersion: "1",
+      eventId: `audit:${claimed.eventId}`,
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      receipt: claimed,
+    });
+    expect(audit).toMatchObject({
+      accepted: true,
+      view: {
+        revision: 3,
+        currentNode: { id: nodeId, state: "running", activeAttemptId: "attempt-claimed" },
+        nodes: { total: 1 },
+        claimAudits: {
+          total: 1,
+          items: [
+            {
+              command: {
+                type: "claim_acquired",
+                claim: {
+                  taskId: "stanah/gh-gantt#328",
+                  ownerId: "planner-claimed",
+                  runId,
+                  fencingToken: 1,
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    await expect(
+      control.recordClaimAudit({
+        schemaVersion: "1",
+        eventId: `audit:${claimed.eventId}`,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        receipt: claimed,
+      }),
+    ).resolves.toEqual(audit);
+    await expect(
+      control.recordClaimAudit({
+        schemaVersion: "1",
+        eventId: `audit:${claimed.eventId}:alternate`,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        receipt: claimed,
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "duplicate_event", stateUnchanged: true });
+    await expect(
+      control.recordClaimAudit({
+        schemaVersion: "1",
+        eventId: "audit:forged-registry-receipt",
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        receipt: { ...claimed, eventId: "forged-registry-receipt" },
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+
+    const beforeBypass = await control.inspect(runId);
+    await expect(
+      control.applyEvent({
+        schemaVersion: "1",
+        eventId: "raw-completion-bypass",
+        runId,
+        actor: { id: "planner-claimed", role: "planner" },
+        command: {
+          type: "attempt_finished",
+          nodeId,
+          attemptId: "attempt-claimed",
+          outcome: "succeeded",
+          artifactIds: [],
+          evidenceIds: ["cross-run-command-evidence"],
+        },
+        evidence: [
+          {
+            id: "cross-run-command-evidence",
+            kind: "command_execution",
+            artifactIds: [],
+            provenance: "cross-runner",
+            reference: reference("cross-run-command"),
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({
+      accepted: false,
+      code: "stale_claim",
+      stateUnchanged: true,
+      view: { revision: beforeBypass.revision, activeAttempt: { state: "running" } },
+    });
+
+    const otherRunId = await startRun(control, "other-run-start");
+    const otherView = await control.inspect(otherRunId);
+    const otherNodeId = otherView.currentNode?.id;
+    if (!otherNodeId) throw new Error("other current node が必要です");
+    await control.applyEvent({
+      schemaVersion: "1",
+      eventId: "other-attempt-start",
+      runId: otherRunId,
+      actor: { id: "planner-claimed", role: "planner" },
+      command: { type: "attempt_started", nodeId: otherNodeId, attemptId: "other-attempt" },
+    });
+    await expect(
+      control.applyClaimedEvent(
+        {
+          schemaVersion: "1",
+          eventId: "cross-run-completion",
+          runId: otherRunId,
+          actor: { id: "planner-claimed", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId: otherNodeId,
+            attemptId: "other-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["stale-command-evidence"],
+          },
+          evidence: [
+            {
+              id: "stale-command-evidence",
+              kind: "command_execution",
+              artifactIds: [],
+              provenance: "stale-runner",
+              reference: reference("stale-command"),
+            },
+          ],
+        },
+        {
+          claimId: claimed.claim.claimId,
+          fencingToken: claimed.claim.fencingToken,
+          ownerId: claimed.claim.ownerId,
+          runId,
+        },
+        1,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+
+    now = "2026-08-02T00:02:00.000Z";
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "registry-reclaim",
+      expectedEntityVersion: 1,
+      claimId: claimed.claim.claimId,
+      reason: "expired",
+    });
+    if (!reclaimed.accepted || !reclaimed.claim) throw new Error("reclaim receipt が必要です");
+    const reclaimAudit = await control.recordClaimAudit({
+      schemaVersion: "1",
+      eventId: `audit:${reclaimed.eventId}`,
+      actor: { id: "orchestrator-1", role: "orchestrator" },
+      receipt: { ...reclaimed, claim: reclaimed.claim },
+    });
+    expect(reclaimAudit).toMatchObject({
+      accepted: true,
+      view: {
+        claimAudits: {
+          total: 2,
+          items: [
+            {},
+            {
+              command: {
+                type: "claim_reclaimed",
+                reclaimReason: "expired",
+                claim: { ownerId: "planner-claimed", runId, taskId: "stanah/gh-gantt#328" },
+              },
+            },
+          ],
+        },
+      },
+    });
+    const beforeStale = await control.inspect(runId);
+    await expect(
+      control.applyClaimedEvent(
+        {
+          schemaVersion: "1",
+          eventId: "stale-completion",
+          runId,
+          actor: { id: "planner-claimed", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId,
+            attemptId: "attempt-claimed",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["stale-completion-command"],
+          },
+          evidence: [
+            {
+              id: "stale-completion-command",
+              kind: "command_execution",
+              artifactIds: [],
+              provenance: "stale-completion-runner",
+              reference: reference("stale-completion-command"),
+            },
+          ],
+        },
+        {
+          claimId: claimed.claim.claimId,
+          fencingToken: claimed.claim.fencingToken,
+          ownerId: claimed.claim.ownerId,
+          runId,
+        },
+        2,
+      ),
+    ).resolves.toMatchObject({
+      accepted: false,
+      code: "stale_claim",
+      stateUnchanged: true,
+      view: { revision: beforeStale.revision, activeAttempt: { state: "running" } },
+    });
+  });
+
+  it("同じ claim で複数 event を認可し、更新 proof で heartbeat と release を継続する", async () => {
+    const { claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const first = await control.applyClaimedEvent(
+      {
+        schemaVersion: "1",
+        eventId: "claimed-planner-finish",
+        runId,
+        actor: { id: "task-runner", role: "planner" },
+        command: {
+          type: "attempt_finished",
+          nodeId,
+          attemptId: "planner-attempt",
+          outcome: "succeeded",
+          artifactIds: [],
+          evidenceIds: ["claimed-planner-command"],
+        },
+        evidence: [commandEvidence("claimed-planner-command")],
+      },
+      {
+        claimId: claimed.claim.claimId,
+        fencingToken: claimed.claim.fencingToken,
+        ownerId: claimed.claim.ownerId,
+        runId,
+      },
+      claimed.entityVersion,
+    );
+    expect(first).toMatchObject({
+      accepted: true,
+      claimAuthorization: {
+        receipt: { entityVersion: 2, claim: { entityVersion: 2, fencingToken: 2 } },
+        proof: { fencingToken: 2 },
+        audit: { recorded: true },
+      },
+    });
+    if (!first.accepted || !first.claimAuthorization) throw new Error("更新 proof が必要です");
+
+    const outcome = await control.applyClaimedEvent(
+      {
+        schemaVersion: "1",
+        eventId: "claimed-planner-outcome",
+        runId,
+        actor: { id: "task-runner", role: "planner" },
+        command: {
+          type: "node_outcome_submitted",
+          nodeId,
+          attemptId: "planner-attempt",
+          outcome: "plan_valid",
+          artifactIds: ["claimed-plan"],
+          evidenceIds: ["claimed-plan-validation"],
+        },
+        artifacts: [
+          {
+            id: "claimed-plan",
+            schemaId: "dev-role.plan",
+            schemaVersion: "1",
+            derivedFromArtifactIds: [],
+            reference: reference("claimed-plan"),
+          },
+        ],
+        evidence: [
+          {
+            id: "claimed-plan-validation",
+            kind: "artifact_validation",
+            artifactIds: ["claimed-plan"],
+            provenance: "task-runner",
+            reference: reference("claimed-plan-validation"),
+          },
+        ],
+      },
+      first.claimAuthorization.proof,
+      first.claimAuthorization.receipt.entityVersion,
+    );
+    expect(outcome).toMatchObject({
+      accepted: true,
+      view: { currentNode: { contractNodeId: "implementer" } },
+      claimAuthorization: { proof: { fencingToken: 3 } },
+    });
+    if (!outcome.accepted || !outcome.claimAuthorization)
+      throw new Error("outcome 更新 proof が必要です");
+    const implementerNodeId = outcome.view.currentNode?.id;
+    if (!implementerNodeId) throw new Error("implementer node が必要です");
+    await control.applyEvent({
+      schemaVersion: "1",
+      eventId: "claimed-implementer-start",
+      runId,
+      actor: { id: "task-runner", role: "implementer" },
+      command: {
+        type: "attempt_started",
+        nodeId: implementerNodeId,
+        attemptId: "implementer-attempt",
+      },
+    });
+    const implementerFinished = await control.applyClaimedEvent(
+      {
+        schemaVersion: "1",
+        eventId: "claimed-implementer-finish",
+        runId,
+        actor: { id: "task-runner", role: "implementer" },
+        command: {
+          type: "attempt_finished",
+          nodeId: implementerNodeId,
+          attemptId: "implementer-attempt",
+          outcome: "succeeded",
+          artifactIds: [],
+          evidenceIds: ["claimed-implementer-command"],
+        },
+        evidence: [commandEvidence("claimed-implementer-command")],
+      },
+      outcome.claimAuthorization.proof,
+      outcome.claimAuthorization.receipt.entityVersion,
+    );
+    expect(implementerFinished).toMatchObject({
+      accepted: true,
+      claimAuthorization: { proof: { fencingToken: 4 } },
+    });
+    if (!implementerFinished.accepted || !implementerFinished.claimAuthorization)
+      throw new Error("implementer 更新 proof が必要です");
+
+    const heartbeat = await claims.heartbeat({
+      schemaVersion: "1",
+      eventId: "claimed-after-events-heartbeat",
+      expectedEntityVersion: implementerFinished.claimAuthorization.receipt.entityVersion,
+      proof: implementerFinished.claimAuthorization.proof,
+      leaseDurationSeconds: 300,
+    });
+    expect(heartbeat).toMatchObject({
+      accepted: true,
+      entityVersion: 5,
+      claim: { fencingToken: 5 },
+    });
+    if (!heartbeat.accepted || !heartbeat.claim) throw new Error("heartbeat claim が必要です");
+    const released = await claims.release({
+      schemaVersion: "1",
+      eventId: "claimed-after-events-release",
+      expectedEntityVersion: heartbeat.entityVersion,
+      proof: {
+        claimId: heartbeat.claim.claimId,
+        fencingToken: heartbeat.claim.fencingToken,
+        ownerId: heartbeat.claim.ownerId,
+        runId: heartbeat.claim.runId,
+      },
+    });
+    expect(released).toMatchObject({ accepted: true, entityVersion: 6 });
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 6, claims: [] });
+  });
+
+  it("domain reject は registry/journal を変更せず、同じ proof の修正 retry を受理する", async () => {
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const initialRegistry = await claims.snapshot();
+    const initialJournal = await new RunGraphEventStore(root).readJournal(runId);
+    await expect(
+      control.applyClaimedEvent(
+        {
+          schemaVersion: "1",
+          eventId: "claimed-missing-evidence",
+          runId,
+          actor: { id: "task-runner", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId,
+            attemptId: "planner-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: [],
+          },
+        },
+        proof,
+        claimed.entityVersion,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "evidence_required" });
+    await expect(claims.snapshot()).resolves.toEqual(initialRegistry);
+    await expect(new RunGraphEventStore(root).readJournal(runId)).resolves.toEqual(initialJournal);
+
+    await expect(
+      control.applyClaimedEvent(
+        {
+          schemaVersion: "1",
+          eventId: "claimed-stale-attempt",
+          runId,
+          actor: { id: "task-runner", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId,
+            attemptId: "other-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["claimed-stale-command"],
+          },
+          evidence: [commandEvidence("claimed-stale-command")],
+        },
+        proof,
+        claimed.entityVersion,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_attempt" });
+    await expect(claims.snapshot()).resolves.toEqual(initialRegistry);
+    await expect(new RunGraphEventStore(root).readJournal(runId)).resolves.toEqual(initialJournal);
+
+    const correctedFinish = await control.applyClaimedEvent(
+      {
+        schemaVersion: "1",
+        eventId: "claimed-corrected-finish",
+        runId,
+        actor: { id: "task-runner", role: "planner" },
+        command: {
+          type: "attempt_finished",
+          nodeId,
+          attemptId: "planner-attempt",
+          outcome: "succeeded",
+          artifactIds: [],
+          evidenceIds: ["claimed-corrected-command"],
+        },
+        evidence: [commandEvidence("claimed-corrected-command")],
+      },
+      proof,
+      claimed.entityVersion,
+    );
+    if (!correctedFinish.accepted || !correctedFinish.claimAuthorization)
+      throw new Error("修正後 completion が必要です");
+    const afterFinishRegistry = await claims.snapshot();
+
+    const outcomeBase = {
+      schemaVersion: "1" as const,
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "node_outcome_submitted" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        artifactIds: ["claimed-retry-plan"],
+        evidenceIds: ["claimed-retry-validation"],
+      },
+      artifacts: [
+        {
+          id: "claimed-retry-plan",
+          schemaId: "dev-role.plan",
+          schemaVersion: "1" as const,
+          derivedFromArtifactIds: [],
+          reference: reference("claimed-retry-plan"),
+        },
+      ],
+      evidence: [
+        {
+          id: "claimed-retry-validation",
+          kind: "artifact_validation" as const,
+          artifactIds: ["claimed-retry-plan"],
+          provenance: "task-runner",
+          reference: reference("claimed-retry-validation"),
+        },
+      ],
+    };
+    await expect(
+      control.applyClaimedEvent(
+        {
+          ...outcomeBase,
+          eventId: "claimed-invalid-outcome",
+          command: { ...outcomeBase.command, outcome: "not-a-contract-edge" },
+        },
+        correctedFinish.claimAuthorization.proof,
+        correctedFinish.claimAuthorization.receipt.entityVersion,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "invalid_transition" });
+    await expect(claims.snapshot()).resolves.toEqual(afterFinishRegistry);
+
+    await expect(
+      control.applyClaimedEvent(
+        {
+          ...outcomeBase,
+          eventId: "claimed-corrected-outcome",
+          command: { ...outcomeBase.command, outcome: "plan_valid" },
+        },
+        correctedFinish.claimAuthorization.proof,
+        correctedFinish.claimAuthorization.receipt.entityVersion,
+      ),
+    ).resolves.toMatchObject({
+      accepted: true,
+      claimAuthorization: { proof: { fencingToken: 3 } },
+    });
+  });
+
+  it("append 競合は pending を解除し、同じ proof で修正 event を継続できる", async () => {
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const originalAppend = RunGraphEventStore.prototype.appendAccepted;
+    let injected = false;
+    const appendSpy = vi
+      .spyOn(RunGraphEventStore.prototype, "appendAccepted")
+      .mockImplementation(async (event) => {
+        if (event.eventId === "claimed-conflicted-finish" && !injected) {
+          injected = true;
+          await originalAppend.call(new RunGraphEventStore(root), {
+            ...event,
+            eventId: "competing-finish",
+          });
+        }
+        return originalAppend.call(new RunGraphEventStore(root), event);
+      });
+    try {
+      const conflict = await control.applyClaimedEvent(
+        {
+          schemaVersion: "1",
+          eventId: "claimed-conflicted-finish",
+          runId,
+          actor: { id: "task-runner", role: "planner" },
+          command: {
+            type: "attempt_finished",
+            nodeId,
+            attemptId: "planner-attempt",
+            outcome: "succeeded",
+            artifactIds: [],
+            evidenceIds: ["claimed-conflict-command"],
+          },
+          evidence: [commandEvidence("claimed-conflict-command")],
+        },
+        {
+          claimId: claimed.claim.claimId,
+          fencingToken: claimed.claim.fencingToken,
+          ownerId: claimed.claim.ownerId,
+          runId,
+        },
+        claimed.entityVersion,
+      );
+      expect(conflict).toMatchObject({
+        accepted: false,
+        code: "stale_attempt",
+        view: { activeAttempt: { state: "succeeded" } },
+      });
+      await expect(claims.snapshot()).resolves.toMatchObject({
+        entityVersion: 1,
+        claims: [{ claimId: claimed.claim.claimId, fencingToken: 1 }],
+        pendingAuthorizations: [],
+      });
+
+      await expect(
+        control.applyClaimedEvent(
+          {
+            schemaVersion: "1",
+            eventId: "claimed-after-conflict-outcome",
+            runId,
+            actor: { id: "task-runner", role: "planner" },
+            command: {
+              type: "node_outcome_submitted",
+              nodeId,
+              attemptId: "planner-attempt",
+              outcome: "plan_valid",
+              artifactIds: ["claimed-after-conflict-plan"],
+              evidenceIds: ["claimed-after-conflict-validation"],
+            },
+            artifacts: [
+              {
+                id: "claimed-after-conflict-plan",
+                schemaId: "dev-role.plan",
+                schemaVersion: "1",
+                derivedFromArtifactIds: [],
+                reference: reference("claimed-after-conflict-plan"),
+              },
+            ],
+            evidence: [
+              {
+                id: "claimed-after-conflict-validation",
+                kind: "artifact_validation",
+                artifactIds: ["claimed-after-conflict-plan"],
+                provenance: "task-runner",
+                reference: reference("claimed-after-conflict-validation"),
+              },
+            ],
+          },
+          {
+            claimId: claimed.claim.claimId,
+            fencingToken: claimed.claim.fencingToken,
+            ownerId: claimed.claim.ownerId,
+            runId,
+          },
+          claimed.entityVersion,
+        ),
+      ).resolves.toMatchObject({
+        accepted: true,
+        view: { currentNode: { contractNodeId: "implementer" } },
+        claimAuthorization: { proof: { fencingToken: 2 } },
+      });
+    } finally {
+      appendSpy.mockRestore();
+    }
+  });
+
+  it("dispatch config 有効時は claim 取得との race でも raw completion を fail-closed にする", async () => {
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const released = await claims.release({
+      schemaVersion: "1",
+      eventId: "raw-race-release",
+      expectedEntityVersion: claimed.entityVersion,
+      proof,
+    });
+    if (!released.accepted) throw new Error(released.message);
+
+    const rawInput = {
+      schemaVersion: "1" as const,
+      eventId: "raw-race-completion",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["raw-race-evidence"],
+      },
+      evidence: [commandEvidence("raw-race-evidence")],
+    };
+    const [raw, reacquired] = await Promise.all([
+      control.applyEvent(rawInput),
+      claims.claim({
+        schemaVersion: "1",
+        eventId: "raw-race-reclaim-owner",
+        expectedEntityVersion: released.entityVersion,
+        taskId: claimed.claim.taskId,
+        repository: claimed.claim.repository,
+        state: claimed.claim.state,
+        ownerId: claimed.claim.ownerId,
+        workspaceId: "workspace:raw-race",
+        runId,
+        leaseDurationSeconds: 300,
+        dispatchPlanId: "dispatch-plan:raw-race",
+        dispatchPlanVersion: "1",
+        snapshotFingerprint: "d".repeat(64),
+      }),
+    ]);
+    expect(raw).toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+    expect(reacquired).toMatchObject({ accepted: true });
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(journal.acceptedEvents.some((event) => event.eventId === rawInput.eventId)).toBe(false);
+  });
+
+  it("同一 control plane の concurrent completion は event/binding を混線させない", async () => {
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = (suffix: string) => ({
+      schemaVersion: "1" as const,
+      eventId: `concurrent-${suffix}`,
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: [`concurrent-evidence-${suffix}`],
+      },
+      evidence: [commandEvidence(`concurrent-evidence-${suffix}`)],
+    });
+    const results = await Promise.all([
+      control.applyClaimedEvent(completion("a"), proof, claimed.entityVersion),
+      control.applyClaimedEvent(completion("b"), proof, claimed.entityVersion),
+    ]);
+    expect(results.filter((result) => result.accepted)).toHaveLength(1);
+    expect(results.filter((result) => !result.accepted)).toMatchObject([
+      { code: "stale_claim", stateUnchanged: true },
+    ]);
+    const acceptedInput = results[0]!.accepted ? completion("a") : completion("b");
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    const completionEvents = journal.acceptedEvents.filter(
+      (event) => event.command.type === "attempt_finished",
+    );
+    expect(completionEvents).toHaveLength(1);
+    expect(completionEvents[0]).toMatchObject({
+      eventId: acceptedInput.eventId,
+      command: acceptedInput.command,
+      dispatchAuthorization: {
+        claimId: proof.claimId,
+        fencingToken: proof.fencingToken,
+        ownerId: proof.ownerId,
+        runId,
+      },
+    });
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 2, claims: [{}] });
+  });
+
+  it("receipt publish 後に reclaim された exact retry は旧 claim 継続 proof を返さない", async () => {
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane();
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "published-before-reclaim",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["published-before-reclaim-evidence"],
+      },
+      evidence: [commandEvidence("published-before-reclaim-evidence")],
+    };
+    const committed = await control.applyClaimedEvent(completion, proof, claimed.entityVersion);
+    if (!committed.accepted || !committed.claimAuthorization)
+      throw new Error("publish 済み authorization が必要です");
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "reclaim-after-published-receipt",
+      expectedEntityVersion: committed.claimAuthorization.receipt.entityVersion,
+      claimId: claimed.claim.claimId,
+      reason: "owner_stopped",
+      ownerStoppedEvidenceId: "process-exit:published-owner",
+    });
+    expect(reclaimed).toMatchObject({ accepted: true, entityVersion: 3 });
+
+    const retry = await control.applyClaimedEvent(completion, proof, claimed.entityVersion);
+    expect(retry).toMatchObject({
+      accepted: true,
+      view: { activeAttempt: { state: "succeeded" } },
+    });
+    expect(retry).not.toHaveProperty("claimAuthorization");
+    await expect(
+      control.applyClaimedEvent(
+        { ...completion, eventId: "new-event-after-published-reclaim" },
+        committed.claimAuthorization.proof,
+        reclaimed.entityVersion,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim", stateUnchanged: true });
+
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      journal.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+    expect(
+      journal.acceptedEvents.some((event) => event.eventId === "new-event-after-published-reclaim"),
+    ).toBe(false);
+  });
+
+  it("pending 永続化後・append 前 crash は heartbeat を止め、同一 event retry だけを許可する", async () => {
+    let crashBeforeAppend = false;
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane({
+      afterAuthorizationPendingPublish: async () => {
+        if (crashBeforeAppend) throw new Error("authorization interrupted before append");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "crash-before-append",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["crash-before-append-evidence"],
+      },
+      evidence: [commandEvidence("crash-before-append-evidence")],
+    };
+
+    crashBeforeAppend = true;
+    await expect(control.applyClaimedEvent(completion, proof, 1)).resolves.toMatchObject({
+      accepted: false,
+      code: "stale_attempt",
+      stateUnchanged: true,
+    });
+    crashBeforeAppend = false;
+    const afterCrash = await new RunGraphEventStore(root).readJournal(runId);
+    expect(afterCrash.acceptedEvents.some((event) => event.eventId === completion.eventId)).toBe(
+      false,
+    );
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      pendingAuthorizations: [{ eventId: completion.eventId, claimId: proof.claimId }],
+    });
+    await expect(
+      claims.heartbeat({
+        schemaVersion: "1",
+        eventId: "heartbeat-before-exact-retry",
+        expectedEntityVersion: 1,
+        proof,
+        leaseDurationSeconds: 300,
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "authorization_pending" });
+
+    await expect(control.applyClaimedEvent(completion, proof, 1)).resolves.toMatchObject({
+      accepted: true,
+      claimAuthorization: { proof: { fencingToken: 2 } },
+      view: { activeAttempt: { state: "succeeded" } },
+    });
+    const afterRetry = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      afterRetry.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+  });
+
+  it("pending exact retry が state 遷移で拒否された場合は pending を解除して修正を許可する", async () => {
+    let crashBeforeAppend = true;
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane({
+      afterAuthorizationPendingPublish: async () => {
+        if (crashBeforeAppend) throw new Error("authorization interrupted before append");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "pending-invalidated-completion",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["pending-invalidated-evidence"],
+      },
+      evidence: [commandEvidence("pending-invalidated-evidence")],
+    };
+
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_attempt" });
+    crashBeforeAppend = false;
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      pendingAuthorizations: [{ eventId: completion.eventId, claimId: proof.claimId }],
+    });
+
+    await expect(
+      control.applyEvent({
+        schemaVersion: "1",
+        eventId: "pending-invalidated-pause",
+        runId,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        command: {
+          type: "run_paused",
+          checkpointArtifactId: "pending-invalidated-checkpoint",
+          evidenceIds: ["pending-invalidated-checkpoint-evidence"],
+          reason: "pending 中に accepted state を変更する",
+        },
+        artifacts: [
+          {
+            id: "pending-invalidated-checkpoint",
+            schemaId: "run.checkpoint",
+            schemaVersion: "1",
+            derivedFromArtifactIds: [],
+            reference: reference("pending-invalidated-checkpoint"),
+          },
+        ],
+        evidence: [
+          {
+            id: "pending-invalidated-checkpoint-evidence",
+            kind: "checkpoint",
+            artifactIds: ["pending-invalidated-checkpoint"],
+            provenance: "orchestrator-1",
+            reference: reference("pending-invalidated-checkpoint-evidence"),
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ accepted: true, view: { state: "paused" } });
+
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: false, code: "invalid_transition" });
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: [{ claimId: proof.claimId, fencingToken: 1 }],
+      pendingAuthorizations: [],
+    });
+
+    const heartbeat = await claims.heartbeat({
+      schemaVersion: "1",
+      eventId: "pending-invalidated-heartbeat",
+      expectedEntityVersion: 1,
+      proof,
+      leaseDurationSeconds: 300,
+    });
+    if (!heartbeat.accepted) throw new Error(heartbeat.message);
+    await expect(
+      control.applyEvent({
+        schemaVersion: "1",
+        eventId: "pending-invalidated-resume",
+        runId,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        command: {
+          type: "run_resumed",
+          checkpointArtifactId: "pending-invalidated-checkpoint",
+          evidenceIds: ["pending-invalidated-checkpoint-evidence"],
+          sideEffectState: "not_started",
+        },
+      }),
+    ).resolves.toMatchObject({ accepted: true, view: { state: "running" } });
+    await expect(
+      control.applyClaimedEvent(
+        { ...completion, eventId: "pending-invalidated-corrected-completion" },
+        {
+          claimId: heartbeat.claim.claimId,
+          fencingToken: heartbeat.claim.fencingToken,
+          ownerId: heartbeat.claim.ownerId,
+          runId: heartbeat.claim.runId,
+        },
+        heartbeat.entityVersion,
+      ),
+    ).resolves.toMatchObject({
+      accepted: true,
+      claimAuthorization: { proof: { fencingToken: 3 } },
+    });
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(journal.acceptedEvents.some((event) => event.eventId === completion.eventId)).toBe(
+      false,
+    );
+  });
+
+  it("B が journal absent 観測後に A append crash と reclaim を挟んでも historical receipt へ収束する", async () => {
+    let crashBeforeFinalize = true;
+    const {
+      root,
+      claims,
+      control: controlA,
+      runId,
+      nodeId,
+      claimed,
+    } = await createClaimedControlPlane({
+      beforeAuthorizationFinalizePublish: async () => {
+        if (crashBeforeFinalize) throw new Error("authorization finalize interrupted");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "concurrent-absent-before-append",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["concurrent-absent-evidence"],
+      },
+      evidence: [commandEvidence("concurrent-absent-evidence")],
+    };
+    let resumeB!: () => void;
+    const waitForA = new Promise<void>((resolveBarrier) => {
+      resumeB = resolveBarrier;
+    });
+    let bObservedAbsent!: () => void;
+    const bObservedAbsentBarrier = new Promise<void>((resolveObserved) => {
+      bObservedAbsent = resolveObserved;
+    });
+    const authorityB = withClaimAuthorityOverrides(claims, {
+      assertCurrentClaim: async (...args) => {
+        bObservedAbsent();
+        await waitForA;
+        return claims.assertCurrentClaim(...args);
+      },
+    });
+    const controlB = new RunGraphControlPlane(root, deterministicDependencies(), authorityB);
+    const retryB = controlB.applyClaimedEvent(completion, proof, claimed.entityVersion);
+    await bObservedAbsentBarrier;
+
+    await expect(
+      controlA.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: true });
+    crashBeforeFinalize = false;
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "concurrent-absent-reclaim",
+      expectedEntityVersion: claimed.entityVersion,
+      claimId: proof.claimId,
+      reason: "owner_stopped",
+      ownerStoppedEvidenceId: "process-exit:concurrent-absent",
+    });
+    expect(reclaimed).toMatchObject({ accepted: true, entityVersion: 2 });
+    resumeB();
+
+    const reconciled = await retryB;
+    expect(reconciled).toMatchObject({ accepted: true });
+    expect(reconciled).not.toHaveProperty("claimAuthorization");
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 3,
+      claims: [],
+      history: [{}, {}, { eventId: completion.eventId, operation: "authorize_event" }],
+    });
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      journal.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+    expect(
+      journal.acceptedEvents.filter((event) => event.eventId === `audit:${completion.eventId}`),
+    ).toHaveLength(1);
+  });
+
+  it("B validation 後に A append crash を挟んでも duplicate append をexact finalizeして単一CASにする", async () => {
+    let crashBeforeFinalize = true;
+    const {
+      root,
+      claims,
+      control: controlA,
+      runId,
+      nodeId,
+      claimed,
+    } = await createClaimedControlPlane({
+      beforeAuthorizationFinalizePublish: async () => {
+        if (crashBeforeFinalize) throw new Error("authorization finalize interrupted");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "concurrent-validated-before-append",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["concurrent-validated-evidence"],
+      },
+      evidence: [commandEvidence("concurrent-validated-evidence")],
+    };
+    let resumeB!: () => void;
+    const waitForA = new Promise<void>((resolveBarrier) => {
+      resumeB = resolveBarrier;
+    });
+    let bValidated!: () => void;
+    const bValidatedBarrier = new Promise<void>((resolveValidated) => {
+      bValidated = resolveValidated;
+    });
+    const authorityB = withClaimAuthorityOverrides(claims, {
+      commitAuthorizedEvent: async (...args) => {
+        bValidated();
+        await waitForA;
+        return claims.commitAuthorizedEvent(...args);
+      },
+    });
+    const controlB = new RunGraphControlPlane(root, deterministicDependencies(), authorityB);
+    const retryB = controlB.applyClaimedEvent(completion, proof, claimed.entityVersion);
+    await bValidatedBarrier;
+
+    await expect(
+      controlA.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: true });
+    crashBeforeFinalize = false;
+    resumeB();
+    const reconciled = await retryB;
+    if (!reconciled.accepted || !reconciled.claimAuthorization)
+      throw new Error("current claim authorization が必要です");
+    expect(reconciled.claimAuthorization).toMatchObject({
+      receipt: { entityVersion: 2, claimContinues: true },
+      proof: { fencingToken: 2 },
+    });
+
+    const [heartbeat, reclaim] = await Promise.all([
+      claims.heartbeat({
+        schemaVersion: "1",
+        eventId: "concurrent-finalized-heartbeat",
+        expectedEntityVersion: 2,
+        proof: reconciled.claimAuthorization.proof,
+        leaseDurationSeconds: 300,
+      }),
+      claims.reclaim({
+        schemaVersion: "1",
+        eventId: "concurrent-finalized-reclaim",
+        expectedEntityVersion: 2,
+        claimId: proof.claimId,
+        reason: "owner_stopped",
+        ownerStoppedEvidenceId: "process-exit:concurrent-finalized",
+      }),
+    ]);
+    expect([heartbeat, reclaim].filter((receipt) => receipt.accepted)).toHaveLength(1);
+    expect([heartbeat, reclaim].filter((receipt) => !receipt.accepted)).toMatchObject([
+      { code: "stale_entity_version", stateUnchanged: true },
+    ]);
+    await expect(claims.verifyReceipt(reconciled.claimAuthorization.receipt)).resolves.toBe(true);
+    const journal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      journal.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+    expect(
+      journal.acceptedEvents.filter((event) => event.eventId === `audit:${completion.eventId}`),
+    ).toHaveLength(1);
+  });
+
+  it("exact caller と journal sequence conflict の場合だけ pending をrollbackする", async () => {
+    let crashBeforeAppend = true;
+    const { claims, control, runId, nodeId, claimed } = await createClaimedControlPlane({
+      afterAuthorizationPendingPublish: async () => {
+        if (crashBeforeAppend) throw new Error("pending before sequence conflict");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "pending-sequence-conflict",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["pending-sequence-conflict-evidence"],
+      },
+      evidence: [commandEvidence("pending-sequence-conflict-evidence")],
+    };
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_attempt" });
+    crashBeforeAppend = false;
+    await expect(
+      control.applyEvent({
+        schemaVersion: "1",
+        eventId: completion.eventId,
+        runId,
+        actor: { id: "orchestrator-1", role: "orchestrator" },
+        command: {
+          type: "run_paused",
+          checkpointArtifactId: "pending-sequence-checkpoint",
+          evidenceIds: ["pending-sequence-checkpoint-evidence"],
+          reason: "同じ event ID の別 raw command を先行させる",
+        },
+        artifacts: [
+          {
+            id: "pending-sequence-checkpoint",
+            schemaId: "run.checkpoint",
+            schemaVersion: "1",
+            derivedFromArtifactIds: [],
+            reference: reference("pending-sequence-checkpoint"),
+          },
+        ],
+        evidence: [
+          {
+            id: "pending-sequence-checkpoint-evidence",
+            kind: "checkpoint",
+            artifactIds: ["pending-sequence-checkpoint"],
+            provenance: "orchestrator-1",
+            reference: reference("pending-sequence-checkpoint-evidence"),
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ accepted: true });
+
+    await expect(
+      control.applyClaimedEvent(
+        {
+          ...completion,
+          command: { ...completion.command, outcome: "failed" as const },
+        },
+        proof,
+        claimed.entityVersion,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "duplicate_event" });
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      pendingAuthorizations: [{ eventId: completion.eventId, claimId: proof.claimId }],
+    });
+
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({ accepted: false, code: "duplicate_event" });
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: [{ claimId: proof.claimId, fencingToken: 1 }],
+      pendingAuthorizations: [],
+    });
+    await expect(
+      claims.heartbeat({
+        schemaVersion: "1",
+        eventId: "pending-sequence-heartbeat",
+        expectedEntityVersion: claimed.entityVersion,
+        proof,
+        leaseDurationSeconds: 300,
+      }),
+    ).resolves.toMatchObject({ accepted: true, entityVersion: 2 });
+  });
+
+  it("Run Graph append 後の registry crash と reclaim 後は既存 event だけを冪等に読む", async () => {
+    let now = "2026-08-02T00:00:00.000Z";
+    let crashBeforePublish = false;
+    const { root, claims, control, runId, nodeId, claimed } = await createClaimedControlPlane({
+      now: () => now,
+      beforeAuthorizationFinalizePublish: async () => {
+        if (crashBeforePublish) throw new Error("authorization publish interrupted");
+      },
+    });
+    const proof = {
+      claimId: claimed.claim.claimId,
+      fencingToken: claimed.claim.fencingToken,
+      ownerId: claimed.claim.ownerId,
+      runId,
+    };
+    const completion = {
+      schemaVersion: "1" as const,
+      eventId: "crash-after-append",
+      runId,
+      actor: { id: "task-runner", role: "planner" as const },
+      command: {
+        type: "attempt_finished" as const,
+        nodeId,
+        attemptId: "planner-attempt",
+        outcome: "succeeded" as const,
+        artifactIds: [],
+        evidenceIds: ["crash-after-append-evidence"],
+      },
+      evidence: [commandEvidence("crash-after-append-evidence")],
+    };
+
+    crashBeforePublish = true;
+    await expect(
+      control.applyClaimedEvent(completion, proof, claimed.entityVersion),
+    ).resolves.toMatchObject({
+      accepted: true,
+      view: { activeAttempt: { state: "succeeded" } },
+    });
+    crashBeforePublish = false;
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 1,
+      claims: [{}],
+      pendingAuthorizations: [{ eventId: completion.eventId, claimId: proof.claimId }],
+    });
+    await expect(
+      claims.heartbeat({
+        schemaVersion: "1",
+        eventId: "heartbeat-during-pending",
+        expectedEntityVersion: 1,
+        proof,
+        leaseDurationSeconds: 300,
+      }),
+    ).resolves.toMatchObject({
+      accepted: false,
+      code: "authorization_pending",
+      stateUnchanged: true,
+      entityVersion: 1,
+    });
+    await expect(
+      claims.release({
+        schemaVersion: "1",
+        eventId: "release-during-pending",
+        expectedEntityVersion: 1,
+        proof,
+      }),
+    ).resolves.toMatchObject({ accepted: false, code: "authorization_pending" });
+    const afterCrash = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      afterCrash.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+    expect(
+      afterCrash.acceptedEvents.find((event) => event.eventId === completion.eventId),
+    ).toMatchObject({ dispatchAuthorization: { claimId: proof.claimId, fencingToken: 1 } });
+
+    now = "2026-08-02T00:10:00.000Z";
+    const reclaimed = await claims.reclaim({
+      schemaVersion: "1",
+      eventId: "crash-after-append-reclaim",
+      expectedEntityVersion: 1,
+      claimId: proof.claimId,
+      reason: "expired",
+    });
+    expect(reclaimed).toMatchObject({ accepted: true, entityVersion: 2 });
+    await expect(control.applyClaimedEvent(completion, proof, 1)).resolves.toMatchObject({
+      accepted: true,
+      view: { activeAttempt: { state: "succeeded" } },
+    });
+    await expect(claims.snapshot()).resolves.toMatchObject({
+      entityVersion: 3,
+      claims: [],
+      pendingAuthorizations: [],
+    });
+    await expect(
+      control.applyClaimedEvent(
+        { ...completion, eventId: "stale-after-reclaim-new-event" },
+        proof,
+        2,
+      ),
+    ).resolves.toMatchObject({ accepted: false, code: "stale_claim" });
+    const finalJournal = await new RunGraphEventStore(root).readJournal(runId);
+    expect(
+      finalJournal.acceptedEvents.filter((event) => event.eventId === completion.eventId),
+    ).toHaveLength(1);
+    expect(
+      finalJournal.acceptedEvents.filter(
+        (event) =>
+          event.eventId === `audit:${completion.eventId}` &&
+          event.command.type === "claim_event_authorized",
+      ),
+    ).toHaveLength(1);
+    expect(
+      finalJournal.acceptedEvents.some(
+        (event) => event.eventId === "stale-after-reclaim-new-event",
+      ),
+    ).toBe(false);
+    await expect(claims.snapshot()).resolves.toMatchObject({ entityVersion: 3, claims: [] });
   });
 });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,8 +3,10 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
   buildDispatchPlan,
+  canonicalJsonStringify,
   DispatchGateSnapshotSchema,
   DispatchClaimProofSchema,
+  DispatchClaimRepositorySchema,
   DispatchPlanSchema,
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   RunGraphRunnerCommandInputSchema,
@@ -21,6 +23,7 @@ import { RunGraphControlPlane, type RunGraphCommandResult } from "../run-graph/c
 import { GraphContractStore } from "../store/graph-contract.js";
 import { withProjectStorage } from "../store/project-storage.js";
 import { DispatchClaimStore } from "../store/dispatch-claims.js";
+import { isNotGitRepositoryError } from "../util/git-errors.js";
 
 const SIDE_EFFECT_STATES = ["not_started", "committed", "reconciled", "unknown"] as const;
 const HUMAN_DECISIONS = ["approved", "rejected", "override"] as const;
@@ -29,27 +32,18 @@ class RunCommandError extends Error {
   constructor(
     readonly code: string,
     message: string,
+    readonly stateUnchanged?: true,
   ) {
     super(message);
   }
 }
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, item]) => [key, canonicalize(item)]),
-    );
-  }
-  return value;
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
-function canonicalFingerprint(value: unknown): string {
-  return createHash("sha256")
-    .update(JSON.stringify(canonicalize(value)))
-    .digest("hex");
+export function canonicalFingerprint(value: unknown): string {
+  return sha256Hex(canonicalJsonStringify(value));
 }
 
 async function readGateSnapshot(projectRoot: string, path: string) {
@@ -83,17 +77,23 @@ function dispatchSnapshotLineage(
 }
 
 function parsePositiveInteger(value: string, option: string): number {
+  if (value.trim().length === 0) {
+    throw new RunCommandError("invalid_input", `${option} は正の整数で指定してください`, true);
+  }
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new RunCommandError("invalid_input", `${option} は正の整数で指定してください`);
+    throw new RunCommandError("invalid_input", `${option} は正の整数で指定してください`, true);
   }
   return parsed;
 }
 
 function parseNonnegativeInteger(value: string, option: string): number {
+  if (value.trim().length === 0) {
+    throw new RunCommandError("invalid_input", `${option} は0以上の整数で指定してください`, true);
+  }
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new RunCommandError("invalid_input", `${option} は0以上の整数で指定してください`);
+    throw new RunCommandError("invalid_input", `${option} は0以上の整数で指定してください`, true);
   }
   return parsed;
 }
@@ -192,7 +192,7 @@ export function formatRunGraphView(view: RunGraphView): string {
     `claim audits: ${view.claimAudits.items.length}/${view.claimAudits.total} (limit=${view.claimAudits.limit}, truncated=${view.claimAudits.truncated})`,
     ...view.claimAudits.items.map(
       (audit) =>
-        `  - ${audit.command.type} ${audit.command.claim.taskId} owner=${audit.command.claim.ownerId} run=${audit.command.claim.runId} fencing=${audit.command.claim.fencingToken}${audit.command.reclaimReason ? ` reason=${audit.command.reclaimReason}` : ""}`,
+        `  - ${audit.command.type} ${audit.command.claim.taskId} owner=${audit.command.claim.ownerId} run=${audit.command.claim.runId} fencing=${audit.command.claim.fencingToken}${"reclaimReason" in audit.command ? ` reason=${audit.command.reclaimReason}` : ""}`,
     ),
   ];
   return lines.join("\n");
@@ -217,8 +217,15 @@ function outputResult(
 function outputError(error: unknown, json: boolean | undefined): void {
   const code = error instanceof RunCommandError ? error.code : "run_command_failed";
   const message = error instanceof Error ? error.message : String(error);
+  const stateUnchanged = error instanceof RunCommandError ? error.stateUnchanged : undefined;
   if (json) {
-    console.log(JSON.stringify({ accepted: false, code, message }, null, 2));
+    console.log(
+      JSON.stringify(
+        { accepted: false, code, message, ...(stateUnchanged ? { stateUnchanged } : {}) },
+        null,
+        2,
+      ),
+    );
   } else {
     console.error(`Run command failed [${code}]: ${message}`);
   }
@@ -236,11 +243,6 @@ function outputJsonFirst(result: unknown, json?: boolean): void {
   ) {
     process.exitCode = 1;
   }
-}
-
-function isNotGitRepositoryError(error: unknown): boolean {
-  const stderr = String((error as { stderr?: unknown }).stderr ?? "");
-  return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
 }
 
 async function reconcileClaimAudit(
@@ -380,23 +382,26 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
               const openIteration = [...(state.loop?.iterations ?? [])]
                 .reverse()
                 .find((iteration) => iteration.outcome === undefined);
-              return buildDispatchPlan({
-                tasks: state.tasks.tasks,
-                config: state.config,
-                now: new Date().toISOString(),
-                syncConflictTaskIds: state.tasks.has_conflicts
-                  ? state.tasks.tasks.map((task) => task.id)
-                  : [],
-                openIterationTaskIds: openIteration?.selectedTask
-                  ? [openIteration.selectedTask]
-                  : [],
-                reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
-                humanGateTaskIds: gate.snapshot.humanGateTaskIds,
-                claims: registry.claims,
-                registryEntityVersion: registry.entityVersion,
-                ...lineage,
-                workspaceByTaskId,
-              });
+              return buildDispatchPlan(
+                {
+                  tasks: state.tasks.tasks,
+                  config: state.config,
+                  now: new Date().toISOString(),
+                  syncConflictTaskIds: state.tasks.has_conflicts
+                    ? state.tasks.tasks.map((task) => task.id)
+                    : [],
+                  openIterationTaskIds: openIteration?.selectedTask
+                    ? [openIteration.selectedTask]
+                    : [],
+                  reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
+                  humanGateTaskIds: gate.snapshot.humanGateTaskIds,
+                  claims: registry.claims,
+                  registryEntityVersion: registry.entityVersion,
+                  ...lineage,
+                  workspaceByTaskId,
+                },
+                { fingerprint: sha256Hex },
+              );
             },
           );
           outputJsonFirst(result, options.json);
@@ -443,6 +448,14 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
         }) => {
           try {
             const projectRoot = process.cwd();
+            const repository = DispatchClaimRepositorySchema.safeParse(options.repository);
+            if (!repository.success) {
+              throw new RunCommandError(
+                "invalid_input",
+                "--repository は canonical owner/repo 形式で指定してください",
+                true,
+              );
+            }
             const plan = DispatchPlanSchema.parse(
               JSON.parse(await readFile(resolve(projectRoot, options.planFile), "utf8")),
             );
@@ -472,23 +485,26 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
                 const openIteration = [...(state.loop?.iterations ?? [])]
                   .reverse()
                   .find((iteration) => iteration.outcome === undefined);
-                const currentPlan = buildDispatchPlan({
-                  tasks: state.tasks.tasks,
-                  config: state.config,
-                  now: new Date().toISOString(),
-                  syncConflictTaskIds: state.tasks.has_conflicts
-                    ? state.tasks.tasks.map((task) => task.id)
-                    : [],
-                  openIterationTaskIds: openIteration?.selectedTask
-                    ? [openIteration.selectedTask]
-                    : [],
-                  reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
-                  humanGateTaskIds: gate.snapshot.humanGateTaskIds,
-                  claims: registry.claims,
-                  registryEntityVersion: registry.entityVersion,
-                  ...lineage,
-                  workspaceByTaskId: plan.context.workspaceByTaskId,
-                });
+                const currentPlan = buildDispatchPlan(
+                  {
+                    tasks: state.tasks.tasks,
+                    config: state.config,
+                    now: new Date().toISOString(),
+                    syncConflictTaskIds: state.tasks.has_conflicts
+                      ? state.tasks.tasks.map((task) => task.id)
+                      : [],
+                    openIterationTaskIds: openIteration?.selectedTask
+                      ? [openIteration.selectedTask]
+                      : [],
+                    reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
+                    humanGateTaskIds: gate.snapshot.humanGateTaskIds,
+                    claims: registry.claims,
+                    registryEntityVersion: registry.entityVersion,
+                    ...lineage,
+                    workspaceByTaskId: plan.context.workspaceByTaskId,
+                  },
+                  { fingerprint: sha256Hex },
+                );
                 if (currentPlan.planId !== plan.planId) {
                   throw new RunCommandError(
                     "stale_entity_version",
@@ -499,7 +515,7 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
                 if (
                   !selected ||
                   selected.workspaceId !== options.workspace ||
-                  selected.repository !== options.repository.toLowerCase() ||
+                  selected.repository !== repository.data ||
                   selected.state !== options.state
                 ) {
                   throw new RunCommandError(
@@ -528,7 +544,7 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
                     eventId: parseRequiredText(options.eventId, "--event-id"),
                     expectedEntityVersion,
                     taskId: parseRequiredText(options.task, "--task"),
-                    repository: parseRequiredText(options.repository, "--repository"),
+                    repository: repository.data,
                     state: parseRequiredText(options.state, "--state"),
                     ownerId: parseRequiredText(options.owner, "--owner"),
                     workspaceId: parseRequiredText(options.workspace, "--workspace"),

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -2,12 +2,17 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
+  buildDispatchPlan,
+  DispatchGateSnapshotSchema,
+  DispatchClaimProofSchema,
+  DispatchPlanSchema,
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   RunGraphRunnerCommandInputSchema,
   type RunGraphRunnerCommandInput,
   type RunGraphView,
 } from "@gh-gantt/shared";
 import { Command } from "commander";
+import { z } from "zod";
 import {
   fetchRunGraphPrObservation as fetchRunGraphPrObservationDefault,
   type RunGraphPrObservation,
@@ -15,6 +20,7 @@ import {
 import { RunGraphControlPlane, type RunGraphCommandResult } from "../run-graph/control-plane.js";
 import { GraphContractStore } from "../store/graph-contract.js";
 import { withProjectStorage } from "../store/project-storage.js";
+import { DispatchClaimStore } from "../store/dispatch-claims.js";
 
 const SIDE_EFFECT_STATES = ["not_started", "committed", "reconciled", "unknown"] as const;
 const HUMAN_DECISIONS = ["approved", "rejected", "override"] as const;
@@ -28,10 +34,66 @@ class RunCommandError extends Error {
   }
 }
 
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    );
+  }
+  return value;
+}
+
+function canonicalFingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+async function readGateSnapshot(projectRoot: string, path: string) {
+  const snapshot = DispatchGateSnapshotSchema.parse(
+    JSON.parse(await readFile(resolve(projectRoot, path), "utf8")),
+  );
+  return { snapshot, fingerprint: canonicalFingerprint(snapshot) };
+}
+
+function dispatchSnapshotLineage(
+  state: { config: unknown; tasks: unknown; loop: unknown },
+  gate: { snapshot: { sourceRevision: string }; fingerprint: string },
+) {
+  const tasks = state.tasks as { tasks?: unknown; has_conflicts?: boolean };
+  const workGraphFingerprint = canonicalFingerprint({
+    config: state.config,
+    tasks: tasks.tasks,
+    hasConflicts: tasks.has_conflicts ?? false,
+    loop: state.loop,
+  });
+  return {
+    workGraphFingerprint,
+    gateSnapshotFingerprint: gate.fingerprint,
+    gateSnapshotSourceRevision: gate.snapshot.sourceRevision,
+    snapshotFingerprint: canonicalFingerprint({
+      workGraphFingerprint,
+      gateSnapshotFingerprint: gate.fingerprint,
+      gateSnapshotSourceRevision: gate.snapshot.sourceRevision,
+    }),
+  };
+}
+
 function parsePositiveInteger(value: string, option: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) {
     throw new RunCommandError("invalid_input", `${option} は正の整数で指定してください`);
+  }
+  return parsed;
+}
+
+function parseNonnegativeInteger(value: string, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new RunCommandError("invalid_input", `${option} は0以上の整数で指定してください`);
   }
   return parsed;
 }
@@ -127,6 +189,11 @@ export function formatRunGraphView(view: RunGraphView): string {
     ...view.evidence.items.map((item) =>
       formatReferenceLine(item.id, item.kind, item.reference.uri),
     ),
+    `claim audits: ${view.claimAudits.items.length}/${view.claimAudits.total} (limit=${view.claimAudits.limit}, truncated=${view.claimAudits.truncated})`,
+    ...view.claimAudits.items.map(
+      (audit) =>
+        `  - ${audit.command.type} ${audit.command.claim.taskId} owner=${audit.command.claim.ownerId} run=${audit.command.claim.runId} fencing=${audit.command.claim.fencingToken}${audit.command.reclaimReason ? ` reason=${audit.command.reclaimReason}` : ""}`,
+    ),
   ];
   return lines.join("\n");
 }
@@ -156,6 +223,52 @@ function outputError(error: unknown, json: boolean | undefined): void {
     console.error(`Run command failed [${code}]: ${message}`);
   }
   process.exitCode = 1;
+}
+
+function outputJsonFirst(result: unknown, json?: boolean): void {
+  if (json) console.log(JSON.stringify(result, null, 2));
+  else console.log(JSON.stringify(result));
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "accepted" in result &&
+    result.accepted === false
+  ) {
+    process.exitCode = 1;
+  }
+}
+
+function isNotGitRepositoryError(error: unknown): boolean {
+  const stderr = String((error as { stderr?: unknown }).stderr ?? "");
+  return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
+}
+
+async function reconcileClaimAudit(
+  projectRoot: string,
+  actorId: string,
+  receipt:
+    | Awaited<ReturnType<DispatchClaimStore["claim"]>>
+    | Awaited<ReturnType<DispatchClaimStore["heartbeat"]>>,
+): Promise<unknown> {
+  if (!receipt.accepted || !receipt.claim) return receipt;
+  try {
+    const audit = await new RunGraphControlPlane(projectRoot).recordClaimAudit({
+      schemaVersion: "1",
+      eventId: `audit:${receipt.eventId}`,
+      actor: { id: actorId, role: "orchestrator" },
+      receipt: { ...receipt, claim: receipt.claim },
+    });
+    return { ...receipt, audit: { recorded: audit.accepted, result: audit } };
+  } catch (error) {
+    return {
+      ...receipt,
+      audit: {
+        recorded: false,
+        pending: true,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
 }
 
 async function startRun(
@@ -236,6 +349,361 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
   const command = new Command("run").description("Durable Run Graph を操作する");
 
   command.addCommand(
+    new Command("dispatch")
+      .description("Work Graph snapshot から bounded ready frontier を導出する")
+      .requiredOption("--workspace-map <path>", "task ID から isolated workspace ID への JSON map")
+      .requiredOption(
+        "--gate-snapshot <path>",
+        "authoritative review/human gate snapshot JSON file",
+      )
+      .option("--json", "JSON 形式で出力")
+      .action(async (options: { workspaceMap: string; gateSnapshot: string; json?: boolean }) => {
+        try {
+          const projectRoot = process.cwd();
+          const result = await withProjectStorage(
+            projectRoot,
+            { mode: "read", scope: "all" },
+            async ({ configStore, tasksStore, loopStore }) => {
+              const state = {
+                config: await configStore.read(),
+                tasks: await tasksStore.read(),
+                loop: await loopStore.readOrNull(),
+              };
+              const gate = await readGateSnapshot(projectRoot, options.gateSnapshot);
+              const lineage = dispatchSnapshotLineage(state, gate);
+              const workspaceByTaskId = z
+                .record(z.string().trim().min(1), z.string().trim().min(1))
+                .parse(
+                  JSON.parse(await readFile(resolve(projectRoot, options.workspaceMap), "utf8")),
+                );
+              const registry = await new DispatchClaimStore(projectRoot).snapshot();
+              const openIteration = [...(state.loop?.iterations ?? [])]
+                .reverse()
+                .find((iteration) => iteration.outcome === undefined);
+              return buildDispatchPlan({
+                tasks: state.tasks.tasks,
+                config: state.config,
+                now: new Date().toISOString(),
+                syncConflictTaskIds: state.tasks.has_conflicts
+                  ? state.tasks.tasks.map((task) => task.id)
+                  : [],
+                openIterationTaskIds: openIteration?.selectedTask
+                  ? [openIteration.selectedTask]
+                  : [],
+                reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
+                humanGateTaskIds: gate.snapshot.humanGateTaskIds,
+                claims: registry.claims,
+                registryEntityVersion: registry.entityVersion,
+                ...lineage,
+                workspaceByTaskId,
+              });
+            },
+          );
+          outputJsonFirst(result, options.json);
+        } catch (error) {
+          outputError(error, options.json);
+        }
+      }),
+  );
+
+  command.addCommand(
+    new Command("claim")
+      .description("ready task と isolated workspace を期限付きで claim する")
+      .requiredOption("--event-id <id>", "冪等 caller event ID")
+      .requiredOption("--expected-version <number>", "registry entityVersion")
+      .requiredOption("--task <id>", "Work Graph task ID")
+      .requiredOption("--repository <owner/repo>", "task repository")
+      .requiredOption("--state <status>", "task status")
+      .requiredOption("--owner <id>", "stable owner ID")
+      .requiredOption("--workspace <id>", "isolated workspace ID")
+      .requiredOption("--run <id>", "workspace-local Run Graph ID")
+      .requiredOption("--plan-file <path>", "run dispatch JSON plan file")
+      .requiredOption(
+        "--gate-snapshot <path>",
+        "claim直前の authoritative review/human gate snapshot JSON file",
+      )
+      .requiredOption("--actor <id>", "audit reconciliation の orchestrator actor ID")
+      .option("--lease-seconds <seconds>", "lease duration", "300")
+      .option("--json", "JSON 形式で出力")
+      .action(
+        async (options: {
+          eventId: string;
+          expectedVersion: string;
+          task: string;
+          repository: string;
+          state: string;
+          owner: string;
+          workspace: string;
+          run: string;
+          planFile: string;
+          gateSnapshot: string;
+          actor: string;
+          leaseSeconds: string;
+          json?: boolean;
+        }) => {
+          try {
+            const projectRoot = process.cwd();
+            const plan = DispatchPlanSchema.parse(
+              JSON.parse(await readFile(resolve(projectRoot, options.planFile), "utf8")),
+            );
+            const expectedEntityVersion = parseNonnegativeInteger(
+              options.expectedVersion,
+              "--expected-version",
+            );
+            if (plan.registryEntityVersion !== expectedEntityVersion) {
+              throw new RunCommandError(
+                "stale_entity_version",
+                "dispatch plan の registry entityVersion が claim と一致しません",
+              );
+            }
+            const result = await withProjectStorage(
+              projectRoot,
+              { mode: "read", scope: "all" },
+              async ({ configStore, tasksStore, loopStore }) => {
+                const state = {
+                  config: await configStore.read(),
+                  tasks: await tasksStore.read(),
+                  loop: await loopStore.readOrNull(),
+                };
+                const gate = await readGateSnapshot(projectRoot, options.gateSnapshot);
+                const lineage = dispatchSnapshotLineage(state, gate);
+                const registryStore = new DispatchClaimStore(projectRoot);
+                const registry = await registryStore.snapshot();
+                const openIteration = [...(state.loop?.iterations ?? [])]
+                  .reverse()
+                  .find((iteration) => iteration.outcome === undefined);
+                const currentPlan = buildDispatchPlan({
+                  tasks: state.tasks.tasks,
+                  config: state.config,
+                  now: new Date().toISOString(),
+                  syncConflictTaskIds: state.tasks.has_conflicts
+                    ? state.tasks.tasks.map((task) => task.id)
+                    : [],
+                  openIterationTaskIds: openIteration?.selectedTask
+                    ? [openIteration.selectedTask]
+                    : [],
+                  reviewGateTaskIds: gate.snapshot.reviewGateTaskIds,
+                  humanGateTaskIds: gate.snapshot.humanGateTaskIds,
+                  claims: registry.claims,
+                  registryEntityVersion: registry.entityVersion,
+                  ...lineage,
+                  workspaceByTaskId: plan.context.workspaceByTaskId,
+                });
+                if (currentPlan.planId !== plan.planId) {
+                  throw new RunCommandError(
+                    "stale_entity_version",
+                    "dispatch plan は current Work Graph/gate/claim snapshot と一致しません",
+                  );
+                }
+                const selected = currentPlan.selected.find((item) => item.taskId === options.task);
+                if (
+                  !selected ||
+                  selected.workspaceId !== options.workspace ||
+                  selected.repository !== options.repository.toLowerCase() ||
+                  selected.state !== options.state
+                ) {
+                  throw new RunCommandError(
+                    "invalid_input",
+                    "task/repository/state/workspace は current dispatch frontier にありません",
+                  );
+                }
+                const run = await new RunGraphControlPlane(projectRoot).inspect(options.run);
+                const runTaskId =
+                  `${run.task.owner}/${run.task.repo}#${run.task.issueNumber}`.toLowerCase();
+                if (runTaskId !== options.task.toLowerCase()) {
+                  throw new RunCommandError(
+                    "invalid_input",
+                    "Run Graph task と claim task が一致しません",
+                  );
+                }
+                if (run.state === "waiting_human" || run.waitReason !== null) {
+                  throw new RunCommandError(
+                    "invalid_input",
+                    "Run Graph が human gate で停止している task は claim できません",
+                  );
+                }
+                const receipt = await registryStore.claim(
+                  {
+                    schemaVersion: "1",
+                    eventId: parseRequiredText(options.eventId, "--event-id"),
+                    expectedEntityVersion,
+                    taskId: parseRequiredText(options.task, "--task"),
+                    repository: parseRequiredText(options.repository, "--repository"),
+                    state: parseRequiredText(options.state, "--state"),
+                    ownerId: parseRequiredText(options.owner, "--owner"),
+                    workspaceId: parseRequiredText(options.workspace, "--workspace"),
+                    runId: parseRequiredText(options.run, "--run"),
+                    leaseDurationSeconds: parsePositiveInteger(
+                      options.leaseSeconds,
+                      "--lease-seconds",
+                    ),
+                    dispatchPlanId: plan.planId,
+                    dispatchPlanVersion: plan.planVersion,
+                    snapshotFingerprint: lineage.snapshotFingerprint,
+                  },
+                  async () =>
+                    dispatchSnapshotLineage(
+                      state,
+                      await readGateSnapshot(projectRoot, options.gateSnapshot),
+                    ).snapshotFingerprint,
+                );
+                return reconcileClaimAudit(projectRoot, options.actor, receipt);
+              },
+            );
+            outputJsonFirst(await result, options.json);
+          } catch (error) {
+            outputError(error, options.json);
+          }
+        },
+      ),
+  );
+
+  const proofOptions = (subcommand: Command): Command =>
+    subcommand
+      .requiredOption("--event-id <id>", "冪等 caller event ID")
+      .requiredOption("--expected-version <number>", "registry entityVersion")
+      .requiredOption("--claim <id>", "claim ID")
+      .requiredOption("--fencing-token <number>", "current fencing token")
+      .requiredOption("--owner <id>", "stable owner ID")
+      .requiredOption("--run <id>", "Run Graph ID")
+      .requiredOption("--actor <id>", "audit reconciliation の orchestrator actor ID")
+      .option("--json", "JSON 形式で出力");
+
+  command.addCommand(
+    proofOptions(new Command("heartbeat").description("current claim lease を延長する"))
+      .option("--lease-seconds <seconds>", "lease duration", "300")
+      .action(
+        async (options: {
+          eventId: string;
+          expectedVersion: string;
+          claim: string;
+          fencingToken: string;
+          owner: string;
+          run: string;
+          actor: string;
+          leaseSeconds: string;
+          json?: boolean;
+        }) => {
+          try {
+            const projectRoot = process.cwd();
+            const receipt = await new DispatchClaimStore(projectRoot).heartbeat({
+              schemaVersion: "1",
+              eventId: options.eventId,
+              expectedEntityVersion: parseNonnegativeInteger(
+                options.expectedVersion,
+                "--expected-version",
+              ),
+              proof: {
+                claimId: options.claim,
+                fencingToken: parsePositiveInteger(options.fencingToken, "--fencing-token"),
+                ownerId: options.owner,
+                runId: options.run,
+              },
+              leaseDurationSeconds: parsePositiveInteger(options.leaseSeconds, "--lease-seconds"),
+            });
+            outputJsonFirst(
+              await reconcileClaimAudit(projectRoot, options.actor, receipt),
+              options.json,
+            );
+          } catch (error) {
+            outputError(error, options.json);
+          }
+        },
+      ),
+  );
+
+  command.addCommand(
+    proofOptions(new Command("release").description("current claim を解放する")).action(
+      async (options: {
+        eventId: string;
+        expectedVersion: string;
+        claim: string;
+        fencingToken: string;
+        owner: string;
+        run: string;
+        actor: string;
+        json?: boolean;
+      }) => {
+        try {
+          const projectRoot = process.cwd();
+          const receipt = await new DispatchClaimStore(projectRoot).release({
+            schemaVersion: "1",
+            eventId: options.eventId,
+            expectedEntityVersion: parseNonnegativeInteger(
+              options.expectedVersion,
+              "--expected-version",
+            ),
+            proof: {
+              claimId: options.claim,
+              fencingToken: parsePositiveInteger(options.fencingToken, "--fencing-token"),
+              ownerId: options.owner,
+              runId: options.run,
+            },
+          });
+          outputJsonFirst(
+            await reconcileClaimAudit(projectRoot, options.actor, receipt),
+            options.json,
+          );
+        } catch (error) {
+          outputError(error, options.json);
+        }
+      },
+    ),
+  );
+
+  command.addCommand(
+    new Command("reclaim")
+      .description("期限切れまたは停止 owner の claim を回収する")
+      .requiredOption("--event-id <id>", "冪等 caller event ID")
+      .requiredOption("--expected-version <number>", "registry entityVersion")
+      .requiredOption("--claim <id>", "reclaim 対象 claim ID")
+      .requiredOption("--reason <reason>", "expired | owner_stopped")
+      .option("--owner-stopped-evidence <id>", "owner_stopped の停止 evidence ID")
+      .requiredOption("--actor <id>", "audit reconciliation の orchestrator actor ID")
+      .option("--json", "JSON 形式で出力")
+      .action(
+        async (options: {
+          eventId: string;
+          expectedVersion: string;
+          claim: string;
+          reason: string;
+          ownerStoppedEvidence?: string;
+          actor: string;
+          json?: boolean;
+        }) => {
+          try {
+            if (options.reason !== "expired" && options.reason !== "owner_stopped") {
+              throw new RunCommandError(
+                "invalid_input",
+                "--reason は expired | owner_stopped で指定してください",
+              );
+            }
+            const projectRoot = process.cwd();
+            const receipt = await new DispatchClaimStore(projectRoot).reclaim({
+              schemaVersion: "1",
+              eventId: options.eventId,
+              expectedEntityVersion: parseNonnegativeInteger(
+                options.expectedVersion,
+                "--expected-version",
+              ),
+              claimId: options.claim,
+              reason: options.reason,
+              ...(options.ownerStoppedEvidence
+                ? { ownerStoppedEvidenceId: options.ownerStoppedEvidence }
+                : {}),
+            });
+            outputJsonFirst(
+              await reconcileClaimAudit(projectRoot, options.actor, receipt),
+              options.json,
+            );
+          } catch (error) {
+            outputError(error, options.json);
+          }
+        },
+      ),
+  );
+
+  command.addCommand(
     new Command("start")
       .description("OPEN Issue から fixed dev-role run を開始する")
       .requiredOption("--issue <number>", "対象 GitHub Issue 番号")
@@ -278,18 +746,67 @@ export function createRunCommand(dependencies: RunCommandDependencies = {}): Com
               `${rawCommandType} は専用の run command からのみ受理します`,
             );
           }
-          const parsed = RunGraphRunnerCommandInputSchema.safeParse({ ...raw, runId });
+          const rawRecord = raw as Record<string, unknown>;
+          const rawClaim = rawRecord.claim;
+          const { claim: _claim, ...eventRecord } = rawRecord;
+          const parsed = RunGraphRunnerCommandInputSchema.safeParse({ ...eventRecord, runId });
           if (!parsed.success) {
             throw new RunCommandError(
               "invalid_input",
               `runner command JSON が schema に一致しません: ${parsed.error.message}`,
             );
           }
-          outputResult(
-            await new RunGraphControlPlane(process.cwd()).applyEvent(parsed.data),
-            options.json,
-            "Run event",
-          );
+          const requiresCurrentClaim =
+            parsed.data.command.type === "attempt_finished" ||
+            parsed.data.command.type === "node_outcome_submitted";
+          if (requiresCurrentClaim && rawClaim === undefined) {
+            try {
+              const snapshot = await new DispatchClaimStore(process.cwd()).snapshot();
+              if (snapshot.history.some((event) => event.runId === runId)) {
+                outputResult(
+                  {
+                    accepted: false,
+                    code: "stale_claim",
+                    message:
+                      "dispatch 済み Run の completion/outcome には current claim proof が必要です",
+                    stateUnchanged: true,
+                    view: await new RunGraphControlPlane(process.cwd()).inspect(runId),
+                  },
+                  options.json,
+                  "Run event",
+                );
+                return;
+              }
+            } catch (error) {
+              // 既存の standalone Run Graph は Git repository 外でも動作するため互換性を保つ。
+              if (!isNotGitRepositoryError(error)) throw error;
+            }
+          }
+          if (rawClaim !== undefined) {
+            const claim = z
+              .object({
+                expectedEntityVersion: z.number().int().nonnegative(),
+                proof: DispatchClaimProofSchema,
+              })
+              .strict()
+              .parse(rawClaim);
+            const claimStore = new DispatchClaimStore(process.cwd());
+            outputResult(
+              await new RunGraphControlPlane(
+                process.cwd(),
+                undefined,
+                claimStore,
+              ).applyClaimedEvent(parsed.data, claim.proof, claim.expectedEntityVersion),
+              options.json,
+              "Run event",
+            );
+          } else {
+            outputResult(
+              await new RunGraphControlPlane(process.cwd()).applyEvent(parsed.data),
+              options.json,
+              "Run event",
+            );
+          }
         } catch (error) {
           outputError(error, options.json);
         }

--- a/packages/cli/src/run-graph/control-plane.ts
+++ b/packages/cli/src/run-graph/control-plane.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
+  canonicalJsonStringify,
   DispatchClaimProofSchema,
+  RunGraphClaimAuditCommandSchema,
   RunGraphClaimAuditInputSchema,
   RunGraphProjectionSchema,
   RunGraphRunnerCommandInputSchema,
@@ -30,6 +32,7 @@ import {
   type DispatchAuthorizedEventCommitContext,
   type PendingAuthorizationInspection,
 } from "../store/dispatch-claims.js";
+import { isNotGitRepositoryError } from "../util/git-errors.js";
 
 export interface RunGraphControlPlaneDependencies {
   now: () => string;
@@ -214,8 +217,9 @@ export class RunGraphControlPlane {
         commandFingerprint,
       };
       if (
-        JSON.stringify(existing.command) !== JSON.stringify(input.command) ||
-        JSON.stringify(existing.dispatchAuthorization) !== JSON.stringify(expectedBinding)
+        canonicalJsonStringify(existing.command) !== canonicalJsonStringify(input.command) ||
+        canonicalJsonStringify(existing.dispatchAuthorization) !==
+          canonicalJsonStringify(expectedBinding)
       ) {
         const reconciled = await this.reconcileOrAbortAuthorization(input, authorizationInput);
         if (reconciled) return reconciled;
@@ -229,7 +233,7 @@ export class RunGraphControlPlane {
       const replay = await this.claimAuthority.commitAuthorizedEvent(
         authorizationInput,
         async ({ binding }) => {
-          if (JSON.stringify(binding) !== JSON.stringify(expectedBinding)) {
+          if (canonicalJsonStringify(binding) !== canonicalJsonStringify(expectedBinding)) {
             throw new Error(
               "stored event の authorization binding が current claim と一致しません",
             );
@@ -289,8 +293,9 @@ export class RunGraphControlPlane {
         const committed = journal.acceptedEvents.find(
           (event) =>
             event.eventId === input.eventId &&
-            JSON.stringify(event.command) === JSON.stringify(input.command) &&
-            JSON.stringify(event.dispatchAuthorization) === JSON.stringify(attemptedBinding),
+            canonicalJsonStringify(event.command) === canonicalJsonStringify(input.command) &&
+            canonicalJsonStringify(event.dispatchAuthorization) ===
+              canonicalJsonStringify(attemptedBinding),
         );
         if (committed) return { accepted: true, view: await this.inspect(input.runId) };
       }
@@ -318,8 +323,8 @@ export class RunGraphControlPlane {
     const journal = await this.events.readJournal(input.runId);
     const event = journal.acceptedEvents.find((candidate) => candidate.eventId === input.eventId);
     if (!event) return "absent";
-    return JSON.stringify(event.command) === JSON.stringify(input.command) &&
-      JSON.stringify(event.dispatchAuthorization) === JSON.stringify(binding)
+    return canonicalJsonStringify(event.command) === canonicalJsonStringify(input.command) &&
+      canonicalJsonStringify(event.dispatchAuthorization) === canonicalJsonStringify(binding)
       ? "exact_committed"
       : "conflict";
   }
@@ -406,7 +411,7 @@ export class RunGraphControlPlane {
       reclaim: "claim_reclaimed",
       authorize_event: "claim_event_authorized",
     } as const;
-    const command = {
+    const command = RunGraphClaimAuditCommandSchema.parse({
       type: typeByOperation[receipt.operation],
       registryEventId: receipt.eventId,
       registryEntityVersion: receipt.entityVersion,
@@ -420,7 +425,7 @@ export class RunGraphControlPlane {
           }
         : {}),
       ...(receipt.operation === "authorize_event" ? { completion: receipt.completion } : {}),
-    };
+    });
     const existingRegistryAudit = journal.acceptedEvents.find(
       (event) =>
         "registryEventId" in event.command &&
@@ -446,7 +451,7 @@ export class RunGraphControlPlane {
       };
     }
     if (existing) {
-      if (JSON.stringify(existing.command) === JSON.stringify(command)) {
+      if (canonicalJsonStringify(existing.command) === canonicalJsonStringify(command)) {
         return { accepted: true, view: await this.inspect(runId) };
       }
       return {
@@ -554,9 +559,7 @@ export class RunGraphControlPlane {
           );
         }
       } catch (error) {
-        const stderr = String((error as { stderr?: unknown }).stderr ?? "");
-        if (!stderr.includes("not a git repository") && !stderr.includes("not a git work tree"))
-          throw error;
+        if (!isNotGitRepositoryError(error)) throw error;
       }
     }
     const prepared = await this.validateAndBuildEvent(input);

--- a/packages/cli/src/run-graph/control-plane.ts
+++ b/packages/cli/src/run-graph/control-plane.ts
@@ -1,29 +1,73 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
+  DispatchClaimProofSchema,
+  RunGraphClaimAuditInputSchema,
   RunGraphProjectionSchema,
   RunGraphRunnerCommandInputSchema,
   RunGraphStartInputSchema,
   RunGraphViewSchema,
   type GraphContract,
+  type DispatchClaimProof,
+  type DispatchClaim,
+  type DispatchClaimEventAuthorizationInput,
+  type DispatchClaimReceipt,
   type RunGraphAcceptedEvent,
   type RunGraphArtifact,
   type RunGraphEvidence,
   type RunGraphProjection,
   type RunGraphRejectionCode,
   type RunGraphRunnerCommandInput,
+  type RunGraphClaimAuditInput,
   type RunGraphStartInput,
   type RunGraphView,
+  type RunGraphDispatchAuthorizationBinding,
 } from "@gh-gantt/shared";
 import { GraphContractStore } from "../store/graph-contract.js";
 import { RunGraphEventStore } from "../store/run-graph.js";
+import {
+  DispatchClaimStore,
+  type AbortPendingAuthorizationResult,
+  type DispatchAuthorizedEventCommitContext,
+  type PendingAuthorizationInspection,
+} from "../store/dispatch-claims.js";
 
 export interface RunGraphControlPlaneDependencies {
   now: () => string;
   nextId: (kind: string) => string;
 }
 
+export interface DispatchClaimAuthority {
+  abortPendingAuthorization(
+    input: DispatchClaimEventAuthorizationInput,
+    inspectCommittedEvent: (
+      context: DispatchAuthorizedEventCommitContext,
+    ) => Promise<PendingAuthorizationInspection>,
+  ): Promise<AbortPendingAuthorizationResult>;
+  commitAuthorizedEvent(
+    input: DispatchClaimEventAuthorizationInput,
+    commit: (context: {
+      claim: DispatchClaim;
+      binding: RunGraphDispatchAuthorizationBinding;
+    }) => Promise<void>,
+    options?: { persistRejection?: boolean; historicalReconciliation?: boolean },
+  ): Promise<DispatchClaimReceipt>;
+  isDispatchConfigured(): Promise<boolean>;
+  isReceiptClaimCurrent(
+    receipt: Extract<DispatchClaimReceipt, { accepted: true; operation: "authorize_event" }>,
+  ): Promise<boolean>;
+  verifyReceipt(receipt: DispatchClaimReceipt): Promise<boolean>;
+  assertCurrentClaim(
+    proof: DispatchClaimProof,
+    expectedEntityVersion: number,
+  ): Promise<DispatchClaim>;
+}
+
 export type RunGraphCommandResult =
-  | { accepted: true; view: RunGraphView }
+  | {
+      accepted: true;
+      view: RunGraphView;
+      claimAuthorization?: DispatchClaimAuthorizationResult;
+    }
   | {
       accepted: false;
       code: RunGraphRejectionCode;
@@ -31,6 +75,21 @@ export type RunGraphCommandResult =
       stateUnchanged: true;
       view?: RunGraphView;
     };
+
+export interface DispatchClaimAuthorizationResult {
+  receipt: Extract<DispatchClaimReceipt, { accepted: true }>;
+  proof: DispatchClaimProof;
+  audit: { recorded: boolean; pending?: true; message?: string };
+}
+
+interface PreparedRunnerEvent {
+  event: RunGraphAcceptedEvent;
+  view: RunGraphView;
+}
+
+type PreparedRunnerEventResult =
+  | { accepted: true; prepared: PreparedRunnerEvent }
+  | Extract<RunGraphCommandResult, { accepted: false }>;
 
 const defaultDependencies: RunGraphControlPlaneDependencies = {
   now: () => new Date().toISOString(),
@@ -93,14 +152,333 @@ export class RunGraphControlPlane {
   private readonly contracts: GraphContractStore;
   private readonly events: RunGraphEventStore;
   private readonly dependencies: RunGraphControlPlaneDependencies;
+  private readonly claimAuthority: DispatchClaimAuthority;
 
   constructor(
     projectRoot: string,
     dependencies: RunGraphControlPlaneDependencies = defaultDependencies,
+    claimAuthority?: DispatchClaimAuthority,
   ) {
     this.contracts = new GraphContractStore(projectRoot);
     this.events = new RunGraphEventStore(projectRoot);
     this.dependencies = dependencies;
+    this.claimAuthority = claimAuthority ?? new DispatchClaimStore(projectRoot);
+  }
+
+  /**
+   * repository registry で current proof を再検証してから completion/outcome event を受理する。
+   * dispatch Config がない従来 repository は applyEvent を使い、この seam は bounded dispatch 専用とする。
+   */
+  async applyClaimedEvent(
+    rawInput: RunGraphRunnerCommandInput,
+    proof: DispatchClaimProof,
+    expectedEntityVersion: number,
+  ): Promise<RunGraphCommandResult> {
+    const input = RunGraphRunnerCommandInputSchema.parse(rawInput);
+    const parsedProof = DispatchClaimProofSchema.parse(proof);
+    const view = await this.inspect(input.runId);
+    if (
+      input.command.type !== "attempt_finished" &&
+      input.command.type !== "node_outcome_submitted"
+    ) {
+      return this.reject(
+        input,
+        "invalid_transition",
+        "claim proof は completion/outcome event にだけ使用できます",
+        view,
+      );
+    }
+    const taskId = `${view.task.owner}/${view.task.repo}#${view.task.issueNumber}`.toLowerCase();
+    const commandFingerprint = createHash("sha256").update(JSON.stringify(input)).digest("hex");
+    const authorizationInput = {
+      schemaVersion: "1",
+      eventId: input.eventId,
+      expectedEntityVersion,
+      proof: parsedProof,
+      runId: input.runId,
+      taskId,
+      actorId: input.actor.id,
+      commandFingerprint,
+    } as const;
+    const existingJournal = await this.events.readJournal(input.runId);
+    const existing = existingJournal.acceptedEvents.find(
+      (event) => event.eventId === input.eventId,
+    );
+    if (existing) {
+      const expectedBinding: RunGraphDispatchAuthorizationBinding = {
+        claimId: parsedProof.claimId,
+        fencingToken: parsedProof.fencingToken,
+        ownerId: parsedProof.ownerId,
+        runId: parsedProof.runId,
+        taskId,
+        commandFingerprint,
+      };
+      if (
+        JSON.stringify(existing.command) !== JSON.stringify(input.command) ||
+        JSON.stringify(existing.dispatchAuthorization) !== JSON.stringify(expectedBinding)
+      ) {
+        const reconciled = await this.reconcileOrAbortAuthorization(input, authorizationInput);
+        if (reconciled) return reconciled;
+        return this.reject(
+          input,
+          "duplicate_event",
+          "completion event ID は異なる command に使用済みです",
+          view,
+        );
+      }
+      const replay = await this.claimAuthority.commitAuthorizedEvent(
+        authorizationInput,
+        async ({ binding }) => {
+          if (JSON.stringify(binding) !== JSON.stringify(expectedBinding)) {
+            throw new Error(
+              "stored event の authorization binding が current claim と一致しません",
+            );
+          }
+        },
+        { persistRejection: false, historicalReconciliation: true },
+      );
+      // append 後・registry publish 前 crash の後に reclaim されても、既存 event だけは冪等に読む。
+      if (!replay.accepted) return { accepted: true, view: await this.inspect(input.runId) };
+      const audit = await this.reconcileCompletionAudit(replay);
+      const claimIsCurrent =
+        replay.operation === "authorize_event" &&
+        (await this.claimAuthority.isReceiptClaimCurrent(replay));
+      return {
+        accepted: true,
+        view: await this.inspect(input.runId),
+        ...(claimIsCurrent
+          ? { claimAuthorization: this.claimAuthorizationResult(replay, audit) }
+          : {}),
+      };
+    }
+
+    let receipt: DispatchClaimReceipt;
+    let attemptedBinding: RunGraphDispatchAuthorizationBinding | undefined;
+    try {
+      await this.claimAuthority.assertCurrentClaim(parsedProof, expectedEntityVersion);
+    } catch {
+      const reconciled = await this.reconcileOrAbortAuthorization(input, authorizationInput);
+      if (reconciled) return reconciled;
+      return this.reject(input, "stale_claim", "current claim/fencing proof が一致しません", view);
+    }
+    const preparation = await this.validateAndBuildEvent(input);
+    if (!preparation.accepted) {
+      const reconciled = await this.reconcileOrAbortAuthorization(input, authorizationInput);
+      if (reconciled) return reconciled;
+      return preparation;
+    }
+    try {
+      receipt = await this.claimAuthority.commitAuthorizedEvent(
+        authorizationInput,
+        async ({ binding }) => {
+          attemptedBinding = binding;
+          try {
+            await this.events.appendAccepted({
+              ...preparation.prepared.event,
+              dispatchAuthorization: binding,
+            });
+          } catch (error) {
+            if ((await this.inspectCommittedEvent(input, binding)) === "exact_committed") return;
+            throw error;
+          }
+        },
+      );
+    } catch (error) {
+      if (attemptedBinding) {
+        const journal = await this.events.readJournal(input.runId);
+        const committed = journal.acceptedEvents.find(
+          (event) =>
+            event.eventId === input.eventId &&
+            JSON.stringify(event.command) === JSON.stringify(input.command) &&
+            JSON.stringify(event.dispatchAuthorization) === JSON.stringify(attemptedBinding),
+        );
+        if (committed) return { accepted: true, view: await this.inspect(input.runId) };
+      }
+      return {
+        accepted: false,
+        code: "stale_attempt",
+        message: `claim transaction 内の event commit に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+        stateUnchanged: true,
+        view: await this.inspect(input.runId),
+      };
+    }
+    if (!receipt.accepted) return this.reject(input, "stale_claim", receipt.message, view);
+    const audit = await this.reconcileCompletionAudit(receipt);
+    return {
+      accepted: true,
+      view: await this.inspect(input.runId),
+      claimAuthorization: this.claimAuthorizationResult(receipt, audit),
+    };
+  }
+
+  private async inspectCommittedEvent(
+    input: RunGraphRunnerCommandInput,
+    binding: RunGraphDispatchAuthorizationBinding,
+  ): Promise<PendingAuthorizationInspection> {
+    const journal = await this.events.readJournal(input.runId);
+    const event = journal.acceptedEvents.find((candidate) => candidate.eventId === input.eventId);
+    if (!event) return "absent";
+    return JSON.stringify(event.command) === JSON.stringify(input.command) &&
+      JSON.stringify(event.dispatchAuthorization) === JSON.stringify(binding)
+      ? "exact_committed"
+      : "conflict";
+  }
+
+  private async reconcileOrAbortAuthorization(
+    input: RunGraphRunnerCommandInput,
+    authorizationInput: DispatchClaimEventAuthorizationInput,
+  ): Promise<RunGraphCommandResult | null> {
+    const resolution = await this.claimAuthority.abortPendingAuthorization(
+      authorizationInput,
+      ({ binding }) => this.inspectCommittedEvent(input, binding),
+    );
+    if (resolution.status !== "exact_committed") return null;
+    const receipt = resolution.receipt;
+    const audit = await this.reconcileCompletionAudit(receipt);
+    const claimIsCurrent = await this.claimAuthority.isReceiptClaimCurrent(receipt);
+    return {
+      accepted: true,
+      view: await this.inspect(input.runId),
+      ...(claimIsCurrent
+        ? { claimAuthorization: this.claimAuthorizationResult(receipt, audit) }
+        : {}),
+    };
+  }
+
+  private claimAuthorizationResult(
+    receipt: Extract<DispatchClaimReceipt, { accepted: true }>,
+    audit: DispatchClaimAuthorizationResult["audit"],
+  ): DispatchClaimAuthorizationResult {
+    return {
+      receipt,
+      proof: {
+        claimId: receipt.claim.claimId,
+        fencingToken: receipt.claim.fencingToken,
+        ownerId: receipt.claim.ownerId,
+        runId: receipt.claim.runId,
+      },
+      audit,
+    };
+  }
+
+  private async reconcileCompletionAudit(
+    receipt: Extract<DispatchClaimReceipt, { accepted: true }>,
+  ): Promise<DispatchClaimAuthorizationResult["audit"]> {
+    try {
+      const audit = await this.recordClaimAudit({
+        schemaVersion: "1",
+        eventId: `audit:${receipt.eventId}`,
+        actor: { id: "registry:completion", role: "orchestrator" },
+        receipt: { ...receipt, claim: receipt.claim },
+      });
+      if (!audit.accepted) throw new Error(audit.message);
+      return { recorded: true };
+    } catch (error) {
+      return {
+        recorded: false,
+        pending: true,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /** registry-first command を workspace-local Run Graph audit へ冪等に反映する。 */
+  async recordClaimAudit(rawInput: RunGraphClaimAuditInput): Promise<RunGraphCommandResult> {
+    const input = RunGraphClaimAuditInputSchema.parse(rawInput);
+    const receipt = input.receipt;
+    const runId = receipt.claim.runId;
+    const journal = await this.events.readJournal(runId);
+    const expectedAuditEventId = `audit:${receipt.eventId}`;
+    if (input.eventId !== expectedAuditEventId) {
+      return {
+        accepted: false,
+        code: "duplicate_event",
+        message: `claim audit event ID は receipt から一意に導出する必要があります: ${expectedAuditEventId}`,
+        stateUnchanged: true,
+        view: await this.inspect(runId),
+      };
+    }
+    const existing = journal.acceptedEvents.find((event) => event.eventId === input.eventId);
+    const typeByOperation = {
+      claim: "claim_acquired",
+      heartbeat: "claim_heartbeat",
+      release: "claim_released",
+      reclaim: "claim_reclaimed",
+      authorize_event: "claim_event_authorized",
+    } as const;
+    const command = {
+      type: typeByOperation[receipt.operation],
+      registryEventId: receipt.eventId,
+      registryEntityVersion: receipt.entityVersion,
+      claim: receipt.claim,
+      ...(receipt.operation === "reclaim"
+        ? {
+            reclaimReason: receipt.reclaimReason,
+            ...(receipt.reclaimReason === "owner_stopped"
+              ? { evidenceId: receipt.evidenceId }
+              : {}),
+          }
+        : {}),
+      ...(receipt.operation === "authorize_event" ? { completion: receipt.completion } : {}),
+    };
+    const existingRegistryAudit = journal.acceptedEvents.find(
+      (event) =>
+        "registryEventId" in event.command &&
+        event.command.registryEventId === receipt.eventId &&
+        event.eventId !== expectedAuditEventId,
+    );
+    if (existingRegistryAudit) {
+      return {
+        accepted: false,
+        code: "duplicate_event",
+        message: `registry event は別の audit event ID で記録済みです: ${receipt.eventId}`,
+        stateUnchanged: true,
+        view: await this.inspect(runId),
+      };
+    }
+    if (!(await this.claimAuthority.verifyReceipt(receipt))) {
+      return {
+        accepted: false,
+        code: "stale_claim",
+        message: "claim audit receipt は repository registry の durable receipt と一致しません",
+        stateUnchanged: true,
+        view: await this.inspect(runId),
+      };
+    }
+    if (existing) {
+      if (JSON.stringify(existing.command) === JSON.stringify(command)) {
+        return { accepted: true, view: await this.inspect(runId) };
+      }
+      return {
+        accepted: false,
+        code: "duplicate_event",
+        message: `Run Graph event ID は異なる audit に使用済みです: ${input.eventId}`,
+        stateUnchanged: true,
+        view: await this.inspect(runId),
+      };
+    }
+    if (input.actor.role !== "orchestrator") {
+      return {
+        accepted: false,
+        code: "authority_denied",
+        message: "claim audit は orchestrator authority が必要です",
+        stateUnchanged: true,
+        view: await this.inspect(runId),
+      };
+    }
+    const event: RunGraphAcceptedEvent = {
+      recordType: "accepted",
+      eventId: input.eventId,
+      sequence: journal.acceptedEvents.length + 1,
+      runId,
+      acceptedAt: this.dependencies.now(),
+      actor: input.actor,
+      command,
+      artifactIds: [],
+      evidenceIds: [],
+    };
+    await this.events.appendAccepted(event);
+    return { accepted: true, view: await this.inspect(runId) };
   }
 
   async start(rawInput: RunGraphStartInput): Promise<RunGraphCommandResult> {
@@ -161,6 +539,38 @@ export class RunGraphControlPlane {
   }
 
   async applyEvent(rawInput: RunGraphRunnerCommandInput): Promise<RunGraphCommandResult> {
+    const input = RunGraphRunnerCommandInputSchema.parse(rawInput);
+    if (
+      input.command.type === "attempt_finished" ||
+      input.command.type === "node_outcome_submitted"
+    ) {
+      try {
+        if (await this.claimAuthority.isDispatchConfigured()) {
+          return this.rejectAndRecord(
+            input,
+            "stale_claim",
+            "dispatch 有効 repository の completion/outcome は claim authorization が必要です",
+            await this.inspect(input.runId),
+          );
+        }
+      } catch (error) {
+        const stderr = String((error as { stderr?: unknown }).stderr ?? "");
+        if (!stderr.includes("not a git repository") && !stderr.includes("not a git work tree"))
+          throw error;
+      }
+    }
+    const prepared = await this.validateAndBuildEvent(input);
+    if (!prepared.accepted) {
+      return this.rejectAndRecord(input, prepared.code, prepared.message, prepared.view!);
+    }
+    await this.events.appendAccepted(prepared.prepared.event);
+    return { accepted: true, view: await this.inspect(input.runId) };
+  }
+
+  /** domain validation と event materialize を永続化から分離した explicit seam。 */
+  private async validateAndBuildEvent(
+    rawInput: RunGraphRunnerCommandInput,
+  ): Promise<PreparedRunnerEventResult> {
     const input = RunGraphRunnerCommandInputSchema.parse(rawInput);
     const journal = await this.events.readJournal(input.runId);
     const projection = this.replay(journal);
@@ -698,8 +1108,7 @@ export class RunGraphControlPlane {
       ...(nextContractNodeId ? { nextContractNodeId } : {}),
       ...(waitReason ? { waitReason } : {}),
     };
-    await this.events.appendAccepted(event);
-    return { accepted: true, view: await this.inspect(input.runId) };
+    return { accepted: true, prepared: { event, view } };
   }
 
   async inspect(runId: string, limit = 20, focusNodeId?: string): Promise<RunGraphView> {
@@ -730,6 +1139,25 @@ export class RunGraphControlPlane {
       limit,
       focusNodeId ? (item) => item.nodeId === focusNodeId : null,
     );
+    const allClaimAudits = journal.acceptedEvents
+      .filter((event) =>
+        (
+          [
+            "claim_acquired",
+            "claim_heartbeat",
+            "claim_released",
+            "claim_reclaimed",
+            "claim_event_authorized",
+          ] as const
+        ).includes(event.command.type as never),
+      )
+      .map((event) => ({
+        eventId: event.eventId,
+        acceptedAt: event.acceptedAt,
+        actor: event.actor,
+        command: event.command,
+      }));
+    const claimAudits = allClaimAudits.slice(-limit);
     return RunGraphViewSchema.parse({
       schemaVersion: "1",
       runId: projection.run.id,
@@ -772,6 +1200,12 @@ export class RunGraphControlPlane {
         truncated: projection.evidence.length > evidence.length,
         items: evidence,
       },
+      claimAudits: {
+        total: allClaimAudits.length,
+        limit,
+        truncated: allClaimAudits.length > claimAudits.length,
+        items: claimAudits,
+      },
     });
   }
 
@@ -780,7 +1214,16 @@ export class RunGraphControlPlane {
     code: RunGraphRejectionCode,
     message: string,
     view: RunGraphView,
-  ): Promise<RunGraphCommandResult> {
+  ): Promise<Extract<RunGraphCommandResult, { accepted: false }>> {
+    return { accepted: false, code, message, stateUnchanged: true, view };
+  }
+
+  private async rejectAndRecord(
+    input: RunGraphRunnerCommandInput,
+    code: RunGraphRejectionCode,
+    message: string,
+    view: RunGraphView,
+  ): Promise<Extract<RunGraphCommandResult, { accepted: false }>> {
     await this.events.appendRejection({
       recordType: "rejected",
       rejectionId: this.dependencies.nextId("rejection"),
@@ -1062,6 +1505,16 @@ export class RunGraphControlPlane {
 
       const currentNode = projection.nodes.find((node) => node.id === projection.run.currentNodeId);
       if (!currentNode) throw new Error("current node が projection に存在しません");
+
+      if (
+        command.type === "claim_acquired" ||
+        command.type === "claim_heartbeat" ||
+        command.type === "claim_released" ||
+        command.type === "claim_reclaimed" ||
+        command.type === "claim_event_authorized"
+      ) {
+        continue;
+      }
 
       if (command.type === "attempt_started") {
         const previous = projection.attempts

--- a/packages/cli/src/run-graph/control-plane.ts
+++ b/packages/cli/src/run-graph/control-plane.ts
@@ -192,7 +192,9 @@ export class RunGraphControlPlane {
       );
     }
     const taskId = `${view.task.owner}/${view.task.repo}#${view.task.issueNumber}`.toLowerCase();
-    const commandFingerprint = createHash("sha256").update(JSON.stringify(input)).digest("hex");
+    const commandFingerprint = createHash("sha256")
+      .update(canonicalJsonStringify(input))
+      .digest("hex");
     const authorizationInput = {
       schemaVersion: "1",
       eventId: input.eventId,

--- a/packages/cli/src/store/dispatch-claims.ts
+++ b/packages/cli/src/store/dispatch-claims.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { z } from "zod";
 import {
   ConfigSchema,
+  canonicalJsonStringify,
   DispatchClaimAcquireInputSchema,
   DispatchClaimEventAuthorizationInputSchema,
   DispatchClaimHeartbeatInputSchema,
@@ -26,11 +27,12 @@ import {
   type DispatchConfig,
   type RunGraphDispatchAuthorizationBinding,
 } from "@gh-gantt/shared";
+import { gitCommandEnvironment } from "../util/git-errors.js";
 
 const execFileAsync = promisify(execFile);
 const REGISTRY_VERSION = "v1";
 const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
-const RECOVERY_CLAIM_STALE_MS = 60_000;
+const MAX_RECOVERY_GENERATIONS = 64;
 
 interface DispatchClaimHistoryEvent {
   eventId: string;
@@ -109,6 +111,11 @@ export interface DispatchClaimStoreDependencies {
   afterDeadOwnerObserved?: (ownerNonce: string) => Promise<void>;
   /** test only: recovery claim candidate 完全書込後・atomic publish 前の crash を模擬する。 */
   afterRecoveryClaimCandidateWritten?: (
+    expectedOwnerNonce: string,
+    claimantNonce: string,
+  ) => Promise<void>;
+  /** test only: recovery winner の最終検証後・LOCK retire 前の停止を模擬する。 */
+  afterRecoveryClaimValidated?: (
     expectedOwnerNonce: string,
     claimantNonce: string,
   ) => Promise<void>;
@@ -271,22 +278,12 @@ function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds));
 }
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, item]) => [key, canonicalize(item)]),
-    );
-  }
-  return value;
+function canonicalJsonEquals(left: unknown, right: unknown): boolean {
+  return canonicalJsonStringify(left) === canonicalJsonStringify(right);
 }
 
 function fingerprint(value: unknown): string {
-  return createHash("sha256")
-    .update(JSON.stringify(canonicalize(value)))
-    .digest("hex");
+  return createHash("sha256").update(canonicalJsonStringify(value)).digest("hex");
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -320,14 +317,10 @@ async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
 }
 
 async function runGit(projectRoot: string, args: string[]): Promise<string> {
-  const environment = { ...process.env };
-  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) {
-    delete environment[name];
-  }
   const result = await execFileAsync("git", ["-C", projectRoot, ...args], {
     encoding: "utf8",
     timeout: 10_000,
-    env: environment,
+    env: gitCommandEnvironment(),
   });
   return result.stdout.trim();
 }
@@ -356,7 +349,47 @@ async function resolveLayout(projectRoot: string): Promise<RegistryLayout> {
 }
 
 function recoveryClaimPath(lockPath: string, expectedOwnerNonce: string): string {
-  return join(lockPath, `recovery-claim-${expectedOwnerNonce}.json`);
+  return join(lockPath, `recovery-claim-${fingerprint(expectedOwnerNonce)}.json`);
+}
+
+function recoverySuccessorPath(
+  lockPath: string,
+  expectedOwnerNonce: string,
+  predecessor: string,
+): string {
+  return join(
+    lockPath,
+    `recovery-successor-${fingerprint(expectedOwnerNonce)}-${fingerprint(predecessor)}.json`,
+  );
+}
+
+function parseRecoveryClaim(
+  raw: string,
+  expectedOwnerNonce: string,
+): z.infer<typeof RecoveryClaimSchema> | null {
+  try {
+    const claim = RecoveryClaimSchema.parse(JSON.parse(raw));
+    return claim.expectedOwnerNonce === expectedOwnerNonce ? claim : null;
+  } catch {
+    return null;
+  }
+}
+
+function createRecoveryClaim(
+  expectedOwnerNonce: string,
+  owner: z.infer<typeof LockOwnerSchema>,
+  dependencies: DispatchClaimStoreDependencies,
+): z.infer<typeof RecoveryClaimSchema> {
+  return RecoveryClaimSchema.parse({
+    schemaVersion: "1",
+    expectedOwnerNonce,
+    claimant: {
+      pid: owner.pid,
+      hostname: owner.hostname,
+      nonce: owner.nonce,
+      claimedAt: dependencies.now(),
+    },
+  });
 }
 
 async function publishRecoveryClaim(
@@ -365,7 +398,7 @@ async function publishRecoveryClaim(
   recoveryClaim: z.infer<typeof RecoveryClaimSchema>,
   dependencies: DispatchClaimStoreDependencies,
 ): Promise<void> {
-  const candidatePath = `${markerPath}.candidate-${claimantNonce}`;
+  const candidatePath = `${markerPath}.candidate-${fingerprint(claimantNonce)}`;
   await writeFile(candidatePath, `${JSON.stringify(recoveryClaim, null, 2)}\n`, { flag: "wx" });
   try {
     await dependencies.afterRecoveryClaimCandidateWritten?.(
@@ -377,6 +410,116 @@ async function publishRecoveryClaim(
   } finally {
     await rm(candidatePath, { force: true }).catch(() => undefined);
   }
+}
+
+async function retireObservedDeadOwnerGeneration(
+  layout: RegistryLayout,
+  observedOwner: z.infer<typeof LockOwnerSchema>,
+  contender: z.infer<typeof LockOwnerSchema>,
+  dependencies: DispatchClaimStoreDependencies,
+): Promise<boolean> {
+  let markerPath = recoveryClaimPath(layout.lockPath, observedOwner.nonce);
+  let markerRaw = await readOptional(markerPath);
+  if (markerRaw === null) {
+    await publishRecoveryClaim(
+      markerPath,
+      contender.nonce,
+      createRecoveryClaim(observedOwner.nonce, contender, dependencies),
+      dependencies,
+    );
+    markerRaw = await readOptional(markerPath);
+    if (markerRaw === null) return false;
+  }
+
+  const visitedMarkers = new Set<string>();
+  for (let generation = 0; generation < MAX_RECOVERY_GENERATIONS; generation += 1) {
+    if (visitedMarkers.has(markerPath)) return false;
+    visitedMarkers.add(markerPath);
+    const recoveryClaim = parseRecoveryClaim(markerRaw, observedOwner.nonce);
+    const predecessor = recoveryClaim
+      ? recoveryClaim.claimant.nonce
+      : `malformed-${fingerprint(markerRaw)}`;
+    const successorPath = recoverySuccessorPath(layout.lockPath, observedOwner.nonce, predecessor);
+
+    if (recoveryClaim?.claimant.nonce === contender.nonce) {
+      const [validatedOwnerRaw, validatedRecoveryRaw, validatedSuccessorRaw] = await Promise.all([
+        readOptional(join(layout.lockPath, "owner.json")),
+        readOptional(markerPath),
+        readOptional(successorPath),
+      ]);
+      if (
+        !validatedOwnerRaw ||
+        validatedRecoveryRaw !== markerRaw ||
+        validatedSuccessorRaw !== null
+      ) {
+        return false;
+      }
+      const validatedOwner = LockOwnerSchema.parse(JSON.parse(validatedOwnerRaw));
+      const validatedRecovery = parseRecoveryClaim(validatedRecoveryRaw, observedOwner.nonce);
+      if (
+        validatedOwner.nonce !== observedOwner.nonce ||
+        validatedRecovery?.claimant.nonce !== contender.nonce
+      ) {
+        return false;
+      }
+      await dependencies.afterRecoveryClaimValidated?.(
+        validatedOwner.nonce,
+        validatedRecovery.claimant.nonce,
+      );
+      const [latestOwnerRaw, latestRecoveryRaw, successorRaw] = await Promise.all([
+        readOptional(join(layout.lockPath, "owner.json")),
+        readOptional(markerPath),
+        readOptional(successorPath),
+      ]);
+      if (!latestOwnerRaw || latestRecoveryRaw !== markerRaw || successorRaw !== null) return false;
+      const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
+      const latestRecovery = parseRecoveryClaim(latestRecoveryRaw, observedOwner.nonce);
+      if (
+        latestOwner.nonce !== observedOwner.nonce ||
+        latestRecovery?.claimant.nonce !== contender.nonce
+      ) {
+        return false;
+      }
+      // recovery marker は observed owner generation に、successor marker は predecessor claimant
+      // generation に hard-link no-replace で束縛される。tip winner 自身が live の間は他 contender が
+      // successor を作れない。pause seam 後にも owner/marker/tip を再検証するため、この再検証から
+      // rename まで compliant writer は LOCK を retire できず、winner crash 後だけ次 generation が
+      // 同じ規則で選出される。
+      const recovered = `${layout.lockPath}.recovered-${fingerprint(observedOwner.nonce)}-${randomUUID()}`;
+      await rename(layout.lockPath, recovered);
+      const retiredOwner = LockOwnerSchema.parse(
+        JSON.parse(await readFile(join(recovered, "owner.json"), "utf8")),
+      );
+      if (retiredOwner.nonce !== observedOwner.nonce) {
+        throw new Error("retire 対象の lock owner generation が変化しました");
+      }
+      await rm(recovered, { recursive: true, force: true });
+      return true;
+    }
+
+    if (recoveryClaim) {
+      if (recoveryClaim.claimant.hostname !== dependencies.processIdentity.hostname) return false;
+      if (dependencies.isProcessAlive(recoveryClaim.claimant.pid)) return false;
+    }
+
+    const successorRaw = await readOptional(successorPath);
+    if (successorRaw !== null) {
+      markerPath = successorPath;
+      markerRaw = successorRaw;
+      continue;
+    }
+    await publishRecoveryClaim(
+      successorPath,
+      contender.nonce,
+      createRecoveryClaim(observedOwner.nonce, contender, dependencies),
+      dependencies,
+    );
+    const publishedRaw = await readOptional(successorPath);
+    if (publishedRaw === null) return false;
+    markerPath = successorPath;
+    markerRaw = publishedRaw;
+  }
+  return false;
 }
 
 async function acquireLock(
@@ -414,88 +557,9 @@ async function acquireLock(
           !dependencies.isProcessAlive(current.pid)
         ) {
           await dependencies.afterDeadOwnerObserved?.(current.nonce);
-          const markerPath = recoveryClaimPath(layout.lockPath, current.nonce);
-          const existingRecoveryRaw = await readOptional(markerPath);
           try {
-            if (existingRecoveryRaw !== null) {
-              let existingRecovery: z.infer<typeof RecoveryClaimSchema>;
-              try {
-                existingRecovery = RecoveryClaimSchema.parse(JSON.parse(existingRecoveryRaw));
-              } catch {
-                const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
-                  readOptional(join(layout.lockPath, "owner.json")),
-                  readOptional(markerPath),
-                ]);
-                if (!latestOwnerRaw || latestRecoveryRaw !== existingRecoveryRaw) continue;
-                const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
-                if (latestOwner.nonce !== current.nonce) continue;
-                const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
-                await rename(layout.lockPath, recovered);
-                await rm(recovered, { recursive: true, force: true });
-                continue;
-              }
-              const claimedAt = Date.parse(existingRecovery.claimant.claimedAt);
-              const age = Date.parse(dependencies.now()) - claimedAt;
-              const claimantDead =
-                existingRecovery.claimant.hostname === dependencies.processIdentity.hostname &&
-                !dependencies.isProcessAlive(existingRecovery.claimant.pid);
-              const markerStale =
-                existingRecovery.expectedOwnerNonce !== current.nonce ||
-                claimantDead ||
-                (Number.isFinite(age) && age >= RECOVERY_CLAIM_STALE_MS);
-              if (!markerStale) {
-                if (Date.now() >= deadline) throw new Error("dispatch claim registry は使用中です");
-                await sleep(10);
-                continue;
-              }
-              const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
-                readOptional(join(layout.lockPath, "owner.json")),
-                readOptional(markerPath),
-              ]);
-              if (!latestOwnerRaw || !latestRecoveryRaw) continue;
-              const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
-              const latestRecovery = RecoveryClaimSchema.parse(JSON.parse(latestRecoveryRaw));
-              if (
-                latestOwner.nonce !== current.nonce ||
-                latestRecovery.expectedOwnerNonce !== existingRecovery.expectedOwnerNonce ||
-                latestRecovery.claimant.nonce !== existingRecovery.claimant.nonce
-              ) {
-                continue;
-              }
-              const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
-              await rename(layout.lockPath, recovered);
-              await rm(recovered, { recursive: true, force: true });
+            if (await retireObservedDeadOwnerGeneration(layout, current, owner, dependencies))
               continue;
-            }
-            const recoveryClaim = RecoveryClaimSchema.parse({
-              schemaVersion: "1",
-              expectedOwnerNonce: current.nonce,
-              claimant: {
-                pid: owner.pid,
-                hostname: owner.hostname,
-                nonce: owner.nonce,
-                claimedAt: dependencies.now(),
-              },
-            });
-            await publishRecoveryClaim(markerPath, owner.nonce, recoveryClaim, dependencies);
-            const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
-              readOptional(join(layout.lockPath, "owner.json")),
-              readOptional(markerPath),
-            ]);
-            if (!latestOwnerRaw || !latestRecoveryRaw) continue;
-            const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
-            const latestRecovery = RecoveryClaimSchema.parse(JSON.parse(latestRecoveryRaw));
-            if (
-              latestOwner.nonce !== current.nonce ||
-              latestRecovery.expectedOwnerNonce !== current.nonce ||
-              latestRecovery.claimant.nonce !== owner.nonce
-            ) {
-              continue;
-            }
-            const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
-            await rename(layout.lockPath, recovered);
-            await rm(recovered, { recursive: true, force: true });
-            continue;
           } catch (recoveryError) {
             if (
               !["ENOENT", "EEXIST", "ENOTEMPTY"].includes(
@@ -641,7 +705,7 @@ export class DispatchClaimStore {
         (claim) => claim.claimId === authorization.claim.claimId,
       );
       const current = registry.claims[index];
-      if (!current || JSON.stringify(current) !== JSON.stringify(authorization.claim)) {
+      if (!current || !canonicalJsonEquals(current, authorization.claim)) {
         throw new Error("pending authorization の claim lineage が失効しました");
       }
       receiptClaim = DispatchClaimSchema.parse({
@@ -1017,7 +1081,7 @@ export class DispatchClaimStore {
         authorization.claim.runId !== command.runId ||
         authorization.claim.taskId !== command.taskId ||
         authorization.actorId !== command.actorId ||
-        JSON.stringify(authorization.binding) !== JSON.stringify(expectedBinding)
+        !canonicalJsonEquals(authorization.binding, expectedBinding)
       ) {
         return { status: "conflict" };
       }
@@ -1035,7 +1099,7 @@ export class DispatchClaimStore {
       const current = registry.claims.find(
         (claim) => claim.claimId === authorization.claim.claimId,
       );
-      if (!current || JSON.stringify(current) !== JSON.stringify(authorization.claim))
+      if (!current || !canonicalJsonEquals(current, authorization.claim))
         return { status: "conflict" };
       registry.authorizations.splice(index, 1);
       await this.publishRegistry(layout, registry);
@@ -1149,7 +1213,7 @@ export class DispatchClaimStore {
         return reject("stale_claim", "authorization は既に reclaim されています");
       const index = registry.claims.findIndex((claim) => claim.claimId === pending.claim.claimId);
       const current = registry.claims[index];
-      if (!current || JSON.stringify(current) !== JSON.stringify(pending.claim))
+      if (!current || !canonicalJsonEquals(current, pending.claim))
         return reject("stale_claim", "pending authorization の claim lineage が失効しました");
 
       try {
@@ -1182,9 +1246,9 @@ export class DispatchClaimStore {
     try {
       const registry = await this.readRegistry(layout);
       const stored = registry.receipts.find((item) => item.eventId === parsed.eventId);
-      if (!stored || JSON.stringify(stored.receipt) !== JSON.stringify(parsed)) return false;
+      if (!stored || !canonicalJsonEquals(stored.receipt, parsed)) return false;
       const current = registry.claims.find((claim) => claim.claimId === parsed.claim.claimId);
-      return current !== undefined && JSON.stringify(current) === JSON.stringify(parsed.claim);
+      return current !== undefined && canonicalJsonEquals(current, parsed.claim);
     } finally {
       await release();
     }
@@ -1197,8 +1261,7 @@ export class DispatchClaimStore {
       const registry = await this.readRegistry(layout);
       return registry.receipts.some(
         (stored) =>
-          stored.eventId === receipt.eventId &&
-          JSON.stringify(stored.receipt) === JSON.stringify(receipt),
+          stored.eventId === receipt.eventId && canonicalJsonEquals(stored.receipt, receipt),
       );
     } finally {
       await release();

--- a/packages/cli/src/store/dispatch-claims.ts
+++ b/packages/cli/src/store/dispatch-claims.ts
@@ -1,0 +1,1247 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod";
+import {
+  ConfigSchema,
+  DispatchClaimAcquireInputSchema,
+  DispatchClaimEventAuthorizationInputSchema,
+  DispatchClaimHeartbeatInputSchema,
+  DispatchClaimReceiptSchema,
+  DispatchClaimReclaimInputSchema,
+  DispatchClaimReleaseInputSchema,
+  DispatchClaimSchema,
+  GANTT_DIR,
+  type DispatchClaim,
+  type DispatchClaimAcquireInput,
+  type DispatchClaimEventAuthorizationInput,
+  type DispatchClaimHeartbeatInput,
+  type DispatchClaimProof,
+  type DispatchClaimReceipt,
+  type DispatchClaimReclaimInput,
+  type DispatchClaimReleaseInput,
+  type DispatchConfig,
+  type RunGraphDispatchAuthorizationBinding,
+} from "@gh-gantt/shared";
+
+const execFileAsync = promisify(execFile);
+const REGISTRY_VERSION = "v1";
+const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
+const RECOVERY_CLAIM_STALE_MS = 60_000;
+
+interface DispatchClaimHistoryEvent {
+  eventId: string;
+  operation: "claim" | "heartbeat" | "release" | "reclaim" | "authorize_event";
+  entityVersion: number;
+  occurredAt: string;
+  claimId: string;
+  taskId: string;
+  ownerId: string;
+  runId: string;
+  reclaimReason?: "expired" | "owner_stopped";
+  evidenceId?: string;
+}
+
+interface StoredReceipt {
+  eventId: string;
+  payloadFingerprint: string;
+  receipt: DispatchClaimReceipt;
+}
+
+interface StoredPendingAuthorization {
+  status: "pending";
+  eventId: string;
+  payloadFingerprint: string;
+  claim: DispatchClaim;
+  binding: RunGraphDispatchAuthorizationBinding;
+  actorId: string;
+  createdAt: string;
+}
+
+interface StoredReclaimedAuthorization {
+  status: "reclaimed";
+  eventId: string;
+  payloadFingerprint: string;
+  claim: DispatchClaim;
+  binding: RunGraphDispatchAuthorizationBinding;
+  actorId: string;
+  createdAt: string;
+  reclaimedAt: string;
+  reclaimEventId: string;
+}
+
+type StoredAuthorization = StoredPendingAuthorization | StoredReclaimedAuthorization;
+
+interface DispatchClaimRegistry {
+  schemaVersion: "1";
+  projectIdentity: string;
+  entityVersion: number;
+  claims: DispatchClaim[];
+  authorizations: StoredAuthorization[];
+  receipts: StoredReceipt[];
+  history: DispatchClaimHistoryEvent[];
+}
+
+export interface DispatchClaimSnapshot {
+  schemaVersion: "1";
+  projectIdentity: string;
+  entityVersion: number;
+  claims: DispatchClaim[];
+  pendingAuthorizations: Array<{ eventId: string; claimId: string }>;
+  history: DispatchClaimHistoryEvent[];
+}
+
+export type DispatchClaimAcquireResult =
+  | Extract<DispatchClaimReceipt, { accepted: false }>
+  | (Extract<DispatchClaimReceipt, { accepted: true }> & { claim: DispatchClaim });
+
+export interface DispatchClaimStoreDependencies {
+  now: () => string;
+  nextId: () => string;
+  waitTimeoutMs: number;
+  processIdentity: { pid: number; hostname: string };
+  isProcessAlive: (pid: number) => boolean;
+  readCurrentSnapshotFingerprint?: () => Promise<string>;
+  /** test only: dead owner 観測後の deterministic interleaving point。 */
+  afterDeadOwnerObserved?: (ownerNonce: string) => Promise<void>;
+  /** test only: recovery claim candidate 完全書込後・atomic publish 前の crash を模擬する。 */
+  afterRecoveryClaimCandidateWritten?: (
+    expectedOwnerNonce: string,
+    claimantNonce: string,
+  ) => Promise<void>;
+  /** test only: registry atomic publish 直前の crash を模擬する。 */
+  beforeRegistryPublish?: () => Promise<void>;
+  /** test only: pending authorization 永続化直後の crash を模擬する。 */
+  afterAuthorizationPendingPublish?: () => Promise<void>;
+  /** test only: Run Graph append 後、authorization receipt publish 前の crash を模擬する。 */
+  beforeAuthorizationFinalizePublish?: () => Promise<void>;
+}
+
+export interface DispatchAuthorizedEventCommitContext {
+  claim: DispatchClaim;
+  binding: RunGraphDispatchAuthorizationBinding;
+}
+
+export type PendingAuthorizationInspection = "exact_committed" | "absent" | "conflict";
+
+export type AbortPendingAuthorizationResult =
+  | {
+      status: "exact_committed";
+      receipt: Extract<DispatchClaimReceipt, { accepted: true; operation: "authorize_event" }>;
+    }
+  | { status: "aborted" | "absent" | "conflict" };
+
+const HistoryEventSchema: z.ZodType<DispatchClaimHistoryEvent> = z
+  .object({
+    eventId: z.string().min(1),
+    operation: z.enum(["claim", "heartbeat", "release", "reclaim", "authorize_event"]),
+    entityVersion: z.number().int().positive(),
+    occurredAt: z.string().datetime({ offset: true }),
+    claimId: z.string().min(1),
+    taskId: z.string().min(1),
+    ownerId: z.string().min(1),
+    runId: z.string().min(1),
+    reclaimReason: z.enum(["expired", "owner_stopped"]).optional(),
+    evidenceId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const StoredReceiptSchema: z.ZodType<StoredReceipt> = z
+  .object({
+    eventId: z.string().min(1),
+    payloadFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    receipt: DispatchClaimReceiptSchema,
+  })
+  .strict();
+
+const AuthorizationBaseSchema = z.object({
+  eventId: z.string().min(1),
+  payloadFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+  claim: DispatchClaimSchema,
+  binding: z
+    .object({
+      claimId: z.string().min(1),
+      fencingToken: z.number().int().positive(),
+      ownerId: z.string().min(1),
+      runId: z.string().min(1),
+      taskId: z.string().min(1),
+      commandFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    })
+    .strict(),
+  actorId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+const StoredAuthorizationSchema: z.ZodType<StoredAuthorization> = z.discriminatedUnion("status", [
+  AuthorizationBaseSchema.extend({ status: z.literal("pending") }).strict(),
+  AuthorizationBaseSchema.extend({
+    status: z.literal("reclaimed"),
+    reclaimedAt: z.string().datetime({ offset: true }),
+    reclaimEventId: z.string().min(1),
+  }).strict(),
+]);
+
+const RegistrySchema: z.ZodType<DispatchClaimRegistry, z.ZodTypeDef, unknown> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    projectIdentity: z.string().min(1),
+    entityVersion: z.number().int().nonnegative(),
+    claims: z.array(DispatchClaimSchema),
+    authorizations: z.array(StoredAuthorizationSchema).default([]),
+    receipts: z.array(StoredReceiptSchema),
+    history: z.array(HistoryEventSchema),
+  })
+  .strict()
+  .superRefine((registry, context) => {
+    if (new Set(registry.claims.map((claim) => claim.taskId)).size !== registry.claims.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["claims"],
+        message: "task claim は一意である必要があります",
+      });
+    }
+    if (
+      new Set(registry.claims.map((claim) => claim.workspaceId)).size !== registry.claims.length
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["claims"],
+        message: "workspace claim は一意である必要があります",
+      });
+    }
+    if (
+      new Set(registry.receipts.map((receipt) => receipt.eventId)).size !== registry.receipts.length
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["receipts"],
+        message: "eventId は一意である必要があります",
+      });
+    }
+    if (
+      new Set(registry.authorizations.map((authorization) => authorization.eventId)).size !==
+      registry.authorizations.length
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authorizations"],
+        message: "authorization eventId は一意である必要があります",
+      });
+    }
+  });
+
+const LockOwnerSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    pid: z.number().int().positive(),
+    hostname: z.string().min(1),
+    nonce: z.string().uuid(),
+    startedAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const RecoveryClaimSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    expectedOwnerNonce: z.string().uuid(),
+    claimant: z
+      .object({
+        pid: z.number().int().positive(),
+        hostname: z.string().min(1),
+        nonce: z.string().uuid(),
+        claimedAt: z.string().datetime({ offset: true }),
+      })
+      .strict(),
+  })
+  .strict();
+
+interface RegistryLayout {
+  root: string;
+  registryPath: string;
+  lockPath: string;
+  projectIdentity: string;
+  dispatch: DispatchConfig | undefined;
+  configuredStates: Set<string>;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    );
+  }
+  return value;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)))
+    .digest("hex");
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function readOptional(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  try {
+    await rename(temporary, path);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function runGit(projectRoot: string, args: string[]): Promise<string> {
+  const environment = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) {
+    delete environment[name];
+  }
+  const result = await execFileAsync("git", ["-C", projectRoot, ...args], {
+    encoding: "utf8",
+    timeout: 10_000,
+    env: environment,
+  });
+  return result.stdout.trim();
+}
+
+async function resolveLayout(projectRoot: string): Promise<RegistryLayout> {
+  const absoluteRoot = resolve(projectRoot);
+  const rawCommonDir = await runGit(absoluteRoot, ["rev-parse", "--git-common-dir"]);
+  const commonDir = await realpath(
+    isAbsolute(rawCommonDir) ? rawCommonDir : resolve(absoluteRoot, rawCommonDir),
+  );
+  const config = ConfigSchema.parse(
+    JSON.parse(await readFile(join(absoluteRoot, GANTT_DIR, "gantt.config.json"), "utf8")),
+  );
+  const github = config.project.github;
+  const projectIdentity = `${github.owner.trim().toLowerCase()}/${github.repo.trim().toLowerCase()}#${github.project_number}`;
+  const projectKey = fingerprint(projectIdentity).slice(0, 32);
+  const root = join(commonDir, "gh-gantt", "coordination", REGISTRY_VERSION, projectKey);
+  return {
+    root,
+    registryPath: join(root, "registry.json"),
+    lockPath: join(root, "LOCK"),
+    projectIdentity,
+    dispatch: config.dispatch,
+    configuredStates: new Set(Object.keys(config.statuses.values)),
+  };
+}
+
+function recoveryClaimPath(lockPath: string, expectedOwnerNonce: string): string {
+  return join(lockPath, `recovery-claim-${expectedOwnerNonce}.json`);
+}
+
+async function publishRecoveryClaim(
+  markerPath: string,
+  claimantNonce: string,
+  recoveryClaim: z.infer<typeof RecoveryClaimSchema>,
+  dependencies: DispatchClaimStoreDependencies,
+): Promise<void> {
+  const candidatePath = `${markerPath}.candidate-${claimantNonce}`;
+  await writeFile(candidatePath, `${JSON.stringify(recoveryClaim, null, 2)}\n`, { flag: "wx" });
+  try {
+    await dependencies.afterRecoveryClaimCandidateWritten?.(
+      recoveryClaim.expectedOwnerNonce,
+      claimantNonce,
+    );
+    // hard link は同一 filesystem 上で atomic かつ既存 marker を上書きしない。
+    await link(candidatePath, markerPath);
+  } finally {
+    await rm(candidatePath, { force: true }).catch(() => undefined);
+  }
+}
+
+async function acquireLock(
+  layout: RegistryLayout,
+  dependencies: DispatchClaimStoreDependencies,
+): Promise<() => Promise<void>> {
+  await mkdir(layout.root, { recursive: true });
+  const owner = {
+    schemaVersion: "1" as const,
+    pid: dependencies.processIdentity.pid,
+    hostname: dependencies.processIdentity.hostname,
+    nonce: randomUUID(),
+    startedAt: dependencies.now(),
+  };
+  const deadline = Date.now() + dependencies.waitTimeoutMs;
+  while (true) {
+    const candidate = `${layout.lockPath}.candidate-${owner.nonce}`;
+    try {
+      await mkdir(candidate);
+      await writeJsonAtomic(join(candidate, "owner.json"), owner);
+      await rename(candidate, layout.lockPath);
+      break;
+    } catch (error) {
+      await rm(candidate, { recursive: true, force: true }).catch(() => undefined);
+      if (
+        (error as NodeJS.ErrnoException).code !== "EEXIST" &&
+        (error as NodeJS.ErrnoException).code !== "ENOTEMPTY"
+      )
+        throw error;
+      const raw = await readOptional(join(layout.lockPath, "owner.json"));
+      if (raw) {
+        const current = LockOwnerSchema.parse(JSON.parse(raw));
+        if (
+          current.hostname === dependencies.processIdentity.hostname &&
+          !dependencies.isProcessAlive(current.pid)
+        ) {
+          await dependencies.afterDeadOwnerObserved?.(current.nonce);
+          const markerPath = recoveryClaimPath(layout.lockPath, current.nonce);
+          const existingRecoveryRaw = await readOptional(markerPath);
+          try {
+            if (existingRecoveryRaw !== null) {
+              let existingRecovery: z.infer<typeof RecoveryClaimSchema>;
+              try {
+                existingRecovery = RecoveryClaimSchema.parse(JSON.parse(existingRecoveryRaw));
+              } catch {
+                const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
+                  readOptional(join(layout.lockPath, "owner.json")),
+                  readOptional(markerPath),
+                ]);
+                if (!latestOwnerRaw || latestRecoveryRaw !== existingRecoveryRaw) continue;
+                const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
+                if (latestOwner.nonce !== current.nonce) continue;
+                const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
+                await rename(layout.lockPath, recovered);
+                await rm(recovered, { recursive: true, force: true });
+                continue;
+              }
+              const claimedAt = Date.parse(existingRecovery.claimant.claimedAt);
+              const age = Date.parse(dependencies.now()) - claimedAt;
+              const claimantDead =
+                existingRecovery.claimant.hostname === dependencies.processIdentity.hostname &&
+                !dependencies.isProcessAlive(existingRecovery.claimant.pid);
+              const markerStale =
+                existingRecovery.expectedOwnerNonce !== current.nonce ||
+                claimantDead ||
+                (Number.isFinite(age) && age >= RECOVERY_CLAIM_STALE_MS);
+              if (!markerStale) {
+                if (Date.now() >= deadline) throw new Error("dispatch claim registry は使用中です");
+                await sleep(10);
+                continue;
+              }
+              const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
+                readOptional(join(layout.lockPath, "owner.json")),
+                readOptional(markerPath),
+              ]);
+              if (!latestOwnerRaw || !latestRecoveryRaw) continue;
+              const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
+              const latestRecovery = RecoveryClaimSchema.parse(JSON.parse(latestRecoveryRaw));
+              if (
+                latestOwner.nonce !== current.nonce ||
+                latestRecovery.expectedOwnerNonce !== existingRecovery.expectedOwnerNonce ||
+                latestRecovery.claimant.nonce !== existingRecovery.claimant.nonce
+              ) {
+                continue;
+              }
+              const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
+              await rename(layout.lockPath, recovered);
+              await rm(recovered, { recursive: true, force: true });
+              continue;
+            }
+            const recoveryClaim = RecoveryClaimSchema.parse({
+              schemaVersion: "1",
+              expectedOwnerNonce: current.nonce,
+              claimant: {
+                pid: owner.pid,
+                hostname: owner.hostname,
+                nonce: owner.nonce,
+                claimedAt: dependencies.now(),
+              },
+            });
+            await publishRecoveryClaim(markerPath, owner.nonce, recoveryClaim, dependencies);
+            const [latestOwnerRaw, latestRecoveryRaw] = await Promise.all([
+              readOptional(join(layout.lockPath, "owner.json")),
+              readOptional(markerPath),
+            ]);
+            if (!latestOwnerRaw || !latestRecoveryRaw) continue;
+            const latestOwner = LockOwnerSchema.parse(JSON.parse(latestOwnerRaw));
+            const latestRecovery = RecoveryClaimSchema.parse(JSON.parse(latestRecoveryRaw));
+            if (
+              latestOwner.nonce !== current.nonce ||
+              latestRecovery.expectedOwnerNonce !== current.nonce ||
+              latestRecovery.claimant.nonce !== owner.nonce
+            ) {
+              continue;
+            }
+            const recovered = `${layout.lockPath}.recovered-${current.nonce}-${randomUUID()}`;
+            await rename(layout.lockPath, recovered);
+            await rm(recovered, { recursive: true, force: true });
+            continue;
+          } catch (recoveryError) {
+            if (
+              !["ENOENT", "EEXIST", "ENOTEMPTY"].includes(
+                (recoveryError as NodeJS.ErrnoException).code ?? "",
+              )
+            )
+              throw recoveryError;
+          }
+        }
+      }
+      if (Date.now() >= deadline) throw new Error("dispatch claim registry は使用中です");
+      await sleep(10);
+    }
+  }
+  return async () => {
+    const raw = await readOptional(join(layout.lockPath, "owner.json"));
+    if (!raw) return;
+    const current = LockOwnerSchema.parse(JSON.parse(raw));
+    if (current.nonce !== owner.nonce)
+      throw new Error("dispatch claim registry lock owner が変化しました");
+    const retired = `${layout.lockPath}.retired-${owner.nonce}`;
+    await rename(layout.lockPath, retired);
+    await rm(retired, { recursive: true, force: true });
+  };
+}
+
+function emptyRegistry(layout: RegistryLayout): DispatchClaimRegistry {
+  return {
+    schemaVersion: "1",
+    projectIdentity: layout.projectIdentity,
+    entityVersion: 0,
+    claims: [],
+    authorizations: [],
+    receipts: [],
+    history: [],
+  };
+}
+
+function proofMatches(claim: DispatchClaim, proof: DispatchClaimProof): boolean {
+  return (
+    claim.claimId === proof.claimId &&
+    claim.fencingToken === proof.fencingToken &&
+    claim.ownerId === proof.ownerId &&
+    claim.runId === proof.runId
+  );
+}
+
+export function createDispatchClaimStoreDependencies(
+  overrides: Partial<DispatchClaimStoreDependencies> = {},
+): DispatchClaimStoreDependencies {
+  return {
+    now: () => new Date().toISOString(),
+    nextId: () => `claim-${randomUUID()}`,
+    waitTimeoutMs: DEFAULT_WAIT_TIMEOUT_MS,
+    processIdentity: { pid: process.pid, hostname: hostname() },
+    isProcessAlive,
+    ...overrides,
+  };
+}
+
+/** repository-shared claim registry を短時間 transaction だけで更新する public Store。 */
+export class DispatchClaimStore {
+  private readonly dependencies: DispatchClaimStoreDependencies;
+
+  constructor(
+    private readonly projectRoot: string,
+    dependencies: DispatchClaimStoreDependencies = createDispatchClaimStoreDependencies(),
+  ) {
+    this.dependencies = dependencies;
+  }
+
+  private async readRegistry(layout: RegistryLayout): Promise<DispatchClaimRegistry> {
+    const raw = await readOptional(layout.registryPath);
+    if (raw === null) return emptyRegistry(layout);
+    const registry = RegistrySchema.parse(JSON.parse(raw));
+    if (registry.projectIdentity !== layout.projectIdentity) {
+      throw new Error("dispatch claim registry の project identity が一致しません");
+    }
+    return registry;
+  }
+
+  private async transact<T>(
+    callback: (layout: RegistryLayout, registry: DispatchClaimRegistry) => Promise<T>,
+  ): Promise<T> {
+    const layout = await resolveLayout(this.projectRoot);
+    const release = await acquireLock(layout, this.dependencies);
+    try {
+      return await callback(layout, await this.readRegistry(layout));
+    } finally {
+      await release();
+    }
+  }
+
+  private replayOrMismatch(
+    registry: DispatchClaimRegistry,
+    eventId: string,
+    payloadFingerprint: string,
+    operation: DispatchClaimReceipt["operation"],
+  ): DispatchClaimReceipt | null {
+    const stored = registry.receipts.find((item) => item.eventId === eventId);
+    if (!stored) return null;
+    if (stored.payloadFingerprint === payloadFingerprint) return stored.receipt;
+    return {
+      accepted: false,
+      operation,
+      eventId,
+      entityVersion: registry.entityVersion,
+      stateUnchanged: true,
+      code: "event_payload_mismatch",
+      message: "同じ eventId に異なる payload は使用できません",
+    };
+  }
+
+  private async reject(
+    layout: RegistryLayout,
+    registry: DispatchClaimRegistry,
+    payloadFingerprint: string,
+    receipt: Extract<DispatchClaimReceipt, { accepted: false }>,
+  ): Promise<DispatchClaimReceipt> {
+    registry.receipts.push({ eventId: receipt.eventId, payloadFingerprint, receipt });
+    await this.publishRegistry(layout, registry);
+    return receipt;
+  }
+
+  private async publishRegistry(
+    layout: RegistryLayout,
+    registry: DispatchClaimRegistry,
+  ): Promise<void> {
+    await this.dependencies.beforeRegistryPublish?.();
+    await writeJsonAtomic(layout.registryPath, RegistrySchema.parse(registry));
+  }
+
+  private async finalizeAuthorization(
+    layout: RegistryLayout,
+    registry: DispatchClaimRegistry,
+    authorization: StoredAuthorization,
+  ): Promise<Extract<DispatchClaimReceipt, { accepted: true; operation: "authorize_event" }>> {
+    const entityVersion = registry.entityVersion + 1;
+    const claimContinues = authorization.status === "pending";
+    let receiptClaim = authorization.claim;
+    if (claimContinues) {
+      const index = registry.claims.findIndex(
+        (claim) => claim.claimId === authorization.claim.claimId,
+      );
+      const current = registry.claims[index];
+      if (!current || JSON.stringify(current) !== JSON.stringify(authorization.claim)) {
+        throw new Error("pending authorization の claim lineage が失効しました");
+      }
+      receiptClaim = DispatchClaimSchema.parse({
+        ...authorization.claim,
+        entityVersion,
+        fencingToken: entityVersion,
+      });
+      registry.claims[index] = receiptClaim;
+    }
+    const receipt = DispatchClaimReceiptSchema.parse({
+      accepted: true,
+      operation: "authorize_event",
+      eventId: authorization.eventId,
+      entityVersion,
+      stateUnchanged: false,
+      claim: receiptClaim,
+      completion: {
+        runId: authorization.claim.runId,
+        taskId: authorization.claim.taskId,
+        actorId: authorization.actorId,
+        commandFingerprint: authorization.binding.commandFingerprint,
+      },
+      claimContinues,
+    });
+    if (!receipt.accepted || receipt.operation !== "authorize_event") {
+      throw new Error("authorize_event receipt の構築に失敗しました");
+    }
+    registry.entityVersion = entityVersion;
+    registry.authorizations = registry.authorizations.filter(
+      (stored) => stored.eventId !== authorization.eventId,
+    );
+    registry.receipts.push({
+      eventId: authorization.eventId,
+      payloadFingerprint: authorization.payloadFingerprint,
+      receipt,
+    });
+    registry.history.push({
+      eventId: authorization.eventId,
+      operation: "authorize_event",
+      entityVersion,
+      occurredAt: this.dependencies.now(),
+      claimId: authorization.claim.claimId,
+      taskId: authorization.claim.taskId,
+      ownerId: authorization.claim.ownerId,
+      runId: authorization.claim.runId,
+    });
+    await this.dependencies.beforeAuthorizationFinalizePublish?.();
+    await this.publishRegistry(layout, registry);
+    return receipt;
+  }
+
+  async claim(
+    input: DispatchClaimAcquireInput,
+    readCurrentSnapshotFingerprint?: () => Promise<string>,
+  ): Promise<DispatchClaimAcquireResult> {
+    const command = DispatchClaimAcquireInputSchema.parse(input);
+    const payloadFingerprint = fingerprint(command);
+    return this.transact(async (layout, registry) => {
+      const replay = this.replayOrMismatch(registry, command.eventId, payloadFingerprint, "claim");
+      if (replay) return replay as DispatchClaimAcquireResult;
+      const rejection = (
+        code: Extract<DispatchClaimReceipt, { accepted: false }>["code"],
+        message: string,
+      ) =>
+        this.reject(layout, registry, payloadFingerprint, {
+          accepted: false,
+          operation: "claim",
+          eventId: command.eventId,
+          entityVersion: registry.entityVersion,
+          stateUnchanged: true,
+          code,
+          message,
+        }) as Promise<DispatchClaimReceipt & { accepted: false }>;
+      if (command.expectedEntityVersion !== registry.entityVersion)
+        return rejection(
+          "stale_entity_version",
+          "expected entityVersion が current と一致しません",
+        );
+      const readSnapshot =
+        readCurrentSnapshotFingerprint ?? this.dependencies.readCurrentSnapshotFingerprint;
+      if (!readSnapshot || (await readSnapshot()) !== command.snapshotFingerprint)
+        return rejection(
+          "snapshot_mismatch",
+          "claim 直前の Work Graph/gate snapshot が dispatch plan と一致しません",
+        );
+      if (registry.claims.some((claim) => claim.taskId === command.taskId))
+        return rejection("task_already_claimed", "task は既に claim されています");
+      if (registry.claims.some((claim) => claim.workspaceId === command.workspaceId))
+        return rejection("workspace_already_claimed", "workspace は既に claim されています");
+      if (!layout.dispatch)
+        return rejection(
+          "dispatch_not_configured",
+          "repository config に dispatch 設定がありません",
+        );
+      if (!layout.configuredStates.has(command.state))
+        return rejection(
+          "unknown_state",
+          "claim state は configured status と一致する必要があります",
+        );
+      if (registry.claims.length >= layout.dispatch.max_concurrency)
+        return rejection("global_capacity", "global concurrency 上限に達しています");
+      const stateLimit =
+        layout.dispatch.state_concurrency?.[command.state] ?? layout.dispatch.max_concurrency;
+      if (registry.claims.filter((claim) => claim.state === command.state).length >= stateLimit)
+        return rejection("state_capacity", "state concurrency 上限に達しています");
+      const repositoryLimit =
+        layout.dispatch.repository_concurrency?.[command.repository] ??
+        layout.dispatch.max_concurrency;
+      if (
+        registry.claims.filter((claim) => claim.repository === command.repository).length >=
+        repositoryLimit
+      )
+        return rejection("repository_capacity", "repository concurrency 上限に達しています");
+      const entityVersion = registry.entityVersion + 1;
+      const acquiredAt = this.dependencies.now();
+      const claim: DispatchClaim = DispatchClaimSchema.parse({
+        taskId: command.taskId,
+        repository: command.repository,
+        state: command.state,
+        ownerId: command.ownerId,
+        workspaceId: command.workspaceId,
+        runId: command.runId,
+        claimId: this.dependencies.nextId(),
+        entityVersion,
+        fencingToken: entityVersion,
+        acquiredAt,
+        expiresAt: new Date(
+          Date.parse(acquiredAt) + command.leaseDurationSeconds * 1000,
+        ).toISOString(),
+        dispatchPlanId: command.dispatchPlanId,
+        dispatchPlanVersion: command.dispatchPlanVersion,
+      });
+      const receipt = DispatchClaimReceiptSchema.parse({
+        accepted: true,
+        operation: "claim",
+        eventId: command.eventId,
+        entityVersion,
+        stateUnchanged: false,
+        claim,
+      }) as Extract<DispatchClaimReceipt, { accepted: true }> & { claim: DispatchClaim };
+      registry.entityVersion = entityVersion;
+      registry.claims.push(claim);
+      registry.receipts.push({ eventId: command.eventId, payloadFingerprint, receipt });
+      registry.history.push({
+        eventId: command.eventId,
+        operation: "claim",
+        entityVersion,
+        occurredAt: acquiredAt,
+        claimId: claim.claimId,
+        taskId: claim.taskId,
+        ownerId: claim.ownerId,
+        runId: claim.runId,
+      });
+      await this.publishRegistry(layout, registry);
+      return receipt;
+    });
+  }
+
+  async heartbeat(input: DispatchClaimHeartbeatInput): Promise<DispatchClaimReceipt> {
+    const command = DispatchClaimHeartbeatInputSchema.parse(input);
+    return this.updateCurrent("heartbeat", command, command.proof, (claim, entityVersion, now) => ({
+      ...claim,
+      entityVersion,
+      fencingToken: entityVersion,
+      expiresAt: new Date(Date.parse(now) + command.leaseDurationSeconds * 1000).toISOString(),
+    }));
+  }
+
+  async release(input: DispatchClaimReleaseInput): Promise<DispatchClaimReceipt> {
+    const command = DispatchClaimReleaseInputSchema.parse(input);
+    return this.updateCurrent("release", command, command.proof, () => null);
+  }
+
+  private async updateCurrent(
+    operation: "heartbeat" | "release",
+    command: DispatchClaimHeartbeatInput | DispatchClaimReleaseInput,
+    proof: DispatchClaimProof,
+    update: (claim: DispatchClaim, entityVersion: number, now: string) => DispatchClaim | null,
+  ): Promise<DispatchClaimReceipt> {
+    const payloadFingerprint = fingerprint(command);
+    return this.transact(async (layout, registry) => {
+      const replay = this.replayOrMismatch(
+        registry,
+        command.eventId,
+        payloadFingerprint,
+        operation,
+      );
+      if (replay) return replay;
+      const reject = (
+        code: Extract<DispatchClaimReceipt, { accepted: false }>["code"],
+        message: string,
+      ) =>
+        this.reject(layout, registry, payloadFingerprint, {
+          accepted: false,
+          operation,
+          eventId: command.eventId,
+          entityVersion: registry.entityVersion,
+          stateUnchanged: true,
+          code,
+          message,
+        });
+      if (
+        registry.authorizations.some(
+          (authorization) =>
+            authorization.status === "pending" && authorization.claim.claimId === proof.claimId,
+        )
+      ) {
+        return reject(
+          "authorization_pending",
+          "未確定の Run Graph authorization があるため claim を更新できません",
+        );
+      }
+      if (command.expectedEntityVersion !== registry.entityVersion)
+        return reject("stale_entity_version", "expected entityVersion が current と一致しません");
+      const index = registry.claims.findIndex((claim) => claim.claimId === proof.claimId);
+      if (index < 0) return reject("stale_claim", "current claim が見つかりません");
+      const current = registry.claims[index]!;
+      if (!proofMatches(current, proof))
+        return reject("stale_claim", "current fencing proof と一致しません");
+      const now = this.dependencies.now();
+      if (Date.parse(current.expiresAt) <= Date.parse(now))
+        return reject("lease_expired", `期限切れ claim は ${operation} できません`);
+      const entityVersion = registry.entityVersion + 1;
+      const next = update(current, entityVersion, now);
+      if (next) registry.claims[index] = DispatchClaimSchema.parse(next);
+      else registry.claims.splice(index, 1);
+      const receipt = DispatchClaimReceiptSchema.parse({
+        accepted: true,
+        operation,
+        eventId: command.eventId,
+        entityVersion,
+        stateUnchanged: false,
+        claim: next ?? current,
+      });
+      registry.entityVersion = entityVersion;
+      registry.receipts.push({ eventId: command.eventId, payloadFingerprint, receipt });
+      registry.history.push({
+        eventId: command.eventId,
+        operation,
+        entityVersion,
+        occurredAt: now,
+        claimId: current.claimId,
+        taskId: current.taskId,
+        ownerId: current.ownerId,
+        runId: current.runId,
+      });
+      await this.publishRegistry(layout, registry);
+      return receipt;
+    });
+  }
+
+  async reclaim(input: DispatchClaimReclaimInput): Promise<DispatchClaimReceipt> {
+    const command = DispatchClaimReclaimInputSchema.parse(input);
+    const payloadFingerprint = fingerprint(command);
+    return this.transact(async (layout, registry) => {
+      const replay = this.replayOrMismatch(
+        registry,
+        command.eventId,
+        payloadFingerprint,
+        "reclaim",
+      );
+      if (replay) return replay;
+      const reject = (
+        code: Extract<DispatchClaimReceipt, { accepted: false }>["code"],
+        message: string,
+      ) =>
+        this.reject(layout, registry, payloadFingerprint, {
+          accepted: false,
+          operation: "reclaim",
+          eventId: command.eventId,
+          entityVersion: registry.entityVersion,
+          stateUnchanged: true,
+          code,
+          message,
+        });
+      if (command.expectedEntityVersion !== registry.entityVersion)
+        return reject("stale_entity_version", "expected entityVersion が current と一致しません");
+      const index = registry.claims.findIndex((claim) => claim.claimId === command.claimId);
+      if (index < 0) return reject("claim_not_found", "reclaim 対象が見つかりません");
+      const current = registry.claims[index]!;
+      const now = this.dependencies.now();
+      if (command.reason === "expired" && Date.parse(current.expiresAt) > Date.parse(now))
+        return reject("lease_not_expired", "期限前の claim は reclaim できません");
+      const entityVersion = registry.entityVersion + 1;
+      registry.authorizations = registry.authorizations.map((authorization) =>
+        authorization.status === "pending" && authorization.claim.claimId === current.claimId
+          ? {
+              ...authorization,
+              status: "reclaimed" as const,
+              reclaimedAt: now,
+              reclaimEventId: command.eventId,
+            }
+          : authorization,
+      );
+      registry.claims.splice(index, 1);
+      const receipt = DispatchClaimReceiptSchema.parse({
+        accepted: true,
+        operation: "reclaim",
+        eventId: command.eventId,
+        entityVersion,
+        stateUnchanged: false,
+        claim: current,
+        reclaimReason: command.reason,
+        ...(command.ownerStoppedEvidenceId ? { evidenceId: command.ownerStoppedEvidenceId } : {}),
+      });
+      registry.entityVersion = entityVersion;
+      registry.receipts.push({ eventId: command.eventId, payloadFingerprint, receipt });
+      registry.history.push({
+        eventId: command.eventId,
+        operation: "reclaim",
+        entityVersion,
+        occurredAt: now,
+        claimId: current.claimId,
+        taskId: current.taskId,
+        ownerId: current.ownerId,
+        runId: current.runId,
+        reclaimReason: command.reason,
+        ...(command.ownerStoppedEvidenceId ? { evidenceId: command.ownerStoppedEvidenceId } : {}),
+      });
+      await this.publishRegistry(layout, registry);
+      return receipt;
+    });
+  }
+
+  /**
+   * append 前の domain rejection で不要になった exact pending authorization だけを解除する。
+   * registry lock 内で Run Graph を再確認し、exact event があれば current/historical receipt を確定する。
+   */
+  async abortPendingAuthorization(
+    input: DispatchClaimEventAuthorizationInput,
+    inspectCommittedEvent: (
+      context: DispatchAuthorizedEventCommitContext,
+    ) => Promise<PendingAuthorizationInspection>,
+  ): Promise<AbortPendingAuthorizationResult> {
+    const command = DispatchClaimEventAuthorizationInputSchema.parse(input);
+    const payloadFingerprint = fingerprint(command);
+    const expectedBinding: RunGraphDispatchAuthorizationBinding = {
+      claimId: command.proof.claimId,
+      fencingToken: command.proof.fencingToken,
+      ownerId: command.proof.ownerId,
+      runId: command.proof.runId,
+      taskId: command.taskId,
+      commandFingerprint: command.commandFingerprint,
+    };
+    return this.transact(async (layout, registry) => {
+      const replay = this.replayOrMismatch(
+        registry,
+        command.eventId,
+        payloadFingerprint,
+        "authorize_event",
+      );
+      if (replay) {
+        if (!replay.accepted || replay.operation !== "authorize_event") {
+          return { status: "conflict" };
+        }
+        const inspection = await inspectCommittedEvent({
+          claim: replay.claim,
+          binding: expectedBinding,
+        });
+        return inspection === "exact_committed"
+          ? { status: "exact_committed", receipt: replay }
+          : { status: "conflict" };
+      }
+      const index = registry.authorizations.findIndex(
+        (authorization) => authorization.eventId === command.eventId,
+      );
+      if (index < 0) return { status: "absent" };
+      const authorization = registry.authorizations[index]!;
+      if (authorization.payloadFingerprint !== payloadFingerprint) return { status: "conflict" };
+      if (
+        !proofMatches(authorization.claim, command.proof) ||
+        authorization.claim.entityVersion !== command.expectedEntityVersion ||
+        authorization.claim.runId !== command.runId ||
+        authorization.claim.taskId !== command.taskId ||
+        authorization.actorId !== command.actorId ||
+        JSON.stringify(authorization.binding) !== JSON.stringify(expectedBinding)
+      ) {
+        return { status: "conflict" };
+      }
+      const inspection = await inspectCommittedEvent({
+        claim: authorization.claim,
+        binding: authorization.binding,
+      });
+      if (inspection === "exact_committed") {
+        return {
+          status: "exact_committed",
+          receipt: await this.finalizeAuthorization(layout, registry, authorization),
+        };
+      }
+      if (authorization.status !== "pending") return { status: "absent" };
+      const current = registry.claims.find(
+        (claim) => claim.claimId === authorization.claim.claimId,
+      );
+      if (!current || JSON.stringify(current) !== JSON.stringify(authorization.claim))
+        return { status: "conflict" };
+      registry.authorizations.splice(index, 1);
+      await this.publishRegistry(layout, registry);
+      return { status: "aborted" };
+    });
+  }
+
+  /**
+   * current proof と binding を pending として先に永続化し、Run Graph append 後に receipt を確定する。
+   * append 前後の crash では pending が repository 共通領域に残るため、heartbeat/release は進めない。
+   */
+  async commitAuthorizedEvent(
+    input: DispatchClaimEventAuthorizationInput,
+    commit: (context: DispatchAuthorizedEventCommitContext) => Promise<void>,
+    options: { persistRejection?: boolean; historicalReconciliation?: boolean } = {},
+  ): Promise<DispatchClaimReceipt> {
+    const command = DispatchClaimEventAuthorizationInputSchema.parse(input);
+    const payloadFingerprint = fingerprint(command);
+    return this.transact(async (layout, registry) => {
+      const replay = this.replayOrMismatch(
+        registry,
+        command.eventId,
+        payloadFingerprint,
+        "authorize_event",
+      );
+      if (replay) return replay;
+      const reject = async (
+        code: Extract<DispatchClaimReceipt, { accepted: false }>["code"],
+        message: string,
+      ) => {
+        const receipt: Extract<DispatchClaimReceipt, { accepted: false }> = {
+          accepted: false,
+          operation: "authorize_event",
+          eventId: command.eventId,
+          entityVersion: registry.entityVersion,
+          stateUnchanged: true,
+          code,
+          message,
+        };
+        return options.persistRejection === false
+          ? receipt
+          : this.reject(layout, registry, payloadFingerprint, receipt);
+      };
+      const storedAuthorization = registry.authorizations.find(
+        (authorization) => authorization.eventId === command.eventId,
+      );
+      if (storedAuthorization && storedAuthorization.payloadFingerprint !== payloadFingerprint)
+        return reject("event_payload_mismatch", "pending authorization の payload が一致しません");
+
+      if (storedAuthorization?.status === "reclaimed") {
+        if (!options.historicalReconciliation)
+          return reject("stale_claim", "reclaim 済み authorization は新規 append に使用できません");
+        await commit({
+          claim: storedAuthorization.claim,
+          binding: storedAuthorization.binding,
+        });
+        return this.finalizeAuthorization(layout, registry, storedAuthorization);
+      }
+
+      let pending = storedAuthorization;
+      if (!pending) {
+        if (command.expectedEntityVersion !== registry.entityVersion)
+          return reject("stale_entity_version", "expected entityVersion が current と一致しません");
+        const index = registry.claims.findIndex((claim) => claim.claimId === command.proof.claimId);
+        if (index < 0) return reject("stale_claim", "current claim が見つかりません");
+        const current = registry.claims[index]!;
+        if (!proofMatches(current, command.proof))
+          return reject("stale_claim", "current fencing proof と一致しません");
+        if (
+          current.runId !== command.runId ||
+          current.runId !== command.proof.runId ||
+          current.taskId !== command.taskId ||
+          current.ownerId !== command.actorId
+        )
+          return reject(
+            "stale_claim",
+            "completion の run/task/actor lineage が claim と一致しません",
+          );
+        const now = this.dependencies.now();
+        if (Date.parse(current.expiresAt) <= Date.parse(now))
+          return reject("lease_expired", "期限切れ claim は completion できません");
+        if (
+          registry.authorizations.some(
+            (authorization) =>
+              authorization.status === "pending" && authorization.claim.claimId === current.claimId,
+          )
+        )
+          return reject("authorization_pending", "同じ claim に未確定の authorization があります");
+        pending = {
+          status: "pending",
+          eventId: command.eventId,
+          payloadFingerprint,
+          claim: current,
+          binding: {
+            claimId: current.claimId,
+            fencingToken: current.fencingToken,
+            ownerId: current.ownerId,
+            runId: current.runId,
+            taskId: current.taskId,
+            commandFingerprint: command.commandFingerprint,
+          },
+          actorId: command.actorId,
+          createdAt: now,
+        };
+        registry.authorizations.push(pending);
+        await this.publishRegistry(layout, registry);
+        await this.dependencies.afterAuthorizationPendingPublish?.();
+      }
+
+      if (pending.status !== "pending")
+        return reject("stale_claim", "authorization は既に reclaim されています");
+      const index = registry.claims.findIndex((claim) => claim.claimId === pending.claim.claimId);
+      const current = registry.claims[index];
+      if (!current || JSON.stringify(current) !== JSON.stringify(pending.claim))
+        return reject("stale_claim", "pending authorization の claim lineage が失効しました");
+
+      try {
+        await commit({ claim: pending.claim, binding: pending.binding });
+      } catch (error) {
+        // RunGraphEventStore は append を commit した後には throw しない契約なので、
+        // callback failure は未appendとして pending を解除し original proof を復活できる。
+        registry.authorizations = registry.authorizations.filter(
+          (authorization) => authorization.eventId !== command.eventId,
+        );
+        await this.publishRegistry(layout, registry);
+        throw error;
+      }
+      return this.finalizeAuthorization(layout, registry, pending);
+    });
+  }
+
+  async isDispatchConfigured(): Promise<boolean> {
+    return (await resolveLayout(this.projectRoot)).dispatch !== undefined;
+  }
+
+  /** stored authorization receipt の claim が現在も継続可能かを registry 上で照合する。 */
+  async isReceiptClaimCurrent(
+    receipt: Extract<DispatchClaimReceipt, { accepted: true; operation: "authorize_event" }>,
+  ): Promise<boolean> {
+    const parsed = DispatchClaimReceiptSchema.parse(receipt);
+    if (!parsed.accepted || parsed.operation !== "authorize_event") return false;
+    const layout = await resolveLayout(this.projectRoot);
+    const release = await acquireLock(layout, this.dependencies);
+    try {
+      const registry = await this.readRegistry(layout);
+      const stored = registry.receipts.find((item) => item.eventId === parsed.eventId);
+      if (!stored || JSON.stringify(stored.receipt) !== JSON.stringify(parsed)) return false;
+      const current = registry.claims.find((claim) => claim.claimId === parsed.claim.claimId);
+      return current !== undefined && JSON.stringify(current) === JSON.stringify(parsed.claim);
+    } finally {
+      await release();
+    }
+  }
+
+  async verifyReceipt(receipt: DispatchClaimReceipt): Promise<boolean> {
+    const layout = await resolveLayout(this.projectRoot);
+    const release = await acquireLock(layout, this.dependencies);
+    try {
+      const registry = await this.readRegistry(layout);
+      return registry.receipts.some(
+        (stored) =>
+          stored.eventId === receipt.eventId &&
+          JSON.stringify(stored.receipt) === JSON.stringify(receipt),
+      );
+    } finally {
+      await release();
+    }
+  }
+
+  async assertCurrentClaim(
+    proof: DispatchClaimProof,
+    expectedEntityVersion: number,
+  ): Promise<DispatchClaim> {
+    const snapshot = await this.snapshot();
+    if (snapshot.entityVersion !== expectedEntityVersion) throw new Error("stale_entity_version");
+    const current = snapshot.claims.find((claim) => claim.claimId === proof.claimId);
+    if (
+      !current ||
+      !proofMatches(current, proof) ||
+      Date.parse(current.expiresAt) <= Date.parse(this.dependencies.now())
+    ) {
+      throw new Error("stale_claim");
+    }
+    return current;
+  }
+
+  async snapshot(): Promise<DispatchClaimSnapshot> {
+    const layout = await resolveLayout(this.projectRoot);
+    const release = await acquireLock(layout, this.dependencies);
+    try {
+      const registry = await this.readRegistry(layout);
+      return {
+        schemaVersion: "1",
+        projectIdentity: registry.projectIdentity,
+        entityVersion: registry.entityVersion,
+        claims: registry.claims,
+        pendingAuthorizations: registry.authorizations
+          .filter((authorization) => authorization.status === "pending")
+          .map((authorization) => ({
+            eventId: authorization.eventId,
+            claimId: authorization.claim.claimId,
+          })),
+        history: registry.history,
+      };
+    } finally {
+      await release();
+    }
+  }
+}

--- a/packages/cli/src/store/project-storage.ts
+++ b/packages/cli/src/store/project-storage.ts
@@ -17,6 +17,7 @@ import { ConfigStore } from "./config.js";
 import { LoopStateStore } from "./loop-state.js";
 import { SyncStateStore } from "./state.js";
 import { TasksStore } from "./tasks.js";
+import { gitCommandEnvironment, isNotGitRepositoryError } from "../util/git-errors.js";
 
 const execFileAsync = promisify(execFile);
 const LAYOUT_VERSION = "v1";
@@ -210,41 +211,6 @@ function parseWorktreeList(output: string): string[] {
     .map((entry) => entry.slice("worktree ".length));
 }
 
-function isNotGitRepository(error: unknown): boolean {
-  const stderr = String((error as { stderr?: unknown }).stderr ?? "");
-  return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
-}
-
-function gitCommandEnvironment(): NodeJS.ProcessEnv {
-  const environment = { ...process.env };
-  // pre-push等のGit hookはrepository選択用envをexportすることがある。
-  // projectRootを正本とするsubprocessへ継承すると、-Cよりenvが優先され別repositoryを操作し得る。
-  for (const name of [
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_CONFIG",
-    "GIT_CONFIG_PARAMETERS",
-    "GIT_CONFIG_COUNT",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_IMPLICIT_WORK_TREE",
-    "GIT_GRAFT_FILE",
-    "GIT_INDEX_FILE",
-    "GIT_NO_REPLACE_OBJECTS",
-    "GIT_REPLACE_REF_BASE",
-    "GIT_PREFIX",
-    "GIT_SHALLOW_FILE",
-    "GIT_COMMON_DIR",
-    "GIT_CEILING_DIRECTORIES",
-    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
-  ]) {
-    delete environment[name];
-  }
-  // Git の診断文を安定させ、non-git 判定がprocess localeに依存しないようにする。
-  environment.LC_ALL = "C";
-  return environment;
-}
-
 async function runGit(projectRoot: string, args: string[]): Promise<string> {
   try {
     const result = await execFileAsync("git", ["-C", projectRoot, ...args], {
@@ -255,7 +221,7 @@ async function runGit(projectRoot: string, args: string[]): Promise<string> {
     });
     return result.stdout.trim();
   } catch (error) {
-    if (isNotGitRepository(error)) {
+    if (isNotGitRepositoryError(error)) {
       throw new ProjectStorageError("NOT_A_GIT_REPOSITORY", "Git repository ではありません", {
         cause: error,
       });

--- a/packages/cli/src/util/git-errors.ts
+++ b/packages/cli/src/util/git-errors.ts
@@ -1,0 +1,33 @@
+const GIT_REPOSITORY_SELECTION_VARIABLES = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CONFIG",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_COUNT",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_GRAFT_FILE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_PREFIX",
+  "GIT_SHALLOW_FILE",
+  "GIT_COMMON_DIR",
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+] as const;
+
+/** projectRoot を正本とし、Git 診断を安定した英語へ固定する subprocess 環境。 */
+export function gitCommandEnvironment(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const environment = { ...source };
+  for (const name of GIT_REPOSITORY_SELECTION_VARIABLES) delete environment[name];
+  environment.LC_ALL = "C";
+  return environment;
+}
+
+/** `LC_ALL=C` で実行した Git subprocess の non-repository 診断を判定する。 */
+export function isNotGitRepositoryError(error: unknown): boolean {
+  const stderr = String((error as { stderr?: unknown }).stderr ?? "");
+  return stderr.includes("not a git repository") || stderr.includes("not a git work tree");
+}

--- a/packages/shared/src/__tests__/dispatch-plan.test.ts
+++ b/packages/shared/src/__tests__/dispatch-plan.test.ts
@@ -11,6 +11,19 @@ const WORK_GRAPH_FINGERPRINT = "1".repeat(64);
 const GATE_SNAPSHOT_FINGERPRINT = "2".repeat(64);
 const SNAPSHOT_FINGERPRINT = "3".repeat(64);
 
+const testFingerprint = (canonicalJson: string): string => {
+  let value = 0;
+  for (let index = 0; index < canonicalJson.length; index += 1) {
+    value = (Math.imul(value, 31) + canonicalJson.charCodeAt(index)) >>> 0;
+  }
+  return value.toString(16).padStart(8, "0").repeat(8);
+};
+
+const buildPlan = (data: DispatchPlanInput) =>
+  buildDispatchPlan(data, {
+    fingerprint: testFingerprint,
+  });
+
 const config: Config = {
   version: "1",
   project: { name: "P", github: { owner: "stanah", repo: "gh-gantt", project_number: 1 } },
@@ -88,13 +101,13 @@ const input = (tasks: Task[]): DispatchPlanInput => ({
 
 describe("dispatch plan の公開 schema", () => {
   it("root の未知 field を拒否する", () => {
-    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const plan = buildPlan(input([task("stanah/gh-gantt#1")]));
 
     expect(DispatchPlanSchema.safeParse({ ...plan, unexpected: true }).success).toBe(false);
   });
 
   it("context・item・excluded・capacity 内の未知 field も拒否する", () => {
-    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const plan = buildPlan(input([task("stanah/gh-gantt#1")]));
     const invalidPlans = [
       { ...plan, context: { ...plan.context, unexpected: true } },
       { ...plan, selected: [{ ...plan.selected[0]!, unexpected: true }] },
@@ -118,7 +131,7 @@ describe("dispatch plan の公開 schema", () => {
   });
 
   it("generatedAt の不正な日時を拒否する", () => {
-    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const plan = buildPlan(input([task("stanah/gh-gantt#1")]));
 
     expect(DispatchPlanSchema.safeParse({ ...plan, generatedAt: "not-a-timestamp" }).success).toBe(
       false,
@@ -126,7 +139,7 @@ describe("dispatch plan の公開 schema", () => {
   });
 
   it("未知の exclusion reason を拒否する", () => {
-    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const plan = buildPlan(input([task("stanah/gh-gantt#1")]));
 
     expect(
       DispatchPlanSchema.safeParse({
@@ -137,7 +150,7 @@ describe("dispatch plan の公開 schema", () => {
   });
 
   it("capacity の負数と導出値の不整合を拒否する", () => {
-    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const plan = buildPlan(input([task("stanah/gh-gantt#1")]));
     const negative = {
       ...plan,
       capacity: {
@@ -163,7 +176,7 @@ describe("dispatch plan の公開 schema", () => {
     const invalidInput = input([task("stanah/gh-gantt#1")]);
     invalidInput.snapshotFingerprint = "not-a-fingerprint";
 
-    expect(() => buildDispatchPlan(invalidInput)).toThrow();
+    expect(() => buildPlan(invalidInput)).toThrow();
   });
 });
 
@@ -188,8 +201,66 @@ describe("dispatch gate snapshot の公開 schema", () => {
 });
 
 describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差から安定導出する", () => {
+  it("dependency lookup 用 task Map は候補 loop の外で一度だけ構築する", () => {
+    const source = buildDispatchPlan.toString();
+    const taskMapAllocations = source.match(/new Map\(input\.tasks\.map/g) ?? [];
+    const taskMapIndex = source.indexOf("new Map(input.tasks.map");
+    const candidateLoopIndex = source.indexOf("for (const task");
+
+    expect(taskMapAllocations).toHaveLength(1);
+    expect(taskMapIndex).toBeGreaterThanOrEqual(0);
+    expect(taskMapIndex).toBeLessThan(candidateLoopIndex);
+    expect(source).toContain("getBlockingTaskIds(task, taskById");
+    expect(source).not.toContain("buildReadiness(");
+    expect(source).not.toContain("calculateDownstreamUnlockCount(");
+  });
+
+  it("長い依存チェーンでも dispatch readiness を入力サイズの定数倍で評価する", () => {
+    const chainLength = 1_024;
+    let statusReads = 0;
+    const chain = Array.from({ length: chainLength }, (_, index) => {
+      const id = `stanah/gh-gantt#${index + 1}`;
+      const customFields: Task["custom_fields"] = {};
+      Object.defineProperty(customFields, "Status", {
+        enumerable: true,
+        get: () => {
+          statusReads += 1;
+          return "Todo";
+        },
+      });
+      return task(id, {
+        custom_fields: customFields,
+        blocked_by:
+          index === 0
+            ? []
+            : [
+                {
+                  task: `stanah/gh-gantt#${index}`,
+                  type: "finish-to-start",
+                  lag: 0,
+                },
+              ],
+      });
+    });
+    const data = input(chain);
+    data.config = {
+      ...data.config,
+      dispatch: {
+        ...data.config.dispatch!,
+        max_concurrency: chainLength,
+      },
+    };
+
+    const result = buildPlan(data);
+
+    expect(result.selected.map((item) => item.taskId)).toEqual(["stanah/gh-gantt#1"]);
+    expect(result.excluded).toHaveLength(chainLength - 1);
+    expect(result.excluded.every((item) => item.reason === "dependency_blocked")).toBe(true);
+    expect(statusReads).toBeLessThanOrEqual(chainLength * 20);
+  });
+
   it("stable task ID 順に global concurrency まで選ぶ", () => {
-    const result = buildDispatchPlan(
+    const result = buildPlan(
       input([task("stanah/gh-gantt#3"), task("stanah/gh-gantt#1"), task("stanah/gh-gantt#2")]),
     );
 
@@ -202,7 +273,39 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
       reason: "global_capacity",
     });
     expect(result).toMatchObject({ planVersion: "1", registryEntityVersion: 0 });
-    expect(result.planId).toContain("dispatch-plan:v1:r0:selected:stanah/gh-gantt#1");
+    expect(result.planId).toMatch(/^dispatch-plan:v1:r0:[0-9a-f]{64}$/);
+  });
+
+  it("planId は task 数によらず固定長で key 挿入順にも依存しない", () => {
+    const small = input([task("stanah/gh-gantt#1")]);
+    const reordered = {
+      ...small,
+      workspaceByTaskId: Object.fromEntries(Object.entries(small.workspaceByTaskId).reverse()),
+    };
+    const changedCapacity = {
+      ...small,
+      config: {
+        ...small.config,
+        dispatch: { ...small.config.dispatch!, max_concurrency: 3 },
+      },
+    };
+    const large = input(
+      Array.from({ length: 1_000 }, (_, index) => task(`stanah/gh-gantt#${index + 1}`)),
+    );
+
+    expect(buildPlan(small).planId).toBe(buildPlan(reordered).planId);
+    expect(buildPlan(changedCapacity).planId).not.toBe(buildPlan(small).planId);
+    expect(buildPlan(large).planId).toMatch(/^dispatch-plan:v1:r0:[0-9a-f]{64}$/);
+    expect(buildPlan(large).planId).toHaveLength(buildPlan(small).planId.length);
+  });
+
+  it("不正な github_repo は unknown state と区別して除外する", () => {
+    const invalid = task("stanah/gh-gantt#1", { github_repo: "stanah" });
+
+    expect(buildPlan(input([invalid]))).toMatchObject({
+      selected: [],
+      excluded: [{ taskId: invalid.id, reason: "invalid_repository" }],
+    });
   });
 
   it("dependency・review/human・sync conflict・open iteration・親コンテナを除外する", () => {
@@ -221,7 +324,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
     data.syncConflictTaskIds = [conflict.id];
     data.openIterationTaskIds = [iteration.id];
 
-    const result = buildDispatchPlan(data);
+    const result = buildPlan(data);
     expect(
       Object.fromEntries(result.excluded.map((item) => [item.taskId, item.reason])),
     ).toMatchObject({
@@ -238,7 +341,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
     const data = input([task("stanah/gh-gantt#1"), task("stanah/gh-gantt#2")]);
     data.humanGateTaskIds = ["stanah/gh-gantt#999"];
 
-    expect(buildDispatchPlan(data)).toMatchObject({
+    expect(buildPlan(data)).toMatchObject({
       selected: [],
       excluded: [
         { taskId: "stanah/gh-gantt#1", reason: "gate_snapshot_inconsistent" },
@@ -268,7 +371,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
     ];
     data.workspaceByTaskId[second.id] = "workspace:occupied";
 
-    const result = buildDispatchPlan(data);
+    const result = buildPlan(data);
     expect(result.selected).toHaveLength(1);
     expect(result.selected[0]?.taskId).toBe(third.id);
     expect(result.excluded).toContainEqual({ taskId: first.id, reason: "active_claim" });
@@ -298,7 +401,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
       },
     };
 
-    expect(buildDispatchPlan(data)).toMatchObject({
+    expect(buildPlan(data)).toMatchObject({
       selected: [{ taskId: first.id }],
       excluded: [
         { taskId: sameState.id, reason: "state_capacity" },
@@ -317,9 +420,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
       ],
     });
     expect(
-      buildDispatchPlan(input([upstreamA, upstreamB, downstream])).selected.map(
-        (item) => item.taskId,
-      ),
+      buildPlan(input([upstreamA, upstreamB, downstream])).selected.map((item) => item.taskId),
     ).not.toContain(downstream.id);
 
     const completed = [
@@ -327,7 +428,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
       { ...upstreamB, state: "closed" as const },
       downstream,
     ];
-    expect(buildDispatchPlan(input(completed)).selected.map((item) => item.taskId)).toContain(
+    expect(buildPlan(input(completed)).selected.map((item) => item.taskId)).toContain(
       downstream.id,
     );
   });
@@ -349,14 +450,14 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
         expiresAt: "2026-08-01T23:00:00.000Z",
       },
     ];
-    expect(buildDispatchPlan(expired)).toMatchObject({
+    expect(buildPlan(expired)).toMatchObject({
       selected: [],
       excluded: [{ taskId: candidate.id, reason: "claim_reclaim_required" }],
     });
 
     const inconsistent = input([candidate]);
     inconsistent.claims = [expired.claims[0]!, { ...expired.claims[0]!, claimId: "claim:other" }];
-    expect(buildDispatchPlan(inconsistent)).toMatchObject({
+    expect(buildPlan(inconsistent)).toMatchObject({
       selected: [],
       excluded: [{ taskId: candidate.id, reason: "registry_snapshot_inconsistent" }],
     });
@@ -369,7 +470,7 @@ describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差か�
         expiresAt: "2026-08-02T01:00:00.000Z",
       },
     ];
-    expect(buildDispatchPlan(unknownClaimState)).toMatchObject({
+    expect(buildPlan(unknownClaimState)).toMatchObject({
       selected: [],
       excluded: [{ taskId: candidate.id, reason: "registry_snapshot_inconsistent" }],
     });

--- a/packages/shared/src/__tests__/dispatch-plan.test.ts
+++ b/packages/shared/src/__tests__/dispatch-plan.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from "vitest";
+import type { Config, Task } from "../types.js";
+import {
+  DispatchGateSnapshotSchema,
+  DispatchPlanSchema,
+  buildDispatchPlan,
+  type DispatchPlanInput,
+} from "../project-map.js";
+
+const WORK_GRAPH_FINGERPRINT = "1".repeat(64);
+const GATE_SNAPSHOT_FINGERPRINT = "2".repeat(64);
+const SNAPSHOT_FINGERPRINT = "3".repeat(64);
+
+const config: Config = {
+  version: "1",
+  project: { name: "P", github: { owner: "stanah", repo: "gh-gantt", project_number: 1 } },
+  sync: {
+    auto_create_issues: false,
+    field_mapping: { start_date: "Start", end_date: "End" },
+  },
+  task_types: {
+    task: { label: "Task", display: "bar", color: "#000", github_label: null },
+    epic: { label: "Epic", display: "summary", color: "#111", github_label: null },
+  },
+  type_hierarchy: { task: [], epic: ["task"] },
+  statuses: {
+    field_name: "Status",
+    values: {
+      Todo: { color: "#000", done: false, category: "todo" },
+      Doing: { color: "#000", done: false, category: "in_progress" },
+      Done: { color: "#000", done: true, category: "done" },
+    },
+  },
+  gantt: {
+    default_view: "month",
+    working_days: [1, 2, 3, 4, 5],
+    colors: { critical_path: "#000", on_track: "#000", at_risk: "#000", overdue: "#000" },
+  },
+  dispatch: {
+    max_concurrency: 2,
+    state_concurrency: { Todo: 2 },
+    repository_concurrency: { "stanah/gh-gantt": 2 },
+  },
+};
+
+const task = (id: string, overrides: Partial<Task> = {}): Task => ({
+  id,
+  type: "task",
+  github_issue: Number(id.split("#").at(-1) ?? 1),
+  github_repo: "stanah/gh-gantt",
+  parent: null,
+  sub_tasks: [],
+  title: id,
+  body: null,
+  state: "open",
+  state_reason: null,
+  assignees: [],
+  labels: [],
+  milestone: null,
+  linked_prs: [],
+  created_at: "2026-08-01T00:00:00.000Z",
+  updated_at: "2026-08-01T00:00:00.000Z",
+  closed_at: null,
+  custom_fields: { Status: "Todo" },
+  start_date: null,
+  end_date: null,
+  date: null,
+  blocked_by: [],
+  ...overrides,
+});
+
+const input = (tasks: Task[]): DispatchPlanInput => ({
+  tasks,
+  config,
+  now: "2026-08-02T00:00:00.000Z",
+  syncConflictTaskIds: [] as string[],
+  openIterationTaskIds: [] as string[],
+  reviewGateTaskIds: [] as string[],
+  humanGateTaskIds: [] as string[],
+  claims: [],
+  registryEntityVersion: 0,
+  workGraphFingerprint: WORK_GRAPH_FINGERPRINT,
+  gateSnapshotFingerprint: GATE_SNAPSHOT_FINGERPRINT,
+  gateSnapshotSourceRevision: "review-system:42",
+  snapshotFingerprint: SNAPSHOT_FINGERPRINT,
+  workspaceByTaskId: Object.fromEntries(tasks.map((item) => [item.id, `workspace:${item.id}`])),
+});
+
+describe("dispatch plan の公開 schema", () => {
+  it("root の未知 field を拒否する", () => {
+    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+
+    expect(DispatchPlanSchema.safeParse({ ...plan, unexpected: true }).success).toBe(false);
+  });
+
+  it("context・item・excluded・capacity 内の未知 field も拒否する", () => {
+    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const invalidPlans = [
+      { ...plan, context: { ...plan.context, unexpected: true } },
+      { ...plan, selected: [{ ...plan.selected[0]!, unexpected: true }] },
+      {
+        ...plan,
+        excluded: [{ taskId: "stanah/gh-gantt#2", reason: "already_done", unexpected: true }],
+      },
+      { ...plan, capacity: { ...plan.capacity, unexpected: true } },
+      {
+        ...plan,
+        capacity: {
+          ...plan.capacity,
+          global: { ...plan.capacity.global, unexpected: true },
+        },
+      },
+    ];
+
+    expect(
+      invalidPlans.every((candidate) => !DispatchPlanSchema.safeParse(candidate).success),
+    ).toBe(true);
+  });
+
+  it("generatedAt の不正な日時を拒否する", () => {
+    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+
+    expect(DispatchPlanSchema.safeParse({ ...plan, generatedAt: "not-a-timestamp" }).success).toBe(
+      false,
+    );
+  });
+
+  it("未知の exclusion reason を拒否する", () => {
+    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+
+    expect(
+      DispatchPlanSchema.safeParse({
+        ...plan,
+        excluded: [{ taskId: "stanah/gh-gantt#2", reason: "unknown_reason" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("capacity の負数と導出値の不整合を拒否する", () => {
+    const plan = buildDispatchPlan(input([task("stanah/gh-gantt#1")]));
+    const negative = {
+      ...plan,
+      capacity: {
+        ...plan.capacity,
+        global: { ...plan.capacity.global, used: -1 },
+      },
+    };
+    const inconsistent = {
+      ...plan,
+      capacity: {
+        ...plan.capacity,
+        global: { ...plan.capacity.global, remaining: plan.capacity.global.remaining + 1 },
+      },
+    };
+
+    expect([
+      DispatchPlanSchema.safeParse(negative).success,
+      DispatchPlanSchema.safeParse(inconsistent).success,
+    ]).toEqual([false, false]);
+  });
+
+  it("builder の返却前に fingerprint を含む完全な plan を検証する", () => {
+    const invalidInput = input([task("stanah/gh-gantt#1")]);
+    invalidInput.snapshotFingerprint = "not-a-fingerprint";
+
+    expect(() => buildDispatchPlan(invalidInput)).toThrow();
+  });
+});
+
+describe("dispatch gate snapshot の公開 schema", () => {
+  it("authoritative source の revision と観測時刻を含む strict snapshot だけを受理する", () => {
+    const snapshot = {
+      schemaVersion: "1",
+      sourceRevision: "review-system:42",
+      observedAt: "2026-08-02T00:00:00.000Z",
+      reviewGateTaskIds: ["stanah/gh-gantt#1"],
+      humanGateTaskIds: ["stanah/gh-gantt#2"],
+    } as const;
+
+    expect(DispatchGateSnapshotSchema.safeParse(snapshot).success).toBe(true);
+    expect(DispatchGateSnapshotSchema.safeParse({ ...snapshot, unexpected: true }).success).toBe(
+      false,
+    );
+    expect(
+      DispatchGateSnapshotSchema.safeParse({ ...snapshot, observedAt: "not-a-timestamp" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("[NFR-STABILITY-014-AC9] ready frontier を gate と容量の交差から安定導出する", () => {
+  it("stable task ID 順に global concurrency まで選ぶ", () => {
+    const result = buildDispatchPlan(
+      input([task("stanah/gh-gantt#3"), task("stanah/gh-gantt#1"), task("stanah/gh-gantt#2")]),
+    );
+
+    expect(result.selected.map((item) => item.taskId)).toEqual([
+      "stanah/gh-gantt#1",
+      "stanah/gh-gantt#2",
+    ]);
+    expect(result.excluded).toContainEqual({
+      taskId: "stanah/gh-gantt#3",
+      reason: "global_capacity",
+    });
+    expect(result).toMatchObject({ planVersion: "1", registryEntityVersion: 0 });
+    expect(result.planId).toContain("dispatch-plan:v1:r0:selected:stanah/gh-gantt#1");
+  });
+
+  it("dependency・review/human・sync conflict・open iteration・親コンテナを除外する", () => {
+    const upstream = task("stanah/gh-gantt#1");
+    const blocked = task("stanah/gh-gantt#2", {
+      blocked_by: [{ task: upstream.id, type: "finish-to-start", lag: 0 }],
+    });
+    const review = task("stanah/gh-gantt#3");
+    const human = task("stanah/gh-gantt#4");
+    const conflict = task("stanah/gh-gantt#5");
+    const iteration = task("stanah/gh-gantt#6");
+    const parent = task("stanah/gh-gantt#7", { type: "epic", sub_tasks: [upstream.id] });
+    const data = input([upstream, blocked, review, human, conflict, iteration, parent]);
+    data.reviewGateTaskIds = [review.id];
+    data.humanGateTaskIds = [human.id];
+    data.syncConflictTaskIds = [conflict.id];
+    data.openIterationTaskIds = [iteration.id];
+
+    const result = buildDispatchPlan(data);
+    expect(
+      Object.fromEntries(result.excluded.map((item) => [item.taskId, item.reason])),
+    ).toMatchObject({
+      [blocked.id]: "dependency_blocked",
+      [review.id]: "review_gate",
+      [human.id]: "human_gate",
+      [conflict.id]: "sync_conflict",
+      [iteration.id]: "open_iteration",
+      [parent.id]: "parent_container",
+    });
+  });
+
+  it("未知の gate task ID が一件でもあれば frontier 全体を停止する", () => {
+    const data = input([task("stanah/gh-gantt#1"), task("stanah/gh-gantt#2")]);
+    data.humanGateTaskIds = ["stanah/gh-gantt#999"];
+
+    expect(buildDispatchPlan(data)).toMatchObject({
+      selected: [],
+      excluded: [
+        { taskId: "stanah/gh-gantt#1", reason: "gate_snapshot_inconsistent" },
+        { taskId: "stanah/gh-gantt#2", reason: "gate_snapshot_inconsistent" },
+      ],
+    });
+  });
+
+  it("active claim を三層の使用数に含めて task と workspace の二重選択を防ぐ", () => {
+    const first = task("stanah/gh-gantt#1");
+    const second = task("stanah/gh-gantt#2");
+    const third = task("stanah/gh-gantt#3");
+    const data = input([first, second, third]);
+    data.claims = [
+      {
+        taskId: first.id,
+        repository: "stanah/gh-gantt",
+        state: "Todo",
+        ownerId: "owner:1",
+        workspaceId: "workspace:occupied",
+        runId: "run:1",
+        claimId: "claim:1",
+        entityVersion: 1,
+        acquiredAt: "2026-08-01T23:00:00.000Z",
+        expiresAt: "2026-08-02T01:00:00.000Z",
+      },
+    ];
+    data.workspaceByTaskId[second.id] = "workspace:occupied";
+
+    const result = buildDispatchPlan(data);
+    expect(result.selected).toHaveLength(1);
+    expect(result.selected[0]?.taskId).toBe(third.id);
+    expect(result.excluded).toContainEqual({ taskId: first.id, reason: "active_claim" });
+    expect(result.excluded).toContainEqual({ taskId: second.id, reason: "workspace_claimed" });
+  });
+
+  it("state と repository の残 slot の交差だけを選ぶ", () => {
+    const first = task("stanah/gh-gantt#1");
+    const sameState = task("stanah/gh-gantt#2", { github_repo: "other/repository" });
+    const sameRepository = task("stanah/gh-gantt#3", {
+      custom_fields: { Status: "Queued" },
+    });
+    const data = input([first, sameState, sameRepository]);
+    data.config = {
+      ...config,
+      statuses: {
+        ...config.statuses,
+        values: {
+          ...config.statuses.values,
+          Queued: { color: "#000", done: false, category: "todo" },
+        },
+      },
+      dispatch: {
+        max_concurrency: 3,
+        state_concurrency: { Todo: 1 },
+        repository_concurrency: { "stanah/gh-gantt": 1 },
+      },
+    };
+
+    expect(buildDispatchPlan(data)).toMatchObject({
+      selected: [{ taskId: first.id }],
+      excluded: [
+        { taskId: sameState.id, reason: "state_capacity" },
+        { taskId: sameRepository.id, reason: "repository_capacity" },
+      ],
+    });
+  });
+
+  it("上流完了後の再評価だけで fan-in を frontier に入れる", () => {
+    const upstreamA = task("stanah/gh-gantt#1");
+    const upstreamB = task("stanah/gh-gantt#2");
+    const downstream = task("stanah/gh-gantt#3", {
+      blocked_by: [
+        { task: upstreamA.id, type: "finish-to-start", lag: 0 },
+        { task: upstreamB.id, type: "finish-to-start", lag: 0 },
+      ],
+    });
+    expect(
+      buildDispatchPlan(input([upstreamA, upstreamB, downstream])).selected.map(
+        (item) => item.taskId,
+      ),
+    ).not.toContain(downstream.id);
+
+    const completed = [
+      { ...upstreamA, state: "closed" as const },
+      { ...upstreamB, state: "closed" as const },
+      downstream,
+    ];
+    expect(buildDispatchPlan(input(completed)).selected.map((item) => item.taskId)).toContain(
+      downstream.id,
+    );
+  });
+
+  it("期限切れ claim は reclaim まで再 dispatch せず、不整合 snapshot は全候補を停止する", () => {
+    const candidate = task("stanah/gh-gantt#1");
+    const expired = input([candidate]);
+    expired.claims = [
+      {
+        taskId: candidate.id,
+        repository: "stanah/gh-gantt",
+        state: "Todo",
+        ownerId: "owner:expired",
+        workspaceId: expired.workspaceByTaskId[candidate.id]!,
+        runId: "run:expired",
+        claimId: "claim:expired",
+        entityVersion: 1,
+        acquiredAt: "2026-08-01T22:00:00.000Z",
+        expiresAt: "2026-08-01T23:00:00.000Z",
+      },
+    ];
+    expect(buildDispatchPlan(expired)).toMatchObject({
+      selected: [],
+      excluded: [{ taskId: candidate.id, reason: "claim_reclaim_required" }],
+    });
+
+    const inconsistent = input([candidate]);
+    inconsistent.claims = [expired.claims[0]!, { ...expired.claims[0]!, claimId: "claim:other" }];
+    expect(buildDispatchPlan(inconsistent)).toMatchObject({
+      selected: [],
+      excluded: [{ taskId: candidate.id, reason: "registry_snapshot_inconsistent" }],
+    });
+
+    const unknownClaimState = input([candidate]);
+    unknownClaimState.claims = [
+      {
+        ...expired.claims[0]!,
+        state: "Unknown",
+        expiresAt: "2026-08-02T01:00:00.000Z",
+      },
+    ];
+    expect(buildDispatchPlan(unknownClaimState)).toMatchObject({
+      selected: [],
+      excluded: [{ taskId: candidate.id, reason: "registry_snapshot_inconsistent" }],
+    });
+  });
+});

--- a/packages/shared/src/__tests__/project-map.test.ts
+++ b/packages/shared/src/__tests__/project-map.test.ts
@@ -410,6 +410,7 @@ function runView(overrides: Partial<RunGraphView> = {}): RunGraphView {
     attempts: { total: attempts.length, limit: 20, truncated: false, items: attempts },
     artifacts: { total: 0, limit: 20, truncated: false, items: [] },
     evidence: { total: 0, limit: 20, truncated: false, items: [] },
+    claimAudits: { total: 0, limit: 20, truncated: false, items: [] },
     ...overrides,
   };
 }

--- a/packages/shared/src/__tests__/run-graph.test.ts
+++ b/packages/shared/src/__tests__/run-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BoundedRunGraphReferenceSchema,
+  DispatchClaimReceiptSchema,
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   GraphContractSchema,
   RunGraphAcceptedEventSchema,
@@ -19,6 +20,91 @@ import {
   RunGraphViewSchema,
   type GraphContract,
 } from "../run-graph.js";
+
+describe("[NFR-STABILITY-014-AC9] claim receipt は operation ごとの不正状態を拒否する", () => {
+  const claim = {
+    taskId: "stanah/gh-gantt#329",
+    repository: "stanah/gh-gantt",
+    state: "Todo",
+    ownerId: "owner-1",
+    workspaceId: "workspace-1",
+    runId: "run-1",
+    claimId: "claim-1",
+    entityVersion: 1,
+    fencingToken: 1,
+    acquiredAt: "2026-08-02T00:00:00.000Z",
+    expiresAt: "2026-08-02T00:05:00.000Z",
+    dispatchPlanId: "dispatch-plan-1",
+    dispatchPlanVersion: "1" as const,
+  };
+  const base = {
+    accepted: true as const,
+    eventId: "event-1",
+    entityVersion: 1,
+    stateUnchanged: false as const,
+    claim,
+  };
+
+  it("authorize_event は completion を必須にし、reclaim field を拒否する", () => {
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({ ...base, operation: "authorize_event" }),
+    ).toThrow();
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({
+        ...base,
+        operation: "authorize_event",
+        completion: {
+          runId: "run-1",
+          taskId: "stanah/gh-gantt#329",
+          actorId: "owner-1",
+          commandFingerprint: "a".repeat(64),
+        },
+        reclaimReason: "expired",
+      }),
+    ).toThrow();
+  });
+
+  it("claim と heartbeat は reclaim/completion field を拒否する", () => {
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({
+        ...base,
+        operation: "claim",
+        completion: {
+          runId: "run-1",
+          taskId: "stanah/gh-gantt#329",
+          actorId: "owner-1",
+          commandFingerprint: "a".repeat(64),
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({
+        ...base,
+        operation: "heartbeat",
+        reclaimReason: "expired",
+      }),
+    ).toThrow();
+  });
+
+  it("reclaim は reason と evidence の組を厳密に検証する", () => {
+    expect(() => DispatchClaimReceiptSchema.parse({ ...base, operation: "reclaim" })).toThrow();
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({
+        ...base,
+        operation: "reclaim",
+        reclaimReason: "expired",
+        evidenceId: "unexpected-evidence",
+      }),
+    ).toThrow();
+    expect(() =>
+      DispatchClaimReceiptSchema.parse({
+        ...base,
+        operation: "reclaim",
+        reclaimReason: "owner_stopped",
+      }),
+    ).toThrow();
+  });
+});
 
 describe("[NFR-STABILITY-014-AC3] Graph Contract が固定 dev-role graph の統制要素を表現する", () => {
   it("version、role、node、edge、artifact、evidence、authority、budget、human gate を検証する", () => {
@@ -542,6 +628,7 @@ describe("[NFR-STABILITY-014-AC2] [NFR-STABILITY-014-AC4] replay projection と 
       attempts: { total: 2, limit: 1, truncated: true, items: [attempt] },
       artifacts: { total: 2, limit: 1, truncated: true, items: [artifact] },
       evidence: { total: 2, limit: 1, truncated: true, items: [evidence] },
+      claimAudits: { total: 0, limit: 1, truncated: false, items: [] },
     });
 
     expect(view.nodes).toMatchObject({ total: 2, limit: 1, truncated: true });

--- a/packages/shared/src/__tests__/run-graph.test.ts
+++ b/packages/shared/src/__tests__/run-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BoundedRunGraphReferenceSchema,
+  DispatchClaimAcquireInputSchema,
   DispatchClaimReceiptSchema,
   FIXED_DEV_ROLE_GRAPH_CONTRACT,
   GraphContractSchema,
@@ -9,6 +10,7 @@ import {
   RunGraphArtifactSubmissionSchema,
   RunGraphAttemptSchema,
   RunGraphConfigSchema,
+  RunGraphClaimAuditCommandSchema,
   RunGraphEvidenceSchema,
   RunGraphEvidenceSubmissionSchema,
   RunGraphJournalSchema,
@@ -20,6 +22,33 @@ import {
   RunGraphViewSchema,
   type GraphContract,
 } from "../run-graph.js";
+
+describe("[NFR-STABILITY-014-AC9] claim acquire repository は canonical owner/repo に限定する", () => {
+  const input = {
+    schemaVersion: "1" as const,
+    eventId: "claim-input-1",
+    expectedEntityVersion: 0,
+    taskId: "stanah/gh-gantt#329",
+    repository: " Stanah/GH-Gantt ",
+    state: "Todo",
+    ownerId: "owner-1",
+    workspaceId: "workspace-1",
+    runId: "run-1",
+    leaseDurationSeconds: 60,
+    dispatchPlanId: "dispatch-plan-1",
+    dispatchPlanVersion: "1" as const,
+    snapshotFingerprint: "a".repeat(64),
+  };
+
+  it("lower-case 正規化後に owner/repo regex を検証する", () => {
+    expect(DispatchClaimAcquireInputSchema.parse(input).repository).toBe("stanah/gh-gantt");
+    for (const repository of ["stanah", "stanah/", "/gh-gantt", "stanah//gh-gantt"]) {
+      expect(DispatchClaimAcquireInputSchema.safeParse({ ...input, repository }).success).toBe(
+        false,
+      );
+    }
+  });
+});
 
 describe("[NFR-STABILITY-014-AC9] claim receipt は operation ごとの不正状態を拒否する", () => {
   const claim = {
@@ -103,6 +132,70 @@ describe("[NFR-STABILITY-014-AC9] claim receipt は operation ごとの不正状
         reclaimReason: "owner_stopped",
       }),
     ).toThrow();
+  });
+});
+
+describe("[NFR-STABILITY-014-AC9] claim audit command は operation ごとの field 組を固定する", () => {
+  const claim = {
+    taskId: "stanah/gh-gantt#329",
+    repository: "stanah/gh-gantt",
+    state: "Todo",
+    ownerId: "owner-1",
+    workspaceId: "workspace-1",
+    runId: "run-1",
+    claimId: "claim-1",
+    entityVersion: 1,
+    fencingToken: 1,
+    acquiredAt: "2026-08-02T00:00:00.000Z",
+    expiresAt: "2026-08-02T00:05:00.000Z",
+    dispatchPlanId: "dispatch-plan-1",
+    dispatchPlanVersion: "1" as const,
+  };
+  const base = { registryEventId: "registry-event-1", registryEntityVersion: 1, claim };
+  const completion = {
+    runId: "run-1",
+    taskId: "stanah/gh-gantt#329",
+    actorId: "owner-1",
+    commandFingerprint: "a".repeat(64),
+  };
+
+  it("各 audit type の許可 field だけを受理する", () => {
+    const valid = [
+      { ...base, type: "claim_acquired" },
+      { ...base, type: "claim_heartbeat" },
+      { ...base, type: "claim_released" },
+      { ...base, type: "claim_reclaimed", reclaimReason: "expired" },
+      {
+        ...base,
+        type: "claim_reclaimed",
+        reclaimReason: "owner_stopped",
+        evidenceId: "process-exit:owner-1",
+      },
+      { ...base, type: "claim_event_authorized", completion },
+    ];
+
+    expect(
+      valid.every((command) => RunGraphClaimAuditCommandSchema.safeParse(command).success),
+    ).toBe(true);
+  });
+
+  it("reclaim/completion/evidence の欠落・混在を全て拒否する", () => {
+    const invalid = [
+      { ...base, type: "claim_acquired", completion },
+      { ...base, type: "claim_heartbeat", reclaimReason: "expired" },
+      { ...base, type: "claim_released", evidenceId: "unexpected" },
+      { ...base, type: "claim_reclaimed" },
+      { ...base, type: "claim_reclaimed", reclaimReason: "expired", evidenceId: "unexpected" },
+      { ...base, type: "claim_reclaimed", reclaimReason: "owner_stopped" },
+      { ...base, type: "claim_reclaimed", reclaimReason: "owner_stopped", completion },
+      { ...base, type: "claim_event_authorized" },
+      { ...base, type: "claim_event_authorized", completion, reclaimReason: "expired" },
+      { ...base, type: "claim_event_authorized", completion, evidenceId: "unexpected" },
+    ];
+
+    expect(
+      invalid.every((command) => !RunGraphClaimAuditCommandSchema.safeParse(command).success),
+    ).toBe(true);
   });
 });
 

--- a/packages/shared/src/__tests__/schema.test.ts
+++ b/packages/shared/src/__tests__/schema.test.ts
@@ -403,6 +403,35 @@ describe("[NFR-STORE-001-AC1] 不正な形式のファイルを読み込んだ�
   });
 });
 
+describe("[NFR-STABILITY-014-AC9] bounded dispatch 設定を fail-closed に検証する", () => {
+  it("global・state・repository concurrency を受理する", () => {
+    const parsed = ConfigSchema.parse({
+      ...validConfig,
+      dispatch: {
+        max_concurrency: 3,
+        state_concurrency: { Todo: 2 },
+        repository_concurrency: { "stanah/my-repo": 1 },
+      },
+    });
+
+    expect(parsed.dispatch).toEqual({
+      max_concurrency: 3,
+      state_concurrency: { Todo: 2 },
+      repository_concurrency: { "stanah/my-repo": 1 },
+    });
+  });
+
+  it.each([
+    { max_concurrency: 0 },
+    { max_concurrency: 1.5 },
+    { max_concurrency: 1, state_concurrency: { Unknown: 1 } },
+    { max_concurrency: 1, repository_concurrency: { "Stanah/my-repo": 1 } },
+    { max_concurrency: 1, repository_concurrency: { invalid: 1 } },
+  ])("不正または未正規化の設定を拒否する: %j", (dispatch) => {
+    expect(() => ConfigSchema.parse({ ...validConfig, dispatch })).toThrow();
+  });
+});
+
 describe("[FR-SYNC-001-AC5] フィールド単位のコンフリクト解決ポリシーを検証できる", () => {
   it("21個の同期フィールドすべてで ours / theirs / manual を受理する", () => {
     expect(SYNC_FIELD_KEYS).toHaveLength(21);

--- a/packages/shared/src/canonical-json.ts
+++ b/packages/shared/src/canonical-json.ts
@@ -1,0 +1,22 @@
+/** JavaScript の文字列 code unit 順で比較する。locale や実行環境には依存しない。 */
+export function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** object key を code unit 順に再帰整列した JSON 互換値を返す。 */
+export function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => compareCodeUnits(left, right))
+        .map(([key, item]) => [key, canonicalizeJson(item)]),
+    );
+  }
+  return value;
+}
+
+/** key の挿入順序と locale に依存しない canonical JSON を返す。 */
+export function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalizeJson(value));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./types.js";
+export * from "./canonical-json.js";
+export * from "./repository.js";
 export * from "./schema.js";
 export * from "./constants.js";
 export * from "./comments.js";

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -142,9 +142,364 @@ export interface ProjectMapOptions {
   nextActionsLimit?: number;
 }
 
+/** repository-shared claim registry から得た lease snapshot。 */
+export interface DispatchClaimSnapshot {
+  taskId: string;
+  repository: string;
+  state: string;
+  ownerId: string;
+  workspaceId: string;
+  runId: string;
+  claimId: string;
+  entityVersion: number;
+  acquiredAt: string;
+  expiresAt: string;
+}
+
+export const DISPATCH_EXCLUSION_REASONS = [
+  "dispatch_not_configured",
+  "already_done",
+  "not_ready_state",
+  "unknown_state",
+  "dependency_blocked",
+  "review_gate",
+  "human_gate",
+  "sync_conflict",
+  "open_iteration",
+  "parent_container",
+  "active_claim",
+  "claim_reclaim_required",
+  "registry_snapshot_inconsistent",
+  "gate_snapshot_inconsistent",
+  "workspace_claimed",
+  "workspace_missing",
+  "global_capacity",
+  "state_capacity",
+  "repository_capacity",
+] as const;
+
+export type DispatchExclusionReason = (typeof DISPATCH_EXCLUSION_REASONS)[number];
+
+const DispatchFingerprintSchema = z.string().regex(/^[0-9a-f]{64}$/);
+const DispatchTaskIdSchema = z.string().min(1);
+const DispatchTaskIdsSchema = z
+  .array(DispatchTaskIdSchema)
+  .refine((ids) => new Set(ids).size === ids.length, "task ID は重複できません");
+const DispatchCapacitySlotSchema = z
+  .object({
+    limit: z.number().int().nonnegative(),
+    used: z.number().int().nonnegative(),
+    remaining: z.number().int().nonnegative(),
+  })
+  .strict()
+  .superRefine((slot, context) => {
+    if (slot.remaining !== Math.max(0, slot.limit - slot.used)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["remaining"],
+        message: "remaining は limit と used から導出した値でなければなりません",
+      });
+    }
+  });
+
+/** review / human gate の authoritative snapshot 入力。 */
+export interface DispatchGateSnapshot {
+  schemaVersion: "1";
+  sourceRevision: string;
+  observedAt: string;
+  reviewGateTaskIds: string[];
+  humanGateTaskIds: string[];
+}
+
+export const DispatchGateSnapshotSchema: z.ZodType<DispatchGateSnapshot> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    sourceRevision: z.string().min(1),
+    observedAt: z.string().datetime({ offset: true }),
+    reviewGateTaskIds: DispatchTaskIdsSchema,
+    humanGateTaskIds: DispatchTaskIdsSchema,
+  })
+  .strict();
+export interface DispatchPlanInput {
+  tasks: Task[];
+  config: Config;
+  now: string;
+  syncConflictTaskIds: string[];
+  openIterationTaskIds: string[];
+  reviewGateTaskIds: string[];
+  humanGateTaskIds: string[];
+  claims: DispatchClaimSnapshot[];
+  registryEntityVersion: number;
+  workGraphFingerprint: string;
+  gateSnapshotFingerprint: string;
+  gateSnapshotSourceRevision: string;
+  snapshotFingerprint: string;
+  workspaceByTaskId: Record<string, string>;
+}
+
+export interface DispatchPlanItem {
+  taskId: string;
+  repository: string;
+  state: string;
+  workspaceId: string;
+}
+
+export interface DispatchPlan {
+  planVersion: "1";
+  planId: string;
+  registryEntityVersion: number;
+  context: {
+    syncConflictTaskIds: string[];
+    openIterationTaskIds: string[];
+    reviewGateTaskIds: string[];
+    humanGateTaskIds: string[];
+    workspaceByTaskId: Record<string, string>;
+    workGraphFingerprint: string;
+    gateSnapshotFingerprint: string;
+    gateSnapshotSourceRevision: string;
+    snapshotFingerprint: string;
+  };
+  generatedAt: string;
+  selected: DispatchPlanItem[];
+  excluded: Array<{ taskId: string; reason: DispatchExclusionReason }>;
+  capacity: {
+    global: { limit: number; used: number; remaining: number };
+    states: Record<string, { limit: number; used: number; remaining: number }>;
+    repositories: Record<string, { limit: number; used: number; remaining: number }>;
+  };
+}
+
+const DispatchPlanItemSchema: z.ZodType<DispatchPlanItem> = z
+  .object({
+    taskId: DispatchTaskIdSchema,
+    repository: z
+      .string()
+      .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/),
+    state: z.string().min(1),
+    workspaceId: z.string().min(1),
+  })
+  .strict();
+
+/** dispatch plan file と builder 出力の双方で使う完全な公開 schema。 */
+export const DispatchPlanSchema: z.ZodType<DispatchPlan> = z
+  .object({
+    planVersion: z.literal("1"),
+    planId: z.string().min(1),
+    registryEntityVersion: z.number().int().nonnegative(),
+    context: z
+      .object({
+        syncConflictTaskIds: DispatchTaskIdsSchema,
+        openIterationTaskIds: DispatchTaskIdsSchema,
+        reviewGateTaskIds: DispatchTaskIdsSchema,
+        humanGateTaskIds: DispatchTaskIdsSchema,
+        workspaceByTaskId: z.record(z.string().min(1)),
+        workGraphFingerprint: DispatchFingerprintSchema,
+        gateSnapshotFingerprint: DispatchFingerprintSchema,
+        gateSnapshotSourceRevision: z.string().min(1),
+        snapshotFingerprint: DispatchFingerprintSchema,
+      })
+      .strict(),
+    generatedAt: z.string().datetime({ offset: true }),
+    selected: z.array(DispatchPlanItemSchema),
+    excluded: z.array(
+      z
+        .object({
+          taskId: DispatchTaskIdSchema,
+          reason: z.enum(DISPATCH_EXCLUSION_REASONS),
+        })
+        .strict(),
+    ),
+    capacity: z
+      .object({
+        global: DispatchCapacitySlotSchema,
+        states: z.record(DispatchCapacitySlotSchema),
+        repositories: z.record(DispatchCapacitySlotSchema),
+      })
+      .strict(),
+  })
+  .strict();
 const RISK_LABELS = new Set(["risk", "spike", "external"]);
 const PRIORITY_WEIGHT: Record<string, number> = { critical: 10, high: 6, medium: 3, low: 1 };
 const PRIORITY_RANK: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+
+function normalizeRepository(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/.test(normalized)
+    ? normalized
+    : null;
+}
+
+/**
+ * Work Graph snapshot から、外部 runner が claim 可能な bounded dispatch plan を pure に導出する。
+ * 時計・filesystem・Store には触れず、期限判定用の時刻も入力として受け取る。
+ */
+export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
+  const configured = input.config.dispatch;
+  const limit = configured?.max_concurrency ?? 0;
+  const now = Date.parse(input.now);
+  const registrySnapshotInconsistent =
+    !Number.isFinite(now) ||
+    !Number.isInteger(input.registryEntityVersion) ||
+    input.registryEntityVersion < 0 ||
+    new Set(input.claims.map((claim) => claim.taskId)).size !== input.claims.length ||
+    new Set(input.claims.map((claim) => claim.workspaceId)).size !== input.claims.length ||
+    new Set(input.claims.map((claim) => claim.claimId)).size !== input.claims.length ||
+    input.claims.some(
+      (claim) =>
+        !Number.isInteger(claim.entityVersion) ||
+        claim.entityVersion < 1 ||
+        !Object.hasOwn(input.config.statuses.values, claim.state) ||
+        normalizeRepository(claim.repository) === null ||
+        !Number.isFinite(Date.parse(claim.acquiredAt)) ||
+        !Number.isFinite(Date.parse(claim.expiresAt)) ||
+        Date.parse(claim.acquiredAt) >= Date.parse(claim.expiresAt),
+    );
+  const activeClaims = input.claims.filter(
+    (claim) => Number.isFinite(Date.parse(claim.expiresAt)) && Date.parse(claim.expiresAt) > now,
+  );
+  const activeTasks = new Set(activeClaims.map((claim) => claim.taskId));
+  const activeWorkspaces = new Set(activeClaims.map((claim) => claim.workspaceId));
+  const expiredTasks = new Set(
+    input.claims.filter((claim) => Date.parse(claim.expiresAt) <= now).map((claim) => claim.taskId),
+  );
+  const expiredWorkspaces = new Set(
+    input.claims
+      .filter((claim) => Date.parse(claim.expiresAt) <= now)
+      .map((claim) => claim.workspaceId),
+  );
+  const usedStates = new Map<string, number>();
+  const usedRepositories = new Map<string, number>();
+  for (const claim of activeClaims) {
+    usedStates.set(claim.state, (usedStates.get(claim.state) ?? 0) + 1);
+    const repository = normalizeRepository(claim.repository);
+    if (repository) usedRepositories.set(repository, (usedRepositories.get(repository) ?? 0) + 1);
+  }
+
+  const readiness = buildReadiness(input.tasks, input.config, new Set());
+  const gateSets = {
+    sync_conflict: new Set(input.syncConflictTaskIds),
+    open_iteration: new Set(input.openIterationTaskIds),
+    review_gate: new Set(input.reviewGateTaskIds),
+    human_gate: new Set(input.humanGateTaskIds),
+  } as const;
+  const knownTaskIds = new Set(input.tasks.map((task) => task.id));
+  const gateSnapshotInconsistent = Object.values(gateSets).some((ids) =>
+    [...ids].some((id) => !knownTaskIds.has(id)),
+  );
+  const selected: DispatchPlanItem[] = [];
+  const excluded: DispatchPlan["excluded"] = [];
+  const selectedWorkspaces = new Set<string>();
+  const selectedStates = new Map<string, number>();
+  const selectedRepositories = new Map<string, number>();
+
+  for (const task of [...input.tasks].sort((left, right) => left.id.localeCompare(right.id))) {
+    let reason: DispatchExclusionReason | null = null;
+    const statusValue = getStatusValue(task, input.config);
+    const state =
+      typeof task.custom_fields[input.config.statuses.field_name] === "string"
+        ? String(task.custom_fields[input.config.statuses.field_name])
+        : "";
+    const repository = normalizeRepository(task.github_repo);
+    const workspaceId = input.workspaceByTaskId[task.id];
+    if (registrySnapshotInconsistent) reason = "registry_snapshot_inconsistent";
+    else if (gateSnapshotInconsistent) reason = "gate_snapshot_inconsistent";
+    else if (!configured) reason = "dispatch_not_configured";
+    else if (isTaskDone(task, input.config)) reason = "already_done";
+    else if (!statusValue) reason = "unknown_state";
+    else if (input.config.task_types[task.type]?.display !== "bar" || task.sub_tasks.length > 0)
+      reason = "parent_container";
+    else if (
+      getBlockingTaskIds(task, new Map(input.tasks.map((item) => [item.id, item])), input.config)
+        .length > 0
+    )
+      reason = "dependency_blocked";
+    else if (gateSets.review_gate.has(task.id) || needsReview(task, input.config))
+      reason = "review_gate";
+    else if (gateSets.human_gate.has(task.id)) reason = "human_gate";
+    else if (gateSets.sync_conflict.has(task.id)) reason = "sync_conflict";
+    else if (gateSets.open_iteration.has(task.id)) reason = "open_iteration";
+    else if (activeTasks.has(task.id)) reason = "active_claim";
+    else if (expiredTasks.has(task.id)) reason = "claim_reclaim_required";
+    else if (!workspaceId) reason = "workspace_missing";
+    else if (activeWorkspaces.has(workspaceId) || selectedWorkspaces.has(workspaceId))
+      reason = "workspace_claimed";
+    else if (expiredWorkspaces.has(workspaceId)) reason = "claim_reclaim_required";
+    else if (!readiness[task.id]?.isReady) reason = "not_ready_state";
+    else if (!repository) reason = "unknown_state";
+    else if (activeClaims.length + selected.length >= limit) reason = "global_capacity";
+    else {
+      const stateLimit = configured.state_concurrency?.[state] ?? limit;
+      const stateUsed = (usedStates.get(state) ?? 0) + (selectedStates.get(state) ?? 0);
+      const repositoryLimit = configured.repository_concurrency?.[repository] ?? limit;
+      const repositoryUsed =
+        (usedRepositories.get(repository) ?? 0) + (selectedRepositories.get(repository) ?? 0);
+      if (stateUsed >= stateLimit) reason = "state_capacity";
+      else if (repositoryUsed >= repositoryLimit) reason = "repository_capacity";
+    }
+
+    if (reason) {
+      excluded.push({ taskId: task.id, reason });
+      continue;
+    }
+    selected.push({ taskId: task.id, repository: repository!, state, workspaceId });
+    selectedWorkspaces.add(workspaceId);
+    selectedStates.set(state, (selectedStates.get(state) ?? 0) + 1);
+    selectedRepositories.set(repository!, (selectedRepositories.get(repository!) ?? 0) + 1);
+  }
+
+  const states = Object.fromEntries(
+    Object.entries(configured?.state_concurrency ?? {}).map(([state, stateLimit]) => {
+      const used = usedStates.get(state) ?? 0;
+      return [state, { limit: stateLimit, used, remaining: Math.max(0, stateLimit - used) }];
+    }),
+  );
+  const repositories = Object.fromEntries(
+    Object.entries(configured?.repository_concurrency ?? {}).map(
+      ([repository, repositoryLimit]) => {
+        const used = usedRepositories.get(repository) ?? 0;
+        return [
+          repository,
+          { limit: repositoryLimit, used, remaining: Math.max(0, repositoryLimit - used) },
+        ];
+      },
+    ),
+  );
+  const lineage = [
+    ...selected.map((item) => `selected:${item.taskId}@${item.workspaceId}`),
+    ...excluded.map((item) => `excluded:${item.taskId}@${item.reason}`),
+  ].join(",");
+  const context = {
+    syncConflictTaskIds: [...input.syncConflictTaskIds].sort(),
+    openIterationTaskIds: [...input.openIterationTaskIds].sort(),
+    reviewGateTaskIds: [...input.reviewGateTaskIds].sort(),
+    humanGateTaskIds: [...input.humanGateTaskIds].sort(),
+    workspaceByTaskId: Object.fromEntries(
+      Object.entries(input.workspaceByTaskId).sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    workGraphFingerprint: input.workGraphFingerprint,
+    gateSnapshotFingerprint: input.gateSnapshotFingerprint,
+    gateSnapshotSourceRevision: input.gateSnapshotSourceRevision,
+    snapshotFingerprint: input.snapshotFingerprint,
+  };
+  return DispatchPlanSchema.parse({
+    planVersion: "1",
+    planId: `dispatch-plan:v1:r${input.registryEntityVersion}:${lineage}:context:${encodeURIComponent(JSON.stringify(context))}`,
+    registryEntityVersion: input.registryEntityVersion,
+    context,
+    generatedAt: input.now,
+    selected,
+    excluded,
+    capacity: {
+      global: {
+        limit,
+        used: activeClaims.length,
+        remaining: Math.max(0, limit - activeClaims.length),
+      },
+      states,
+      repositories,
+    },
+  });
+}
 
 function getStatusValue(task: Task, config: Config): StatusValue | undefined {
   const name = task.custom_fields[config.statuses.field_name];

--- a/packages/shared/src/project-map.ts
+++ b/packages/shared/src/project-map.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { canonicalJsonStringify, compareCodeUnits } from "./canonical-json.js";
+import { NormalizedRepositorySchema, normalizeRepository } from "./repository.js";
 import type { Task, Config, StatusValue, StatusCategory, GroupingFacet } from "./types.js";
 import {
   calculateCriticalPath,
@@ -161,6 +163,7 @@ export const DISPATCH_EXCLUSION_REASONS = [
   "already_done",
   "not_ready_state",
   "unknown_state",
+  "invalid_repository",
   "dependency_blocked",
   "review_gate",
   "human_gate",
@@ -272,9 +275,7 @@ export interface DispatchPlan {
 const DispatchPlanItemSchema: z.ZodType<DispatchPlanItem> = z
   .object({
     taskId: DispatchTaskIdSchema,
-    repository: z
-      .string()
-      .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/),
+    repository: NormalizedRepositorySchema,
     state: z.string().min(1),
     workspaceId: z.string().min(1),
   })
@@ -284,7 +285,7 @@ const DispatchPlanItemSchema: z.ZodType<DispatchPlanItem> = z
 export const DispatchPlanSchema: z.ZodType<DispatchPlan> = z
   .object({
     planVersion: z.literal("1"),
-    planId: z.string().min(1),
+    planId: z.string().regex(/^dispatch-plan:v1:r\d+:[0-9a-f]{64}$/),
     registryEntityVersion: z.number().int().nonnegative(),
     context: z
       .object({
@@ -322,18 +323,19 @@ const RISK_LABELS = new Set(["risk", "spike", "external"]);
 const PRIORITY_WEIGHT: Record<string, number> = { critical: 10, high: 6, medium: 3, low: 1 };
 const PRIORITY_RANK: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
 
-function normalizeRepository(value: string): string | null {
-  const normalized = value.trim().toLowerCase();
-  return /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/.test(normalized)
-    ? normalized
-    : null;
-}
-
 /**
  * Work Graph snapshot から、外部 runner が claim 可能な bounded dispatch plan を pure に導出する。
  * 時計・filesystem・Store には触れず、期限判定用の時刻も入力として受け取る。
  */
-export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
+export interface DispatchPlanDependencies {
+  /** canonical JSON を同期的に固定長 SHA-256 hex へ変換する。 */
+  fingerprint: (canonicalJson: string) => string;
+}
+
+export function buildDispatchPlan(
+  input: DispatchPlanInput,
+  dependencies: DispatchPlanDependencies,
+): DispatchPlan {
   const configured = input.config.dispatch;
   const limit = configured?.max_concurrency ?? 0;
   const now = Date.parse(input.now);
@@ -375,7 +377,6 @@ export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
     if (repository) usedRepositories.set(repository, (usedRepositories.get(repository) ?? 0) + 1);
   }
 
-  const readiness = buildReadiness(input.tasks, input.config, new Set());
   const gateSets = {
     sync_conflict: new Set(input.syncConflictTaskIds),
     open_iteration: new Set(input.openIterationTaskIds),
@@ -386,13 +387,14 @@ export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
   const gateSnapshotInconsistent = Object.values(gateSets).some((ids) =>
     [...ids].some((id) => !knownTaskIds.has(id)),
   );
+  const taskById = new Map(input.tasks.map((task) => [task.id, task]));
   const selected: DispatchPlanItem[] = [];
   const excluded: DispatchPlan["excluded"] = [];
   const selectedWorkspaces = new Set<string>();
   const selectedStates = new Map<string, number>();
   const selectedRepositories = new Map<string, number>();
 
-  for (const task of [...input.tasks].sort((left, right) => left.id.localeCompare(right.id))) {
+  for (const task of [...input.tasks].sort((left, right) => compareCodeUnits(left.id, right.id))) {
     let reason: DispatchExclusionReason | null = null;
     const statusValue = getStatusValue(task, input.config);
     const state =
@@ -406,12 +408,10 @@ export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
     else if (!configured) reason = "dispatch_not_configured";
     else if (isTaskDone(task, input.config)) reason = "already_done";
     else if (!statusValue) reason = "unknown_state";
+    else if (!repository) reason = "invalid_repository";
     else if (input.config.task_types[task.type]?.display !== "bar" || task.sub_tasks.length > 0)
       reason = "parent_container";
-    else if (
-      getBlockingTaskIds(task, new Map(input.tasks.map((item) => [item.id, item])), input.config)
-        .length > 0
-    )
+    else if (getBlockingTaskIds(task, taskById, input.config).length > 0)
       reason = "dependency_blocked";
     else if (gateSets.review_gate.has(task.id) || needsReview(task, input.config))
       reason = "review_gate";
@@ -424,8 +424,7 @@ export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
     else if (activeWorkspaces.has(workspaceId) || selectedWorkspaces.has(workspaceId))
       reason = "workspace_claimed";
     else if (expiredWorkspaces.has(workspaceId)) reason = "claim_reclaim_required";
-    else if (!readiness[task.id]?.isReady) reason = "not_ready_state";
-    else if (!repository) reason = "unknown_state";
+    else if (!isDispatchReady(task, taskById, input.config)) reason = "not_ready_state";
     else if (activeClaims.length + selected.length >= limit) reason = "global_capacity";
     else {
       const stateLimit = configured.state_concurrency?.[state] ?? limit;
@@ -464,40 +463,52 @@ export function buildDispatchPlan(input: DispatchPlanInput): DispatchPlan {
       },
     ),
   );
-  const lineage = [
-    ...selected.map((item) => `selected:${item.taskId}@${item.workspaceId}`),
-    ...excluded.map((item) => `excluded:${item.taskId}@${item.reason}`),
-  ].join(",");
   const context = {
     syncConflictTaskIds: [...input.syncConflictTaskIds].sort(),
     openIterationTaskIds: [...input.openIterationTaskIds].sort(),
     reviewGateTaskIds: [...input.reviewGateTaskIds].sort(),
     humanGateTaskIds: [...input.humanGateTaskIds].sort(),
     workspaceByTaskId: Object.fromEntries(
-      Object.entries(input.workspaceByTaskId).sort(([left], [right]) => left.localeCompare(right)),
+      Object.entries(input.workspaceByTaskId).sort(([left], [right]) =>
+        compareCodeUnits(left, right),
+      ),
     ),
     workGraphFingerprint: input.workGraphFingerprint,
     gateSnapshotFingerprint: input.gateSnapshotFingerprint,
     gateSnapshotSourceRevision: input.gateSnapshotSourceRevision,
     snapshotFingerprint: input.snapshotFingerprint,
   };
+  const capacity = {
+    global: {
+      limit,
+      used: activeClaims.length,
+      remaining: Math.max(0, limit - activeClaims.length),
+    },
+    states,
+    repositories,
+  };
+  const planFingerprint = dependencies.fingerprint(
+    canonicalJsonStringify({
+      planVersion: "1",
+      registryEntityVersion: input.registryEntityVersion,
+      selected,
+      excluded,
+      context,
+      capacity,
+    }),
+  );
+  if (!/^[0-9a-f]{64}$/.test(planFingerprint)) {
+    throw new Error("dispatch plan fingerprint は64桁の lower-case SHA-256 hex が必要です");
+  }
   return DispatchPlanSchema.parse({
     planVersion: "1",
-    planId: `dispatch-plan:v1:r${input.registryEntityVersion}:${lineage}:context:${encodeURIComponent(JSON.stringify(context))}`,
+    planId: `dispatch-plan:v1:r${input.registryEntityVersion}:${planFingerprint}`,
     registryEntityVersion: input.registryEntityVersion,
     context,
     generatedAt: input.now,
     selected,
     excluded,
-    capacity: {
-      global: {
-        limit,
-        used: activeClaims.length,
-        remaining: Math.max(0, limit - activeClaims.length),
-      },
-      states,
-      repositories,
-    },
+    capacity,
   });
 }
 
@@ -647,6 +658,14 @@ function classifyColumn(
   // 依存解除済み。明示的に backlog に置かれたものはパーク扱い、それ以外は着手可能。
   if (category === "backlog") return { column: "backlog", reason: "backlog" };
   return { column: "ready_now", reason: "ready" };
+}
+
+/**
+ * dispatch 候補が ready_now に分類されるかだけを判定する。
+ * UI 用 readiness の下流解除数は計算せず、依存辺の走査までに留める。
+ */
+function isDispatchReady(task: Task, taskById: Map<string, Task>, config: Config): boolean {
+  return classifyColumn(task, taskById, config).column === "ready_now";
 }
 
 /**

--- a/packages/shared/src/repository.ts
+++ b/packages/shared/src/repository.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/** dispatch contract 全体で共有する正規化済み owner/repo の形式。 */
+export const NORMALIZED_REPOSITORY_PATTERN: RegExp =
+  /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
+
+export const NormalizedRepositorySchema: z.ZodType<string> = z
+  .string()
+  .regex(NORMALIZED_REPOSITORY_PATTERN);
+
+/** trim と lower-case 化後に正規 owner/repo のみ返す。 */
+export function normalizeRepository(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return NORMALIZED_REPOSITORY_PATTERN.test(normalized) ? normalized : null;
+}

--- a/packages/shared/src/run-graph.ts
+++ b/packages/shared/src/run-graph.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { NormalizedRepositorySchema } from "./repository.js";
 
 export const RUN_GRAPH_ROLES = [
   "orchestrator",
@@ -555,15 +556,29 @@ export interface DispatchCompletionAuthorization {
   commandFingerprint: string;
 }
 
-export interface RunGraphClaimAuditCommand {
-  type: (typeof RUN_GRAPH_CLAIM_AUDIT_TYPES)[number];
+interface RunGraphClaimAuditCommandBase {
   registryEventId: string;
   registryEntityVersion: number;
   claim: DispatchClaim;
-  reclaimReason?: "expired" | "owner_stopped";
-  evidenceId?: string;
-  completion?: DispatchCompletionAuthorization;
 }
+
+export type RunGraphClaimAuditCommand =
+  | (RunGraphClaimAuditCommandBase & {
+      type: "claim_acquired" | "claim_heartbeat" | "claim_released";
+    })
+  | (RunGraphClaimAuditCommandBase & {
+      type: "claim_reclaimed";
+      reclaimReason: "expired";
+    })
+  | (RunGraphClaimAuditCommandBase & {
+      type: "claim_reclaimed";
+      reclaimReason: "owner_stopped";
+      evidenceId: string;
+    })
+  | (RunGraphClaimAuditCommandBase & {
+      type: "claim_event_authorized";
+      completion: DispatchCompletionAuthorization;
+    });
 
 export interface RunGraphClaimAuditInput {
   schemaVersion: "1";
@@ -632,12 +647,17 @@ export const DispatchClaimProofSchema: z.ZodType<DispatchClaimProof> = z
   })
   .strict();
 
+export const DispatchClaimRepositorySchema: z.ZodType<string> = z
+  .string()
+  .trim()
+  .min(1)
+  .transform((value) => value.toLowerCase())
+  .pipe(NormalizedRepositorySchema);
+
 export const DispatchClaimSchema: z.ZodType<DispatchClaim> = z
   .object({
     taskId: z.string().trim().min(1),
-    repository: z
-      .string()
-      .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/),
+    repository: NormalizedRepositorySchema,
     state: z.string().trim().min(1),
     ownerId: z.string().trim().min(1),
     workspaceId: z.string().trim().min(1),
@@ -661,11 +681,7 @@ const DispatchClaimInputBaseSchema = z.object({
 export const DispatchClaimAcquireInputSchema: z.ZodType<DispatchClaimAcquireInput> =
   DispatchClaimInputBaseSchema.extend({
     taskId: z.string().trim().min(1),
-    repository: z
-      .string()
-      .trim()
-      .min(1)
-      .transform((value) => value.toLowerCase()),
+    repository: DispatchClaimRepositorySchema,
     state: z.string().trim().min(1),
     ownerId: z.string().trim().min(1),
     workspaceId: z.string().trim().min(1),
@@ -788,17 +804,30 @@ export const DispatchClaimReceiptSchema: z.ZodType<DispatchClaimReceipt> = z.uni
   DispatchClaimRejectedReceiptSchema,
 ]);
 
-export const RunGraphClaimAuditCommandSchema: z.ZodType<RunGraphClaimAuditCommand> = z
-  .object({
-    type: z.enum(RUN_GRAPH_CLAIM_AUDIT_TYPES),
-    registryEventId: z.string().trim().min(1),
-    registryEntityVersion: z.number().int().positive(),
-    claim: DispatchClaimSchema,
-    reclaimReason: z.enum(["expired", "owner_stopped"]).optional(),
-    evidenceId: z.string().trim().min(1).optional(),
-    completion: DispatchCompletionAuthorizationSchema.optional(),
-  })
-  .strict();
+const RunGraphClaimAuditCommandBaseSchema = z.object({
+  registryEventId: z.string().trim().min(1),
+  registryEntityVersion: z.number().int().positive(),
+  claim: DispatchClaimSchema,
+});
+
+export const RunGraphClaimAuditCommandSchema: z.ZodType<RunGraphClaimAuditCommand> = z.union([
+  RunGraphClaimAuditCommandBaseSchema.extend({
+    type: z.enum(["claim_acquired", "claim_heartbeat", "claim_released"]),
+  }).strict(),
+  RunGraphClaimAuditCommandBaseSchema.extend({
+    type: z.literal("claim_reclaimed"),
+    reclaimReason: z.literal("expired"),
+  }).strict(),
+  RunGraphClaimAuditCommandBaseSchema.extend({
+    type: z.literal("claim_reclaimed"),
+    reclaimReason: z.literal("owner_stopped"),
+    evidenceId: z.string().trim().min(1),
+  }).strict(),
+  RunGraphClaimAuditCommandBaseSchema.extend({
+    type: z.literal("claim_event_authorized"),
+    completion: DispatchCompletionAuthorizationSchema,
+  }).strict(),
+]);
 
 export const RunGraphClaimAuditInputSchema: z.ZodType<RunGraphClaimAuditInput> = z
   .object({

--- a/packages/shared/src/run-graph.ts
+++ b/packages/shared/src/run-graph.ts
@@ -453,6 +453,362 @@ export interface RunGraphEvidenceSubmission {
   reference: BoundedRunGraphReference;
 }
 
+/** repository coordination registry が発行する current claim の fencing proof。 */
+export interface DispatchClaimProof {
+  claimId: string;
+  fencingToken: number;
+  ownerId: string;
+  runId: string;
+}
+
+/** isolated workspace に対する期限付き claim。 */
+export interface DispatchClaim {
+  taskId: string;
+  repository: string;
+  state: string;
+  ownerId: string;
+  workspaceId: string;
+  runId: string;
+  claimId: string;
+  entityVersion: number;
+  fencingToken: number;
+  acquiredAt: string;
+  expiresAt: string;
+  dispatchPlanId: string;
+  dispatchPlanVersion: "1";
+}
+
+export type DispatchClaimOperation =
+  | "claim"
+  | "heartbeat"
+  | "release"
+  | "reclaim"
+  | "authorize_event";
+export type DispatchClaimRejectionCode =
+  | "event_payload_mismatch"
+  | "stale_entity_version"
+  | "dispatch_not_configured"
+  | "unknown_state"
+  | "global_capacity"
+  | "state_capacity"
+  | "repository_capacity"
+  | "task_already_claimed"
+  | "workspace_already_claimed"
+  | "claim_not_found"
+  | "stale_claim"
+  | "authorization_pending"
+  | "snapshot_mismatch"
+  | "lease_expired"
+  | "lease_not_expired";
+
+interface DispatchClaimAcceptedReceiptBase {
+  accepted: true;
+  eventId: string;
+  entityVersion: number;
+  stateUnchanged: false;
+  claim: DispatchClaim;
+}
+
+export type DispatchClaimAcceptedReceipt =
+  | (DispatchClaimAcceptedReceiptBase & { operation: "claim" })
+  | (DispatchClaimAcceptedReceiptBase & { operation: "heartbeat" })
+  | (DispatchClaimAcceptedReceiptBase & { operation: "release" })
+  | (DispatchClaimAcceptedReceiptBase & {
+      operation: "reclaim";
+      reclaimReason: "expired";
+    })
+  | (DispatchClaimAcceptedReceiptBase & {
+      operation: "reclaim";
+      reclaimReason: "owner_stopped";
+      evidenceId: string;
+    })
+  | (DispatchClaimAcceptedReceiptBase & {
+      operation: "authorize_event";
+      completion: DispatchCompletionAuthorization;
+      claimContinues: boolean;
+    });
+
+export type DispatchClaimReceipt =
+  | DispatchClaimAcceptedReceipt
+  | {
+      accepted: false;
+      operation: DispatchClaimOperation;
+      eventId: string;
+      entityVersion: number;
+      stateUnchanged: true;
+      code: DispatchClaimRejectionCode;
+      message: string;
+    };
+
+export const RUN_GRAPH_CLAIM_AUDIT_TYPES = [
+  "claim_acquired",
+  "claim_heartbeat",
+  "claim_released",
+  "claim_reclaimed",
+  "claim_event_authorized",
+] as const;
+
+export interface DispatchCompletionAuthorization {
+  runId: string;
+  taskId: string;
+  actorId: string;
+  commandFingerprint: string;
+}
+
+export interface RunGraphClaimAuditCommand {
+  type: (typeof RUN_GRAPH_CLAIM_AUDIT_TYPES)[number];
+  registryEventId: string;
+  registryEntityVersion: number;
+  claim: DispatchClaim;
+  reclaimReason?: "expired" | "owner_stopped";
+  evidenceId?: string;
+  completion?: DispatchCompletionAuthorization;
+}
+
+export interface RunGraphClaimAuditInput {
+  schemaVersion: "1";
+  eventId: string;
+  actor: RunGraphActor;
+  receipt: Extract<DispatchClaimReceipt, { accepted: true }> & { claim: DispatchClaim };
+}
+
+export interface DispatchClaimAcquireInput {
+  schemaVersion: "1";
+  eventId: string;
+  expectedEntityVersion: number;
+  taskId: string;
+  repository: string;
+  state: string;
+  ownerId: string;
+  workspaceId: string;
+  runId: string;
+  leaseDurationSeconds: number;
+  dispatchPlanId: string;
+  dispatchPlanVersion: "1";
+  snapshotFingerprint: string;
+}
+
+export interface DispatchClaimHeartbeatInput {
+  schemaVersion: "1";
+  eventId: string;
+  expectedEntityVersion: number;
+  proof: DispatchClaimProof;
+  leaseDurationSeconds: number;
+}
+
+export interface DispatchClaimReleaseInput {
+  schemaVersion: "1";
+  eventId: string;
+  expectedEntityVersion: number;
+  proof: DispatchClaimProof;
+}
+
+export interface DispatchClaimReclaimInput {
+  schemaVersion: "1";
+  eventId: string;
+  expectedEntityVersion: number;
+  claimId: string;
+  reason: "expired" | "owner_stopped";
+  ownerStoppedEvidenceId?: string;
+}
+
+export interface DispatchClaimEventAuthorizationInput {
+  schemaVersion: "1";
+  eventId: string;
+  expectedEntityVersion: number;
+  proof: DispatchClaimProof;
+  runId: string;
+  taskId: string;
+  actorId: string;
+  commandFingerprint: string;
+}
+
+export const DispatchClaimProofSchema: z.ZodType<DispatchClaimProof> = z
+  .object({
+    claimId: z.string().trim().min(1),
+    fencingToken: z.number().int().positive(),
+    ownerId: z.string().trim().min(1),
+    runId: z.string().trim().min(1),
+  })
+  .strict();
+
+export const DispatchClaimSchema: z.ZodType<DispatchClaim> = z
+  .object({
+    taskId: z.string().trim().min(1),
+    repository: z
+      .string()
+      .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/),
+    state: z.string().trim().min(1),
+    ownerId: z.string().trim().min(1),
+    workspaceId: z.string().trim().min(1),
+    runId: z.string().trim().min(1),
+    claimId: z.string().trim().min(1),
+    entityVersion: z.number().int().positive(),
+    fencingToken: z.number().int().positive(),
+    acquiredAt: z.string().datetime({ offset: true }),
+    expiresAt: z.string().datetime({ offset: true }),
+    dispatchPlanId: z.string().trim().min(1),
+    dispatchPlanVersion: z.literal("1"),
+  })
+  .strict();
+
+const DispatchClaimInputBaseSchema = z.object({
+  schemaVersion: z.literal("1"),
+  eventId: z.string().trim().min(1),
+  expectedEntityVersion: z.number().int().nonnegative(),
+});
+
+export const DispatchClaimAcquireInputSchema: z.ZodType<DispatchClaimAcquireInput> =
+  DispatchClaimInputBaseSchema.extend({
+    taskId: z.string().trim().min(1),
+    repository: z
+      .string()
+      .trim()
+      .min(1)
+      .transform((value) => value.toLowerCase()),
+    state: z.string().trim().min(1),
+    ownerId: z.string().trim().min(1),
+    workspaceId: z.string().trim().min(1),
+    runId: z.string().trim().min(1),
+    leaseDurationSeconds: z.number().int().min(5).max(86_400),
+    dispatchPlanId: z.string().trim().min(1),
+    dispatchPlanVersion: z.literal("1"),
+    snapshotFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+  }).strict();
+
+export const DispatchClaimHeartbeatInputSchema: z.ZodType<DispatchClaimHeartbeatInput> =
+  DispatchClaimInputBaseSchema.extend({
+    proof: DispatchClaimProofSchema,
+    leaseDurationSeconds: z.number().int().min(5).max(86_400),
+  }).strict();
+
+export const DispatchClaimReleaseInputSchema: z.ZodType<DispatchClaimReleaseInput> =
+  DispatchClaimInputBaseSchema.extend({ proof: DispatchClaimProofSchema }).strict();
+
+export const DispatchClaimReclaimInputSchema: z.ZodType<DispatchClaimReclaimInput> =
+  DispatchClaimInputBaseSchema.extend({
+    claimId: z.string().trim().min(1),
+    reason: z.enum(["expired", "owner_stopped"]),
+    ownerStoppedEvidenceId: z.string().trim().min(1).optional(),
+  })
+    .strict()
+    .superRefine((input, context) => {
+      if (input.reason === "owner_stopped" && !input.ownerStoppedEvidenceId) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["ownerStoppedEvidenceId"],
+          message: "owner_stopped reclaim には停止 evidence ID が必要です",
+        });
+      }
+      if (input.reason === "expired" && input.ownerStoppedEvidenceId) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["ownerStoppedEvidenceId"],
+          message: "expired reclaim に owner 停止 evidence は指定できません",
+        });
+      }
+    });
+
+export const DispatchClaimEventAuthorizationInputSchema: z.ZodType<DispatchClaimEventAuthorizationInput> =
+  DispatchClaimInputBaseSchema.extend({
+    proof: DispatchClaimProofSchema,
+    runId: z.string().trim().min(1),
+    taskId: z.string().trim().min(1),
+    actorId: z.string().trim().min(1),
+    commandFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+  }).strict();
+
+const DispatchCompletionAuthorizationSchema: z.ZodType<DispatchCompletionAuthorization> = z
+  .object({
+    runId: z.string().trim().min(1),
+    taskId: z.string().trim().min(1),
+    actorId: z.string().trim().min(1),
+    commandFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+  })
+  .strict();
+
+const DispatchClaimAcceptedReceiptBaseSchema = z.object({
+  accepted: z.literal(true),
+  eventId: z.string().trim().min(1),
+  entityVersion: z.number().int().nonnegative(),
+  stateUnchanged: z.literal(false),
+  claim: DispatchClaimSchema,
+});
+
+const DispatchClaimAcceptedReceiptSchema: z.ZodType<DispatchClaimAcceptedReceipt> = z.union([
+  DispatchClaimAcceptedReceiptBaseSchema.extend({ operation: z.literal("claim") }).strict(),
+  DispatchClaimAcceptedReceiptBaseSchema.extend({ operation: z.literal("heartbeat") }).strict(),
+  DispatchClaimAcceptedReceiptBaseSchema.extend({ operation: z.literal("release") }).strict(),
+  DispatchClaimAcceptedReceiptBaseSchema.extend({
+    operation: z.literal("reclaim"),
+    reclaimReason: z.literal("expired"),
+  }).strict(),
+  DispatchClaimAcceptedReceiptBaseSchema.extend({
+    operation: z.literal("reclaim"),
+    reclaimReason: z.literal("owner_stopped"),
+    evidenceId: z.string().trim().min(1),
+  }).strict(),
+  DispatchClaimAcceptedReceiptBaseSchema.extend({
+    operation: z.literal("authorize_event"),
+    completion: DispatchCompletionAuthorizationSchema,
+    claimContinues: z.boolean(),
+  }).strict(),
+]);
+
+const DispatchClaimRejectedReceiptSchema = z
+  .object({
+    accepted: z.literal(false),
+    operation: z.enum(["claim", "heartbeat", "release", "reclaim", "authorize_event"]),
+    eventId: z.string().trim().min(1),
+    entityVersion: z.number().int().nonnegative(),
+    stateUnchanged: z.literal(true),
+    code: z.enum([
+      "event_payload_mismatch",
+      "stale_entity_version",
+      "dispatch_not_configured",
+      "unknown_state",
+      "global_capacity",
+      "state_capacity",
+      "repository_capacity",
+      "task_already_claimed",
+      "workspace_already_claimed",
+      "claim_not_found",
+      "stale_claim",
+      "authorization_pending",
+      "snapshot_mismatch",
+      "lease_expired",
+      "lease_not_expired",
+    ]),
+    message: z.string().trim().min(1),
+  })
+  .strict();
+
+export const DispatchClaimReceiptSchema: z.ZodType<DispatchClaimReceipt> = z.union([
+  DispatchClaimAcceptedReceiptSchema,
+  DispatchClaimRejectedReceiptSchema,
+]);
+
+export const RunGraphClaimAuditCommandSchema: z.ZodType<RunGraphClaimAuditCommand> = z
+  .object({
+    type: z.enum(RUN_GRAPH_CLAIM_AUDIT_TYPES),
+    registryEventId: z.string().trim().min(1),
+    registryEntityVersion: z.number().int().positive(),
+    claim: DispatchClaimSchema,
+    reclaimReason: z.enum(["expired", "owner_stopped"]).optional(),
+    evidenceId: z.string().trim().min(1).optional(),
+    completion: DispatchCompletionAuthorizationSchema.optional(),
+  })
+  .strict();
+
+export const RunGraphClaimAuditInputSchema: z.ZodType<RunGraphClaimAuditInput> = z
+  .object({
+    schemaVersion: z.literal("1"),
+    eventId: z.string().trim().min(1),
+    actor: z.object({ id: z.string().min(1).max(200), role: z.enum(RUN_GRAPH_ROLES) }).strict(),
+    receipt: DispatchClaimAcceptedReceiptSchema,
+  })
+  .strict();
+
 const OpaqueIdSchema = z.string().min(1).max(200);
 const TimestampSchema = z.string().datetime({ offset: true });
 const ArtifactIdListSchema = z.array(OpaqueIdSchema);
@@ -667,7 +1023,20 @@ export interface RunGraphStartedCommand {
   firstNodeId: string;
 }
 
-export type RunGraphAcceptedCommand = RunGraphStartedCommand | RunGraphRunnerCommand;
+export type RunGraphAcceptedCommand =
+  | RunGraphStartedCommand
+  | RunGraphRunnerCommand
+  | RunGraphClaimAuditCommand;
+
+/** crash 後も exact completion だけを識別する immutable claim authorization binding。 */
+export interface RunGraphDispatchAuthorizationBinding {
+  claimId: string;
+  fencingToken: number;
+  ownerId: string;
+  runId: string;
+  taskId: string;
+  commandFingerprint: string;
+}
 
 export interface RunGraphAcceptedEvent {
   recordType: "accepted";
@@ -681,6 +1050,7 @@ export interface RunGraphAcceptedEvent {
   evidenceIds: string[];
   artifacts?: RunGraphArtifact[];
   evidence?: RunGraphEvidence[];
+  dispatchAuthorization?: RunGraphDispatchAuthorizationBinding;
   nextNodeId?: string;
   nextContractNodeId?: string;
   waitReason?: string;
@@ -696,6 +1066,7 @@ export const RUN_GRAPH_REJECTION_CODES = [
   "evidence_required",
   "pr_not_linked_to_task",
   "github_live_state_unavailable",
+  "stale_claim",
 ] as const;
 
 export type RunGraphRejectionCode = (typeof RUN_GRAPH_REJECTION_CODES)[number];
@@ -871,7 +1242,20 @@ const RunGraphStartedCommandSchema: z.ZodType<RunGraphStartedCommand> = z
 export const RunGraphAcceptedCommandSchema: z.ZodType<RunGraphAcceptedCommand> = z.union([
   RunGraphStartedCommandSchema,
   RunGraphRunnerCommandSchema,
+  RunGraphClaimAuditCommandSchema,
 ]);
+
+export const RunGraphDispatchAuthorizationBindingSchema: z.ZodType<RunGraphDispatchAuthorizationBinding> =
+  z
+    .object({
+      claimId: OpaqueIdSchema,
+      fencingToken: z.number().int().positive(),
+      ownerId: OpaqueIdSchema,
+      runId: OpaqueIdSchema,
+      taskId: OpaqueIdSchema,
+      commandFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    })
+    .strict();
 
 export const RunGraphAcceptedEventSchema: z.ZodType<RunGraphAcceptedEvent> = z
   .object({
@@ -886,6 +1270,7 @@ export const RunGraphAcceptedEventSchema: z.ZodType<RunGraphAcceptedEvent> = z
     evidenceIds: z.array(OpaqueIdSchema),
     artifacts: z.array(RunGraphArtifactSchema).optional(),
     evidence: z.array(RunGraphEvidenceSchema).optional(),
+    dispatchAuthorization: RunGraphDispatchAuthorizationBindingSchema.optional(),
     nextNodeId: OpaqueIdSchema.optional(),
     nextContractNodeId: OpaqueIdSchema.optional(),
     waitReason: z.string().min(1).max(2000).optional(),
@@ -895,6 +1280,19 @@ export const RunGraphAcceptedEventSchema: z.ZodType<RunGraphAcceptedEvent> = z
     const submittedArtifactIds = (event.artifacts ?? []).map((artifact) => artifact.id);
     const submittedEvidenceIds = (event.evidence ?? []).map((evidence) => evidence.id);
     const checkpointUsesAttemptProducer = event.command.type === "run_paused";
+    if (
+      event.dispatchAuthorization &&
+      (event.dispatchAuthorization.runId !== event.runId ||
+        event.dispatchAuthorization.ownerId !== event.actor.id ||
+        (event.command.type !== "attempt_finished" &&
+          event.command.type !== "node_outcome_submitted"))
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["dispatchAuthorization"],
+        message: "dispatch authorization は同じ Run/actor の completion/outcome にだけ指定できます",
+      });
+    }
     if (
       new Set(event.artifactIds).size !== event.artifactIds.length ||
       new Set(event.evidenceIds).size !== event.evidenceIds.length ||
@@ -1070,6 +1468,13 @@ export interface RunGraphBoundedCollection<T> {
   items: T[];
 }
 
+export interface RunGraphClaimAuditView {
+  eventId: string;
+  acceptedAt: string;
+  actor: RunGraphActor;
+  command: RunGraphClaimAuditCommand;
+}
+
 export interface RunGraphView {
   schemaVersion: "1";
   runId: string;
@@ -1088,6 +1493,7 @@ export interface RunGraphView {
   attempts: RunGraphBoundedCollection<RunGraphAttempt>;
   artifacts: RunGraphBoundedCollection<RunGraphArtifact>;
   evidence: RunGraphBoundedCollection<RunGraphEvidence>;
+  claimAudits: RunGraphBoundedCollection<RunGraphClaimAuditView>;
 }
 
 const RunGraphBudgetProjectionSchema: z.ZodType<RunGraphBudgetProjection> = z
@@ -1261,6 +1667,15 @@ const BoundedArtifactCollectionSchema = boundedCollectionSchema(RunGraphArtifact
 const BoundedEvidenceCollectionSchema = boundedCollectionSchema(RunGraphEvidenceSchema);
 const BoundedNodeCollectionSchema = boundedCollectionSchema(RunGraphNodeSchema);
 const BoundedAttemptCollectionSchema = boundedCollectionSchema(RunGraphAttemptSchema);
+const RunGraphClaimAuditViewSchema: z.ZodType<RunGraphClaimAuditView> = z
+  .object({
+    eventId: OpaqueIdSchema,
+    acceptedAt: TimestampSchema,
+    actor: RunGraphActorSchema,
+    command: RunGraphClaimAuditCommandSchema,
+  })
+  .strict();
+const BoundedClaimAuditCollectionSchema = boundedCollectionSchema(RunGraphClaimAuditViewSchema);
 
 export const RunGraphViewSchema: z.ZodType<RunGraphView> = z
   .object({
@@ -1281,5 +1696,6 @@ export const RunGraphViewSchema: z.ZodType<RunGraphView> = z
     attempts: BoundedAttemptCollectionSchema,
     artifacts: BoundedArtifactCollectionSchema,
     evidence: BoundedEvidenceCollectionSchema,
+    claimAudits: BoundedClaimAuditCollectionSchema,
   })
   .strict();

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { LoopConfigSchema } from "./loop-state.js";
+import { NormalizedRepositorySchema } from "./repository.js";
 import { RunGraphConfigSchema } from "./run-graph.js";
 import type {
   AcceptanceCriterion,
@@ -159,10 +160,6 @@ const CalendarHolidaySchema: z.ZodType<CalendarHoliday> = z.object({
 const DoctorConfigSchema: z.ZodType<DoctorConfig> = z.object({
   stale_in_progress_days: z.number().int().positive().optional(),
 });
-
-const NormalizedRepositorySchema = z
-  .string()
-  .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/);
 
 export const DispatchConfigSchema: z.ZodType<DispatchConfig> = z
   .object({

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -7,6 +7,7 @@ import type {
   Config,
   Dependency,
   DoctorConfig,
+  DispatchConfig,
   LinkedPullRequest,
   SprintConfig,
   Statuses,
@@ -159,6 +160,20 @@ const DoctorConfigSchema: z.ZodType<DoctorConfig> = z.object({
   stale_in_progress_days: z.number().int().positive().optional(),
 });
 
+const NormalizedRepositorySchema = z
+  .string()
+  .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/);
+
+export const DispatchConfigSchema: z.ZodType<DispatchConfig> = z
+  .object({
+    max_concurrency: z.number().int().positive(),
+    state_concurrency: z.record(z.string().trim().min(1), z.number().int().positive()).optional(),
+    repository_concurrency: z
+      .record(NormalizedRepositorySchema, z.number().int().positive())
+      .optional(),
+  })
+  .strict();
+
 const ConflictPolicyChoiceSchema = z.enum(["ours", "theirs", "manual"]);
 const ConflictPolicySchema = z
   .object(
@@ -170,58 +185,71 @@ const ConflictPolicySchema = z
 
 // `default_view` の z.preprocess が input 型を unknown に広げるため、
 // Input 引数を unknown に明示して TS の input 型不整合を回避する。
-export const ConfigSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z.object({
-  version: z.string(),
-  project: z.object({
-    name: z.string(),
-    github: z.object({
-      owner: z.string(),
-      repo: z.string(),
-      project_number: z.number(),
-    }),
-  }),
-  sync: z
-    .object({
-      auto_create_issues: z.boolean(),
-      auto_push: z.boolean().default(true),
-      conflict_policy: ConflictPolicySchema.optional(),
-      field_mapping: z.object({
-        start_date: z.string(),
-        end_date: z.string(),
-        // deprecated: Status フィールド名の正は statuses.field_name (#315)。
-        // 既存 config の後方互換のため受理するが、値は無視される。
-        status: z.string().optional(),
-        type: z.string().nullable().optional(),
-        priority: z.string().optional(),
-        estimate_hours: z.string().optional(),
+export const ConfigSchema: z.ZodType<Config, z.ZodTypeDef, unknown> = z
+  .object({
+    version: z.string(),
+    project: z.object({
+      name: z.string(),
+      github: z.object({
+        owner: z.string(),
+        repo: z.string(),
+        project_number: z.number(),
       }),
-    })
-    .passthrough(),
-  task_types: z.record(TaskTypeSchema),
-  type_hierarchy: z.record(z.array(z.string())),
-  statuses: StatusesSchema,
-  gantt: z.object({
-    default_view: z.preprocess((v) => (v === "day" ? "week" : v), ViewScaleSchema),
-    working_days: z.array(z.number()),
-    holidays: z.array(CalendarHolidaySchema).optional(),
-    at_risk_threshold_days: z.number().int().positive().optional(),
-    colors: z.object({
-      critical_path: z.string(),
-      on_track: z.string(),
-      at_risk: z.string(),
-      overdue: z.string(),
     }),
-  }),
-  grouping: GroupingSchema.optional(),
-  sprints: z.array(SprintSchema).optional(),
-  task_templates: TaskTemplatesSchema.optional(),
-  doctor: DoctorConfigSchema.optional(),
-  loop: LoopConfigSchema.optional(),
-  run_graph: RunGraphConfigSchema.optional(),
-  require_review_for_types: z.array(z.string().trim().min(1)).default([]),
-  require_close_evidence: z.boolean().default(false),
-  max_task_size_hours: z.number().positive().optional(),
-});
+    sync: z
+      .object({
+        auto_create_issues: z.boolean(),
+        auto_push: z.boolean().default(true),
+        conflict_policy: ConflictPolicySchema.optional(),
+        field_mapping: z.object({
+          start_date: z.string(),
+          end_date: z.string(),
+          // deprecated: Status フィールド名の正は statuses.field_name (#315)。
+          // 既存 config の後方互換のため受理するが、値は無視される。
+          status: z.string().optional(),
+          type: z.string().nullable().optional(),
+          priority: z.string().optional(),
+          estimate_hours: z.string().optional(),
+        }),
+      })
+      .passthrough(),
+    task_types: z.record(TaskTypeSchema),
+    type_hierarchy: z.record(z.array(z.string())),
+    statuses: StatusesSchema,
+    gantt: z.object({
+      default_view: z.preprocess((v) => (v === "day" ? "week" : v), ViewScaleSchema),
+      working_days: z.array(z.number()),
+      holidays: z.array(CalendarHolidaySchema).optional(),
+      at_risk_threshold_days: z.number().int().positive().optional(),
+      colors: z.object({
+        critical_path: z.string(),
+        on_track: z.string(),
+        at_risk: z.string(),
+        overdue: z.string(),
+      }),
+    }),
+    grouping: GroupingSchema.optional(),
+    sprints: z.array(SprintSchema).optional(),
+    task_templates: TaskTemplatesSchema.optional(),
+    doctor: DoctorConfigSchema.optional(),
+    dispatch: DispatchConfigSchema.optional(),
+    loop: LoopConfigSchema.optional(),
+    run_graph: RunGraphConfigSchema.optional(),
+    require_review_for_types: z.array(z.string().trim().min(1)).default([]),
+    require_close_evidence: z.boolean().default(false),
+    max_task_size_hours: z.number().positive().optional(),
+  })
+  .superRefine((config, context) => {
+    for (const state of Object.keys(config.dispatch?.state_concurrency ?? {})) {
+      if (!(state in config.statuses.values)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dispatch", "state_concurrency", state],
+          message: "state_concurrency のキーは configured status と一致する必要があります",
+        });
+      }
+    }
+  });
 
 export const TasksFileSchema: z.ZodType<TasksFile> = z.object({
   tasks: z.array(TaskSchema),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -174,6 +174,13 @@ export interface DoctorConfig {
   stale_in_progress_days?: number;
 }
 
+/** ready frontier の同時実行上限。未指定の軸は global 上限だけを使う。 */
+export interface DispatchConfig {
+  max_concurrency: number;
+  state_concurrency?: Record<string, number>;
+  repository_concurrency?: Record<string, number>;
+}
+
 export interface Config {
   version: string;
   project: {
@@ -189,6 +196,8 @@ export interface Config {
   sprints?: SprintConfig[];
   task_templates?: TaskTemplates;
   doctor?: DoctorConfig;
+  /** 外部 runner へ渡す ready frontier の bounded concurrency 設定。 */
+  dispatch?: DispatchConfig;
   /** 外側ループの停止条件（ADR-016 案C / ADR-017）。未設定でも既存挙動は変わらない。 */
   loop?: LoopConfig;
   /** 単一 Issue Run Graph が exact binding する versioned Graph Contract。 */

--- a/skills/gh-gantt-dev-role/SKILL.md
+++ b/skills/gh-gantt-dev-role/SKILL.md
@@ -98,6 +98,7 @@ gh-gantt run show <run-id> --json
 - `human_decision` と `pr_observed` を raw `run event` に含めない。human authority は `gh-gantt run decide`、PR live evidence は read-only の `gh-gantt run observe-pr` からだけ投入する。
 - human gate は human authority の decision evidence、または契約で許可された edge への理由付き override でのみ解除する。
 - Run Graph event は Work Graph の task status を暗黙更新しない。GitHub への反映は既存 gh-gantt workflow に委ねる。
+- accepted outcome、claim release/reclaim 後の fan-in 再評価は `gh-gantt pull` と `gh-gantt list` を使い、共有 Work Graph Cache の内部ファイルを直接読み書きしない。
 
 `run` command がない既存 project では、従来どおり `.dev-flow` の schema-valid artifact を handoff とする。
 artifact が存在することを durable Run Graph event が受理された証拠にはしない。

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -102,6 +102,38 @@ Evidence: コマンド出力をそのまま提示する。
 17. **★`on_session_end`** — workflow.md の該当セクションを実行
 18. **REQUIRED:** `gh-gantt-sync`（push）を invoke。タスクの close は PR マージ時に GitHub が自動で行う
 
+## Bounded dispatch
+
+複数 task を並列実行するときも、gh-gantt は runner ではなく control plane として振る舞う。
+次の lifecycle を順番どおり実行する。
+
+1. `gh-gantt pull` で GitHub Projects 由来の Work Graph を更新し、dependency readiness と同期状態を確認する。
+2. `gh-gantt run dispatch --workspace-map <path> --gate-snapshot <path>` で Config の global / state / repository 上限内にある ready frontier の dispatch plan をファイルへ保存する。gate snapshot は strict JSON の `schemaVersion` / `sourceRevision` / `observedAt` / review/human IDs を持つ。plan は shared strict schema の `planVersion: "1"`、`planId`、`registryEntityVersion`、`generatedAt`、候補、除外理由、capacity と Work Graph/gate/combined fingerprint を持つ。
+3. dispatch plan の各 task に `gh-gantt run claim --plan-file <path> --gate-snapshot <path>` を実行する。claim は Work Graph read lease 内で current Work Graph、loop、sync、current gate snapshot、registry を再計算し、selected task の repository / state / workspace、Run Graph の task binding、plan lineage / version / fingerprint を検証してから、独立した registry CAS で claim receipt を確定する。固定 lock order は Work Graph read lease → claim registry lock とし、Work Graph lease を registry storage に流用しない。
+4. 外部 runner が task ごとに別の isolated workspace を用意する。同じ workspace を複数 claim で共有しない。
+5. 実行中は lease が失効する前に `gh-gantt run heartbeat` を送り、current owner と fencing version を更新する。
+6. completion fencing として、registry lock 内で current claim proof と Run / task / actor lineage を検証し、Run Graph の transition、attempt、artifact、evidence を明示的な副作用なしの domain validation seam で検証する。reject では registry と journal を変更せず、同じ current proof で修正 event を retry できる。dispatch Config が有効なら proof なしの completion/outcome は一律に拒否する。
+7. validation 後、event ID / payload fingerprint / current claim lineage と dispatch authorization binding を repository-shared pending authorization として先に永続化する。pending 中の heartbeat / release / 別 event は `authorization_pending` で拒否する。同じ event ID / payload / binding の retry だけが binding 付き Run Graph event を append でき、append 成功後だけ durable receipt が entity version と fencing token を進め、claim を維持したまま更新 proof を返す。sequence 競合では pending を解除して original proof を維持する。
+8. pending publish 後・append 前、または append 後・receipt publish 前に中断した場合、exact retry だけを reconciliation する。claim が current なら receipt と更新 proof を回収する。先に expired / owner_stopped reclaim された場合は pending を terminalize し、既存 event だけを historical audit できるが新規 event と継続 proof は受け取れない。receipt publish 後は stored receipt に収束する。
+9. task / Run の正常終了または中止時は `gh-gantt run release` で claim を明示解放する。中間 event の認可は release ではない。期限切れ claim の release は `lease_expired` で拒否し、expired reclaim を使う。
+10. owner 停止を evidence ID で確認した場合、または lease が失効した場合だけ、別 owner が `gh-gantt run reclaim` を実行する。旧 owner の heartbeat、release、event authorization は stale として拒否される。
+11. accepted outcome event、release、reclaim の後は Work Graph を読み直し、dependency を再評価して fan-in を解く。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
+
+claim lifecycle は `claim_acquired` / `claim_heartbeat` / `claim_released` / `claim_reclaimed` / `claim_event_authorized` として
+workspace-local の Run Graph audit へ記録する。audit は event ID、fingerprint、entity version、run / task lineage を
+repository-shared durable registry receipt と照合し、偽造・stale receipt は `stale_claim` で拒否する。audit event ID は
+`audit:${receipt.eventId}` に固定し、同じ registry event の別 ID 追記を拒否する。receipt 確定後、
+local audit の追記前に中断した場合は、同じ event ID で command を再実行して reconciliation する。
+`gh-gantt run show` は `claimAudits` の total / limit / truncated / bounded items を JSON と人間表示で公開する。
+
+sync conflict、open iteration、review gate、human gate のいずれかがある task は dispatch しない。
+Work Graph に存在しない task ID を含む不明な gate snapshot は `gate_snapshot_inconsistent` で frontier 全体を停止する。
+claim registry の不整合、Config にない status、plan 生成後に変化した dependency / gate / claim も fail-closed とする。
+
+gh-gantt が提供するのは schema-validated な dispatch plan と event contract だけである。
+agent/provider/shell runner を内蔵しないほか、workspace を作成しない。外部 runner が isolated workspace の
+作成、process の起動、成果物の生成を担当し、gh-gantt は GitHub task status を暗黙更新しない。
+
 ## 自律ループモード
 
 人間との対話なしで複数タスクを連続処理する場合（Claude Code の /loop 等）は、

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -117,7 +117,7 @@ Evidence: コマンド出力をそのまま提示する。
 8. pending publish 後・append 前、または append 後・receipt publish 前に中断した場合、exact retry だけを reconciliation する。claim が current なら receipt と更新 proof を回収する。先に expired / owner_stopped reclaim された場合は pending を terminalize し、既存 event だけを historical audit できるが新規 event と継続 proof は受け取れない。receipt publish 後は stored receipt に収束する。
 9. task / Run の正常終了または中止時は `gh-gantt run release` で claim を明示解放する。中間 event の認可は release ではない。期限切れ claim の release は `lease_expired` で拒否し、expired reclaim を使う。
 10. owner 停止を evidence ID で確認した場合、または lease が失効した場合だけ、別 owner が `gh-gantt run reclaim` を実行する。旧 owner の heartbeat、release、event authorization は stale として拒否される。
-11. accepted outcome event、release、reclaim の後は Work Graph を読み直し、dependency を再評価して fan-in を解く。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
+11. accepted outcome event、release、reclaim の後は `gh-gantt pull` で GitHub 由来の Work Graph を更新し、`gh-gantt list` で dependency readiness を再評価して fan-in を解く。共有 Work Graph Cache の内部ファイルは直接読み書きしない。全 upstream task が完了した downstream task だけを次の dispatch 対象にする。
 
 claim lifecycle は `claim_acquired` / `claim_heartbeat` / `claim_released` / `claim_reclaimed` / `claim_event_authorized` として
 workspace-local の Run Graph audit へ記録する。audit は event ID、fingerprint、entity version、run / task lineage を

--- a/tests/workflow/gh-gantt-workflow-skill.test.ts
+++ b/tests/workflow/gh-gantt-workflow-skill.test.ts
@@ -1,0 +1,96 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { z } from "zod";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+async function readRepoFile(path: string): Promise<string> {
+  const content = await readFile(resolve(repoRoot, path), "utf-8");
+  return z.string().min(1).parse(content);
+}
+
+function expectOrdered(content: string, fragments: string[]): void {
+  let previousIndex = -1;
+  for (const fragment of fragments) {
+    const currentIndex = content.indexOf(fragment);
+    expect(currentIndex, `${fragment} が見つからない`).toBeGreaterThan(previousIndex);
+    previousIndex = currentIndex;
+  }
+}
+
+describe("[NFR-STABILITY-014-AC9] ready frontier は global/state/repository 上限内で isolated workspace を claim/lease し、heartbeat、release/reclaim、completion fencing、停止 gate、Run Graph audit、fan-in 再評価を持つ", () => {
+  it("汎用 skill と repository workflow が同じ公開 CLI lifecycle を順序付きで定義する", async () => {
+    const [skill, workflow] = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/SKILL.md"),
+      readRepoFile(".gantt-sync/workflow.md"),
+    ]);
+    const lifecycle = [
+      "gh-gantt pull",
+      "gh-gantt run dispatch",
+      "gh-gantt run claim",
+      "isolated workspace",
+      "gh-gantt run heartbeat",
+      "completion fencing",
+      "gh-gantt run release",
+      "gh-gantt run reclaim",
+      "fan-in",
+    ];
+
+    expectOrdered(skill, lifecycle);
+    expectOrdered(workflow, lifecycle);
+  });
+
+  it("dispatch は sync conflict、open iteration、review gate、human gate で停止する", async () => {
+    const documents = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/SKILL.md"),
+      readRepoFile(".gantt-sync/workflow.md"),
+    ]);
+
+    for (const document of documents) {
+      expect(document).toContain("sync conflict");
+      expect(document).toContain("open iteration");
+      expect(document).toContain("review gate");
+      expect(document).toContain("human gate");
+      expect(document).toContain("dispatch しない");
+    }
+  });
+
+  it("gh-gantt は dispatch plan と event contract だけを提供し runner や workspace を起動しない", async () => {
+    const documents = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/SKILL.md"),
+      readRepoFile(".gantt-sync/workflow.md"),
+    ]);
+
+    for (const document of documents) {
+      expect(document).toContain("dispatch plan");
+      expect(document).toContain("event contract");
+      expect(document).toContain("runner を内蔵しない");
+      expect(document).toContain("workspace を作成しない");
+    }
+  });
+
+  it("claim lifecycle は Run Graph audit へ記録し receipt 確定後の中断を同じ event ID で reconciliation する", async () => {
+    const documents = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/SKILL.md"),
+      readRepoFile(".gantt-sync/workflow.md"),
+    ]);
+
+    for (const document of documents) {
+      expect(document).toContain("Run Graph audit");
+      expect(document).toContain("claim_event_authorized");
+      expect(document).toContain("domain validation");
+      expect(document).toContain("--gate-snapshot <path>");
+      expect(document).toContain("sourceRevision");
+      expect(document).toContain("combined fingerprint");
+      expect(document).toContain("pending authorization");
+      expect(document).toContain("authorization_pending");
+      expect(document).toContain("historical audit");
+      expect(document).toContain("audit:${receipt.eventId}");
+      expect(document).toContain("claim を維持したまま更新 proof");
+      expect(document).toContain("中間 event の認可は release ではない");
+      expect(document).toContain("同じ event ID");
+      expect(document).toContain("reconciliation");
+    }
+  });
+});

--- a/tests/workflow/graph-contract.test.ts
+++ b/tests/workflow/graph-contract.test.ts
@@ -648,7 +648,7 @@ describe("Graph Contract の公開文書契約", () => {
     expect(mapSection.length).toBeLessThan(700);
   });
 
-  it("NFR-STABILITY-014はAC1からAC8をcoverage状態と分離して固有意味のまま保持する", async () => {
+  it("NFR-STABILITY-014はAC1からAC9をcoverage状態と分離して固有意味のまま保持する", async () => {
     const requirements = RequirementsSchema.parse(
       parse(await readRepoFile("docs/requirements.yaml")) as unknown,
     );
@@ -657,7 +657,7 @@ describe("Graph Contract の公開文書契約", () => {
     const criteria = requirement?.acceptance_criteria ?? [];
 
     expect(criteria.map((entry) => entry.id)).toEqual(
-      Array.from({ length: 8 }, (_, index) => `NFR-STABILITY-014-AC${index + 1}`),
+      Array.from({ length: 9 }, (_, index) => `NFR-STABILITY-014-AC${index + 1}`),
     );
     const meanings: Record<string, string[]> = {
       "NFR-STABILITY-014-AC1": [
@@ -693,6 +693,21 @@ describe("Graph Contract の公開文書契約", () => {
       ],
       "NFR-STABILITY-014-AC7": ["bypass", "authority", "evidence", "human gate"],
       "NFR-STABILITY-014-AC8": ["bounded parallelism", "Work Graph", "versioned extension"],
+      "NFR-STABILITY-014-AC9": [
+        "ready frontier",
+        "global/state/repository",
+        "isolated workspace",
+        "claim/lease",
+        "heartbeat",
+        "release/reclaim",
+        "completion fencing",
+        "domain validation",
+        "更新 proof",
+        "修正 retry",
+        "停止 gate",
+        "Run Graph audit",
+        "fan-in 再評価",
+      ],
     };
 
     for (const entry of criteria) {

--- a/tests/workflow/graph-contract.test.ts
+++ b/tests/workflow/graph-contract.test.ts
@@ -622,6 +622,17 @@ describe("Graph Contract の公開文書契約", () => {
     expect(projectWorkflow).toContain("JSON/schema/manual gate");
     expect(projectWorkflow).toContain("現行 (#328)");
     expect(projectWorkflow).toContain("製品control plane");
+    expect(projectWorkflow).toContain("`gh-gantt pull`");
+    expect(projectWorkflow).toContain("`gh-gantt list`");
+    expect(projectWorkflow).toContain("共有 Work Graph Cache の内部ファイルは直接読み書きしない");
+
+    const workflowSkill = await readRepoFile("skills/gh-gantt-workflow/SKILL.md");
+    const devRoleSkill = await readRepoFile("skills/gh-gantt-dev-role/SKILL.md");
+    for (const content of [workflowSkill, devRoleSkill]) {
+      expect(content).toContain("`gh-gantt pull`");
+      expect(content).toContain("`gh-gantt list`");
+      expect(content).toContain("共有 Work Graph Cache の内部ファイル");
+    }
 
     const sharedSkillPaths = [
       "skills/gh-gantt-dev-role/SKILL.md",

--- a/tests/workflow/project-config.test.ts
+++ b/tests/workflow/project-config.test.ts
@@ -146,3 +146,22 @@ describe("[NFR-STABILITY-014-AC1] 共有 project config が versioned Graph Cont
     expect(workflow).toContain("gh-gantt run observe-pr");
   });
 });
+
+describe("[NFR-STABILITY-014-AC9] ready frontier は global/state/repository 上限内で isolated workspace を claim/lease し、heartbeat、release/reclaim、completion fencing、停止 gate、Run Graph audit、fan-in 再評価を持つ", () => {
+  it("共有 project config が global、state、repository の concurrency 上限を固定する", async () => {
+    const rawConfig = JSON.parse(await readRepoFile(".gantt-sync/gantt.config.json"));
+    const config = ConfigSchema.parse(rawConfig);
+
+    expect(config).toMatchObject({
+      dispatch: {
+        max_concurrency: 2,
+        state_concurrency: {
+          "In Progress": 2,
+        },
+        repository_concurrency: {
+          "stanah/gh-gantt": 2,
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Work Graph・gate snapshot・claim snapshot から決定論的な ready frontier と bounded dispatch plan を生成する
- repository-shared claim registry に lease・heartbeat・release・reclaim・fencing・crash recovery を追加する
- claim proof 付き Run Graph event を append-before-receipt で確定し、crash / retry / reclaim race を監査可能にする
- `run dispatch` / `run claim` / `run heartbeat` / `run release` / `run reclaim` と公開 JSON contract を追加する
- ADR-024、要件 Reconciliation、workflow skill を更新する（NFR-STABILITY-014-AC9 は covered、#331 の責務である AC8 は uncovered のまま）

Closes #329

## Test Plan

- `pnpm test`: workflow 71 / shared 238 / CLI 820 / UI 229 / smoke 15
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm req:trace`: covered 211 / uncovered 20 / failing 0
- `pnpm req:validate`（既存 orphan warning 23件のみ）
- `pnpm docs:gen`
- claim / lease / completion / reclaim の multi-process・linked-worktree・crash境界・race回帰テスト
- 実 `pre-push` hook の test / build / req-trace / req-validate / docs-gen を通過
- betterleaks 1.1.2（固定 digest）で staged 差分とPR全差分を non-skip走査し、`no leaks found`
- 独立 executor / reviewer 検証: approve、finding 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * タスクの同時実行数を、全体・状態別・リポジトリ別に制限できるようになりました。
  * dispatch計画の生成、claimの取得・維持・解放・再取得をCLIから管理できます。
  * 実行状況にclaim監査情報を表示し、期限切れや不正な完了報告を安全に拒否します。

* **ドキュメント**
  * bounded dispatchの運用手順、監査、復旧、再試行に関する仕様を追加しました。

* **テスト**
  * 並行実行、競合、クラッシュ復旧、期限切れclaimなどの検証を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->