### PR TITLE
feat(smoke): Graph Engineering の実測ゲートを追加 (#332)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A pnpm workspaces monorepo with 3 packages:
 ## ドキュメント
 
 - [Project Map / Task Landscape（プロジェクトマップ）](docs/project-map.md) — 構造探索・依存探索・次アクション判断のための第 2 ビュー仕様
+- [Graph Engineering の計測・導入・停止・復旧](skills/gh-gantt-workflow/references/graph-engineering.md) — single-loopとの実測比較、recovery smoke、採用・縮退条件
 
 ## Development
 

--- a/docs/adr/ADR-026-measured-graph-engineering-adoption.md
+++ b/docs/adr/ADR-026-measured-graph-engineering-adoption.md
@@ -47,7 +47,9 @@ verified success、wall-clock、input/output token、cost、Run node、agent inv
 human intervention / wait、recovery time、coordination failureを記録する。各 metric は
 `known(value)` または `unknown(reason)` の排他的 union とし、known 0 を unknown へ丸めない。
 
-公開 evidence は repository 相対 path または HTTPS URL、SHA-256、byte length、種別だけを持つ。
+公開 evidence reference は repository 相対 path または HTTPS URL、SHA-256、byte length、種別だけを持つ。
+公開 recovery observation は scenario、status、recovery time と reference のみを許可し、command、fault injection、
+postcondition本文は非公開の実行記録へ分離する。
 raw prompt、conversation、provider response、token、秘密鍵、絶対 path、hostname、内部 run/session ID は残さない。
 1 trial の reference は最大20件、1 reference metadata は最大64 KiB とし、report は evidence URI 自体も再出力しない。
 
@@ -55,7 +57,7 @@ raw prompt、conversation、provider response、token、秘密鍵、絶対 path�
 
 Graph arm を task-shape 固有の候補にできるのは、次をすべて満たす場合だけである。
 
-1. 5 scenario に最低1 pairずつあり、先行順の差が1以内である。
+1. 5 scenario に最低1 pairずつあり、suite順で先行strategyが交互である。
 2. 5 recovery smoke が evidence 付きで pass し、recovery time が known である。
 3. verified success が全 trial で known かつ Graph arm に failure がない。
 4. `ready_frontier` の Graph arm が同じ pair の single-loop より20%以上短い。

--- a/docs/adr/ADR-026-measured-graph-engineering-adoption.md
+++ b/docs/adr/ADR-026-measured-graph-engineering-adoption.md
@@ -1,0 +1,112 @@
+---
+id: ADR-026
+title: Graph Engineering の採用を実測と recovery evidence で gate する
+date: 2026-08-03
+status: accepted
+related_requirements:
+  - NFR-STABILITY-016
+---
+
+## Context
+
+ADR-021 で定義した Graph Engineering は、Plan / Work / Org / Run Graph を別の正本として扱い、
+version、authority、evidence、budget、human gate で結ぶ gh-gantt 固有の設計規律である。
+Graph Engineering は外部標準ではない。graph を作ったこと自体は、single-loop より高い品質、短い時間、
+低い費用を証明しない。
+
+一次資料調査では、Anthropic は単純な構成から始め、独立した task への並列化や独立観点に価値がある場合だけ
+複雑化するよう勧めている。同社の research system の評価値を coding task へ一般化することはできない。
+OpenAI Symphony は issue tracker、bounded concurrency、reconciliation の参考になるが scheduler state は
+memory-only であり、gh-gantt の durable Run Graph、claim、fencing の保証とは同じでない。詳細は
+[一次資料調査](../research/graph-engineering-primary-sources.md)を正本とする。
+
+## Decision
+
+### 実行と測定の seam
+
+`@gh-gantt/smoke` に strict JSON の benchmark module を置く。外部 runner は作業を実行し、bounded observation と
+hash-bound evidence reference を入力する。module は schema validation、paired comparison、coverage、採用・縮退
+判定だけを行う。provider SDK、agent subprocess、任意 shell executor は製品へ内蔵しない。
+
+入力は同じ acceptance criteria hash、repository revision、verifier hash、environment hash を持つ
+`single_loop` と `graph_orchestration` の pair に限定する。strategy の先行順は交互にし、次の5 scenarioを
+別々に含める。
+
+入力の suite / task shape / pair ID は照合用の非公開データとして扱い、reportへ再出力しない。report上のpairは
+入力値と結び付かない1始まりのordinalだけを持つ。CLIのstdout modeは単一JSON documentだけを返す。
+
+- `fixed_run_graph`
+- `ready_frontier`
+- `verify_failure_recovery`
+- `human_gate`
+- `approved_work_graph_mutation`
+
+### metric と evidence
+
+verified success、wall-clock、input/output token、cost、Run node、agent invocation、tool call、retry、
+human intervention / wait、recovery time、coordination failureを記録する。各 metric は
+`known(value)` または `unknown(reason)` の排他的 union とし、known 0 を unknown へ丸めない。
+
+公開 evidence は repository 相対 path または HTTPS URL、SHA-256、byte length、種別だけを持つ。
+raw prompt、conversation、provider response、token、秘密鍵、絶対 path、hostname、内部 run/session ID は残さない。
+1 trial の reference は最大20件、1 reference metadata は最大64 KiB とし、report は evidence URI 自体も再出力しない。
+
+### qualification と初期値
+
+Graph arm を task-shape 固有の候補にできるのは、次をすべて満たす場合だけである。
+
+1. 5 scenario に最低1 pairずつあり、先行順の差が1以内である。
+2. 5 recovery smoke が evidence 付きで pass し、recovery time が known である。
+3. verified success が全 trial で known かつ Graph arm に failure がない。
+4. `ready_frontier` の Graph arm が同じ pair の single-loop より20%以上短い。
+5. token と cost が known で、Graph arm / single-loop の比が2倍以下である。
+6. wall-clock、node / agent / tool call、retry、human intervention / wait、recovery timeが全trialでknownである。
+7. 両armのcoordination failureがknown 0である。
+
+どれかが欠ける場合は `single-loop` を既定とし、concurrency 1、implicit automatic retry 0 へ縮退する。
+全 gate を通った task shape だけ concurrency 2、automatic retry 1 を初期値にできる。remote side effect、
+Work Graph mutation、principal separation が必要な操作の human gate は成績によらず必須である。
+
+これらは runner の初期値であり、Graph Contract の `maxExecutorRetries: 2`、repository dispatch の
+`max_concurrency: 2` という contract ceiling を変更しない。benchmark は ceiling を緩和せず、観測値を
+全 task へ一般化しない。output policy は `outputReferenceLimit: 20`、inline evidence 0 byte とする。
+
+### recovery smoke
+
+次の failure class を一つずつ注入し、別々の postcondition と evidence を残す。
+
+- runner failure
+- process restart
+- stale lease
+- controlled GitHub API transient failure
+- sync conflict
+
+GitHub API は実 rate-limit や実障害を起こさない。専用 smoke 環境の transport seam で fail-once / timeout を
+発生させ、回復後に実 GitHub read または限定 mutation の postcondition を照合する。unknown side effect は
+自動再送せず human gate へ送る。
+
+## Alternatives
+
+### 製品に multi-agent runner を内蔵する
+
+provider と process lifecycle が control plane へ漏れ、外部 runner と製品の責務が混ざるため採用しない。
+
+### Anthropic または Symphony の既定値を流用する
+
+task、model、権限、durability が異なり、coding task の安全値を証明しないため採用しない。
+
+### 欠測を0として比較する
+
+未取得の token / cost / retry と実測0を混同し、Graph arm を誤って昇格できるため採用しない。
+
+### 実 rate-limit や GitHub障害を発生させる
+
+GitHub の利用規律に反し、他の利用者と公開repositoryへ影響するため採用しない。
+
+## Consequences
+
+- Graph Engineering は opt-in となり、データ不足時は単純な single-loop が選ばれる。
+- task shape ごとに同条件の pair と recovery evidence を維持する運用コストが増える。
+- token / cost を公開安全に取得できない provider では Graph arm は自動昇格しない。
+- durable Run Graph と Symphony の memory-only scheduler state の保証差を維持できる。
+- benchmark report は task quality の証拠ではなく、入力 evidence を検証・要約した qualification 結果である。

--- a/docs/benchmarks/graph-engineering-2026-08-03.md
+++ b/docs/benchmarks/graph-engineering-2026-08-03.md
@@ -3,8 +3,9 @@
 Issue #332 の導入前 pilot。公開 repository を変更しない一時 workspace と、
 base revision `09ba15a046f721b98b728ea39a8b81d9053e6f70` から build した CLI を使った。
 raw log、認証情報、絶対 path、内部 Run / claim / session ID は保存していない。
-各観測の入力条件、command template、期待・観測 postcondition、digest は
-[versioned recovery evidence](graph-engineering-recovery-evidence.json) に固定する。
+各観測の詳細な入力条件、command、期待・観測 postcondition は非公開の一時実行記録にのみ保持し、
+versioned な [recovery evidence pack](graph-engineering-recovery-evidence.json) は、この公開要約への
+kind / URI / SHA-256 / byte length と outcome / recovery time だけを固定する。
 
 ## 結論
 
@@ -44,7 +45,7 @@ GitHub API smoke は実 rate-limit、GitHub 障害、大量 requestを発生さ�
 `resource_metrics_unknown`、`operational_metrics_unknown`、`recovery_time_unknown` を含む。
 これは benchmark harness の失敗ではなく、Graph を自動昇格させないための fail-closed な結果である。
 
-## 再現コマンド
+## 公開 runbook
 
 ```bash
 pnpm build
@@ -57,6 +58,7 @@ node packages/cli/dist/index.js run heartbeat --help
 gh-gantt conflicts
 ```
 
-Run Graph / claim の具体的な command file と opaque ID は一時 workspace にのみ置く。
+この節は再実行用の一般化した操作例であり、実行 evidence そのものではない。
+Run Graph / claim の具体的な command file と opaque ID は非公開の一時 workspace にのみ置く。
 再実行時も [Graph Engineering 運用 reference](../../skills/gh-gantt-workflow/references/graph-engineering.md) の
 public-safe evidence 規律に従い、結果は bounded summaryへ変換する。

--- a/docs/benchmarks/graph-engineering-2026-08-03.md
+++ b/docs/benchmarks/graph-engineering-2026-08-03.md
@@ -1,0 +1,62 @@
+# Graph Engineering pre-adoption benchmark — 2026-08-03
+
+Issue #332 の導入前 pilot。公開 repository を変更しない一時 workspace と、
+base revision `09ba15a046f721b98b728ea39a8b81d9053e6f70` から build した CLI を使った。
+raw log、認証情報、絶対 path、内部 Run / claim / session ID は保存していない。
+各観測の入力条件、command template、期待・観測 postcondition、digest は
+[versioned recovery evidence](graph-engineering-recovery-evidence.json) に固定する。
+
+## 結論
+
+この task shape は `single_loop` のままとする。5つの recovery class は別々に確認できたが、
+同一 acceptance criteria / revision / verifier / environment の paired trial と token / cost が未取得であり、
+sync conflict の operator recovery time も計測していない。欠測を0へ変換せず、Graph arm の改善とは判定しない。
+
+採用前の安全な初期値は concurrency 1、automatic retry 0、remote side effect の human gate 必須、
+`outputReferenceLimit: 20`、inline evidence 0 byte とする。
+
+## Recovery smoke
+
+| failure class          | 注入と postcondition                                                                                                                                            | 結果   | recovery time                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------------- |
+| `runner_failure`       | planner attempt を terminal failure にし、`attempt_failed` の human gate を観測。override 後は失敗 attempt を保持した新 planner node へ進んだ                   | passed | known 726 ms                                 |
+| `process_restart`      | event を適用した process を終了し、別 CLI process の `run show --json` で state、wait reason、terminal attempt を再観測した                                     | passed | known 197 ms                                 |
+| `stale_lease`          | 5秒 lease の期限後に `run reclaim --reason expired`。旧 owner の heartbeat は `stale_claim` で拒否され、registry version は変化しなかった                       | passed | known 13,060 ms（期限から reclaim 受理まで） |
+| `github_api_transient` | pre-check transport seam を1回失敗させ、full fetch fallback を同じ verifier で確認。その後の認証済み real `pull` は exit 0、remote change 0で完了した           | passed | known 3 ms（controlled fallback test）       |
+| `sync_conflict`        | #331 の status が local `In Progress` / remote `Done` で競合。`--theirs` の明示 resolve と idempotent push 後、`gh-gantt conflicts` が `No conflicts.` を返した | passed | unknown (`not_collected`)                    |
+
+GitHub API smoke は実 rate-limit、GitHub 障害、大量 requestを発生させていない。controlled seam の failureと、
+回復後の実 read postconditionを分離した。sync conflict では公開 Issue の最終値を変更せず、merge済みの`Done`へ
+収束させた。
+
+## 比較 coverage
+
+| gate                 | 観測                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 5 scenario registry  | known: `fixed_run_graph`, `ready_frontier`, `verify_failure_recovery`, `human_gate`, `approved_work_graph_mutation` |
+| same-condition pair  | unknown: 未実行                                                                                                     |
+| verified success     | recovery smoke は known passed。比較 trial は unknown                                                               |
+| token / cost         | unknown (`provider_not_exposed`)                                                                                    |
+| coordination failure | recovery smoke 中は known 0。比較 trial は unknown                                                                  |
+| recovery time        | 4件 known、1件 unknown                                                                                              |
+
+したがって qualification reason は少なくとも `paired_trial_count_insufficient`、
+`resource_metrics_unknown`、`operational_metrics_unknown`、`recovery_time_unknown` を含む。
+これは benchmark harness の失敗ではなく、Graph を自動昇格させないための fail-closed な結果である。
+
+## 再現コマンド
+
+```bash
+pnpm build
+pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/pull-precheck.test.ts \
+  -t 'pre-check が例外を投げたらフル fetch にフォールバック'
+node packages/cli/dist/index.js pull
+node packages/cli/dist/index.js run show <run-id> --json
+node packages/cli/dist/index.js run reclaim --help
+node packages/cli/dist/index.js run heartbeat --help
+gh-gantt conflicts
+```
+
+Run Graph / claim の具体的な command file と opaque ID は一時 workspace にのみ置く。
+再実行時も [Graph Engineering 運用 reference](../../skills/gh-gantt-workflow/references/graph-engineering.md) の
+public-safe evidence 規律に従い、結果は bounded summaryへ変換する。

--- a/docs/benchmarks/graph-engineering-recovery-evidence.json
+++ b/docs/benchmarks/graph-engineering-recovery-evidence.json
@@ -2,119 +2,71 @@
   "schemaVersion": "1",
   "recordedAt": "2026-08-03T00:48:00.000Z",
   "baseRevision": "09ba15a046f721b98b728ea39a8b81d9053e6f70",
-  "configSummary": "run_graph=dev-role-fixed@1;dispatch.max_concurrency=2",
-  "configFingerprint": "sha256:e320a6075d970eee839bb6d95ce79736ec055a2e8114fcfae9b53c2192266c7b",
   "observations": [
     {
       "scenario": "runner_failure",
-      "faultInjection": "planner attemptをterminal failureにする",
-      "commands": [
-        "gh-gantt run event <run-id> --file <failed-event.json> --json",
-        "gh-gantt run show <run-id> --json",
-        "gh-gantt run decide <run-id> --decision override --json"
-      ],
-      "expectedPostconditions": [
-        "state=waiting_human",
-        "wait_reason=attempt_failed",
-        "failed_attempt_terminal=true",
-        "override_creates_new_planner_node=true"
-      ],
-      "observedPostconditions": [
-        "state=waiting_human",
-        "wait_reason=attempt_failed",
-        "failed_attempt_terminal=true",
-        "override_creates_new_planner_node=true"
-      ],
       "recoveryTimeMs": { "status": "known", "value": 726 },
       "status": "passed",
-      "digest": "sha256:34227ecd8dce8037a58454d85ee2550f0dbdc865c326b51c46cddb68b1b2c28a"
+      "evidence": [
+        {
+          "kind": "recovery",
+          "uri": "docs/benchmarks/graph-engineering-2026-08-03.md",
+          "sha256": "sha256:f0ec38c56273cfaa93fc10cda8d58199aa6f3a0e7d020d3a344e66617793eb85",
+          "byteLength": 5753
+        }
+      ]
     },
     {
       "scenario": "process_restart",
-      "faultInjection": "event適用ごとにCLI processを終了する",
-      "commands": [
-        "gh-gantt run event <run-id> --file <event.json> --json",
-        "gh-gantt run show <run-id> --json"
-      ],
-      "expectedPostconditions": [
-        "state_reobserved=true",
-        "wait_reason_reobserved=true",
-        "attempt_lineage_reobserved=true"
-      ],
-      "observedPostconditions": [
-        "state_reobserved=true",
-        "wait_reason_reobserved=true",
-        "attempt_lineage_reobserved=true"
-      ],
       "recoveryTimeMs": { "status": "known", "value": 197 },
       "status": "passed",
-      "digest": "sha256:83f04d6792faed0fbc057e3af19e0509429631a9773559ee87addd1ad9ff1ca4"
+      "evidence": [
+        {
+          "kind": "recovery",
+          "uri": "docs/benchmarks/graph-engineering-2026-08-03.md",
+          "sha256": "sha256:f0ec38c56273cfaa93fc10cda8d58199aa6f3a0e7d020d3a344e66617793eb85",
+          "byteLength": 5753
+        }
+      ]
     },
     {
       "scenario": "stale_lease",
-      "faultInjection": "5秒leaseを期限切れにする",
-      "commands": [
-        "gh-gantt run reclaim --claim <claim-id> --reason expired --json",
-        "gh-gantt run heartbeat --claim <claim-id> --fencing-token <token> --json"
-      ],
-      "expectedPostconditions": [
-        "reclaim_accepted=true",
-        "old_owner_heartbeat=stale_claim",
-        "rejected_state_unchanged=true"
-      ],
-      "observedPostconditions": [
-        "reclaim_accepted=true",
-        "old_owner_heartbeat=stale_claim",
-        "rejected_state_unchanged=true"
-      ],
       "recoveryTimeMs": { "status": "known", "value": 13060 },
       "status": "passed",
-      "digest": "sha256:66456e9979bb1c207e1eeded31e1a118bdc86d9ed487158aa824dcdd7b4097c9"
+      "evidence": [
+        {
+          "kind": "recovery",
+          "uri": "docs/benchmarks/graph-engineering-2026-08-03.md",
+          "sha256": "sha256:f0ec38c56273cfaa93fc10cda8d58199aa6f3a0e7d020d3a344e66617793eb85",
+          "byteLength": 5753
+        }
+      ]
     },
     {
       "scenario": "github_api_transient",
-      "faultInjection": "pre-check transport seamを1回failureにする",
-      "commands": [
-        "pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/pull-precheck.test.ts -t <fallback-case>",
-        "gh-gantt pull"
-      ],
-      "expectedPostconditions": [
-        "full_fetch_fallback=true",
-        "authenticated_pull_exit=0",
-        "remote_change_count=0"
-      ],
-      "observedPostconditions": [
-        "full_fetch_fallback=true",
-        "authenticated_pull_exit=0",
-        "remote_change_count=0"
-      ],
       "recoveryTimeMs": { "status": "known", "value": 3 },
       "status": "passed",
-      "digest": "sha256:667261283f1644f3f8ef1ab224c8d24a99f010af61ab448cd9be7bd1e18d2fc7"
+      "evidence": [
+        {
+          "kind": "recovery",
+          "uri": "docs/benchmarks/graph-engineering-2026-08-03.md",
+          "sha256": "sha256:f0ec38c56273cfaa93fc10cda8d58199aa6f3a0e7d020d3a344e66617793eb85",
+          "byteLength": 5753
+        }
+      ]
     },
     {
       "scenario": "sync_conflict",
-      "faultInjection": "Issue #331 statusをlocal/remoteで競合させる",
-      "commands": [
-        "gh-gantt pull",
-        "gh-gantt conflicts",
-        "gh-gantt resolve <conflict-id> --theirs",
-        "gh-gantt push --yes --force",
-        "gh-gantt conflicts"
-      ],
-      "expectedPostconditions": [
-        "remote_done_preserved=true",
-        "idempotent_push=true",
-        "remaining_conflicts=0"
-      ],
-      "observedPostconditions": [
-        "remote_done_preserved=true",
-        "idempotent_push=true",
-        "remaining_conflicts=0"
-      ],
       "recoveryTimeMs": { "status": "unknown", "reason": "not_collected" },
       "status": "passed",
-      "digest": "sha256:56d518dfd47e1b6755125f5c2cb4a041ab19a8f12f70f80c8ef726d60be9ca52"
+      "evidence": [
+        {
+          "kind": "recovery",
+          "uri": "docs/benchmarks/graph-engineering-2026-08-03.md",
+          "sha256": "sha256:f0ec38c56273cfaa93fc10cda8d58199aa6f3a0e7d020d3a344e66617793eb85",
+          "byteLength": 5753
+        }
+      ]
     }
   ]
 }

--- a/docs/benchmarks/graph-engineering-recovery-evidence.json
+++ b/docs/benchmarks/graph-engineering-recovery-evidence.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "1",
+  "recordedAt": "2026-08-03T00:48:00.000Z",
+  "baseRevision": "09ba15a046f721b98b728ea39a8b81d9053e6f70",
+  "configSummary": "run_graph=dev-role-fixed@1;dispatch.max_concurrency=2",
+  "configFingerprint": "sha256:e320a6075d970eee839bb6d95ce79736ec055a2e8114fcfae9b53c2192266c7b",
+  "observations": [
+    {
+      "scenario": "runner_failure",
+      "faultInjection": "planner attemptをterminal failureにする",
+      "commands": [
+        "gh-gantt run event <run-id> --file <failed-event.json> --json",
+        "gh-gantt run show <run-id> --json",
+        "gh-gantt run decide <run-id> --decision override --json"
+      ],
+      "expectedPostconditions": [
+        "state=waiting_human",
+        "wait_reason=attempt_failed",
+        "failed_attempt_terminal=true",
+        "override_creates_new_planner_node=true"
+      ],
+      "observedPostconditions": [
+        "state=waiting_human",
+        "wait_reason=attempt_failed",
+        "failed_attempt_terminal=true",
+        "override_creates_new_planner_node=true"
+      ],
+      "recoveryTimeMs": { "status": "known", "value": 726 },
+      "status": "passed",
+      "digest": "sha256:34227ecd8dce8037a58454d85ee2550f0dbdc865c326b51c46cddb68b1b2c28a"
+    },
+    {
+      "scenario": "process_restart",
+      "faultInjection": "event適用ごとにCLI processを終了する",
+      "commands": [
+        "gh-gantt run event <run-id> --file <event.json> --json",
+        "gh-gantt run show <run-id> --json"
+      ],
+      "expectedPostconditions": [
+        "state_reobserved=true",
+        "wait_reason_reobserved=true",
+        "attempt_lineage_reobserved=true"
+      ],
+      "observedPostconditions": [
+        "state_reobserved=true",
+        "wait_reason_reobserved=true",
+        "attempt_lineage_reobserved=true"
+      ],
+      "recoveryTimeMs": { "status": "known", "value": 197 },
+      "status": "passed",
+      "digest": "sha256:83f04d6792faed0fbc057e3af19e0509429631a9773559ee87addd1ad9ff1ca4"
+    },
+    {
+      "scenario": "stale_lease",
+      "faultInjection": "5秒leaseを期限切れにする",
+      "commands": [
+        "gh-gantt run reclaim --claim <claim-id> --reason expired --json",
+        "gh-gantt run heartbeat --claim <claim-id> --fencing-token <token> --json"
+      ],
+      "expectedPostconditions": [
+        "reclaim_accepted=true",
+        "old_owner_heartbeat=stale_claim",
+        "rejected_state_unchanged=true"
+      ],
+      "observedPostconditions": [
+        "reclaim_accepted=true",
+        "old_owner_heartbeat=stale_claim",
+        "rejected_state_unchanged=true"
+      ],
+      "recoveryTimeMs": { "status": "known", "value": 13060 },
+      "status": "passed",
+      "digest": "sha256:66456e9979bb1c207e1eeded31e1a118bdc86d9ed487158aa824dcdd7b4097c9"
+    },
+    {
+      "scenario": "github_api_transient",
+      "faultInjection": "pre-check transport seamを1回failureにする",
+      "commands": [
+        "pnpm --filter @gh-gantt/cli exec vp test run src/__tests__/pull-precheck.test.ts -t <fallback-case>",
+        "gh-gantt pull"
+      ],
+      "expectedPostconditions": [
+        "full_fetch_fallback=true",
+        "authenticated_pull_exit=0",
+        "remote_change_count=0"
+      ],
+      "observedPostconditions": [
+        "full_fetch_fallback=true",
+        "authenticated_pull_exit=0",
+        "remote_change_count=0"
+      ],
+      "recoveryTimeMs": { "status": "known", "value": 3 },
+      "status": "passed",
+      "digest": "sha256:667261283f1644f3f8ef1ab224c8d24a99f010af61ab448cd9be7bd1e18d2fc7"
+    },
+    {
+      "scenario": "sync_conflict",
+      "faultInjection": "Issue #331 statusをlocal/remoteで競合させる",
+      "commands": [
+        "gh-gantt pull",
+        "gh-gantt conflicts",
+        "gh-gantt resolve <conflict-id> --theirs",
+        "gh-gantt push --yes --force",
+        "gh-gantt conflicts"
+      ],
+      "expectedPostconditions": [
+        "remote_done_preserved=true",
+        "idempotent_push=true",
+        "remaining_conflicts=0"
+      ],
+      "observedPostconditions": [
+        "remote_done_preserved=true",
+        "idempotent_push=true",
+        "remaining_conflicts=0"
+      ],
+      "recoveryTimeMs": { "status": "unknown", "reason": "not_collected" },
+      "status": "passed",
+      "digest": "sha256:56d518dfd47e1b6755125f5c2cb4a041ab19a8f12f70f80c8ef726d60be9ca52"
+    }
+  ]
+}

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -185,3 +185,16 @@ URL は `view=project-map&task=...&run=...&node=...` を使い、run 変更時�
 - accepted event timestamp から導出できる duration は既知値とする。現行 runner contract が保持しない
   token / cost / latency は `0` へ丸めず `unknown` とする。
 - Run Graph が存在しない project では空状態を表示し、従来の5パネルと task 編集を維持する。
+
+## 12. Graph Engineering の運用
+
+Project Map の Planned vs Actual は bounded な観測 view であり、Graph Engineering の採用判定や
+benchmark report の正本ではない。Run Graph が見えること自体を single-loop に対する改善証拠としない。
+
+- 導入前: 同一受入基準の `single_loop` / `graph_orchestration` pairを
+  [Graph Engineering運用reference](../skills/gh-gantt-workflow/references/graph-engineering.md)に従って測る。
+- 運用中: wait reason、deviation、claim auditを確認し、raw runner logから状態を推測しない。
+- 停止: unknown side effect、sync conflict、human gate、retry budget超過を検出したら新規dispatchを止める。
+- 復旧: Work Graphをpullし、Run Graphのcheckpoint / claim lineageを再観測してからreclaim / resumeする。
+
+benchmarkが`single_loop`を返したtask shapeではProject MapにRun Graphが存在しても並列dispatchへ昇格しない。

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1692,3 +1692,59 @@ areas:
             status: covered
             tests:
               - packages/cli/src/__tests__/regressions/issue-299-worktree-cache-layout.test.ts
+      - id: NFR-STABILITY-016
+        summary: Graph Engineering の実測比較と安全な運用縮退
+        acceptance_criteria:
+          - id: NFR-STABILITY-016-AC1
+            description: |
+              benchmark metric は known(value) と unknown(reason) の排他的 union を使い、
+              verified success、wall-clock、token、cost、node/agent/tool call、retry、
+              human intervention、recovery time、coordination failureで既知の0と欠測を区別する
+            status: covered
+            tests:
+              - packages/smoke/src/__tests__/graph-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC2
+            description: |
+              同じ acceptance criteria、repository revision、verifier、environment を持つ
+              single-loop と graph orchestration の pairだけを比較し、固定Run Graph、ready frontier、
+              verify failure recovery、human gate、承認付きmutationの5 scenarioを識別する
+            status: covered
+            tests:
+              - packages/smoke/src/__tests__/graph-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC3
+            description: |
+              scenario、recovery、verified success、resource、coordination evidenceが不足または
+              不合格ならgraphを昇格せず、single-loop、concurrency 1、automatic retry 0、
+              remote side effectのhuman gate、bounded outputへfail-closedに縮退する
+            status: covered
+            tests:
+              - packages/smoke/src/__tests__/graph-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC4
+            description: |
+              workspace rootからstrict inputのbenchmark CLIを実行でき、sanitized reportを出力し、
+              明示されたqualification gateではgraph candidate以外を失敗させる
+            status: covered
+            tests:
+              - packages/smoke/src/__tests__/graph-benchmark.test.ts
+              - tests/workflow/graph-engineering-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC5
+            description: |
+              runner failure、process restart、stale lease、controlled GitHub API transient failure、
+              sync conflictを別々のpostconditionとpublic-safe evidenceで実環境検証する
+            status: covered
+            tests:
+              - tests/workflow/graph-engineering-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC6
+            description: |
+              README、workflow reference、Project Map、smoke runbookがGraph Engineeringの導入、
+              計測、停止、復旧、contract ceilingとの境界を同じ運用正本へ結ぶ
+            status: covered
+            tests:
+              - tests/workflow/graph-engineering-benchmark.test.ts
+          - id: NFR-STABILITY-016-AC7
+            description: |
+              外部一次資料の事実とgh-gantt固有の推論を分離し、Anthropicのresearch結果、
+              Symphonyのmemory-only state、GitHub API利用規律をcoding品質の外部標準として一般化しない
+            status: covered
+            tests:
+              - tests/workflow/graph-engineering-benchmark.test.ts

--- a/docs/research/graph-engineering-primary-sources.md
+++ b/docs/research/graph-engineering-primary-sources.md
@@ -1,0 +1,144 @@
+# Graph Engineering の task-fit と運用証拠に関する一次資料調査
+
+参照日: 2026-08-03
+
+## 調査範囲と用語
+
+この文書は、Graph Engineering の実環境ベンチマークと運用ガイドを設計するために、Anthropic の公式 engineering 記事、OpenAI Symphony の公式仕様、GitHub 公式 API ドキュメントを調査した結果をまとめる。
+
+ここでいう **Graph Engineering** は、計画・仕事・権限・実行履歴を別の graph として扱い、version、authority、evidence、budget、human gate で結ぶ、このリポジトリ固有の設計規律である。調査した外部一次資料はこの名称や 4 graph モデルを定義していない。したがって、外部で確立済みの一般標準とは表現しない。[A1][O1]
+
+以下では、一次資料に直接書かれている内容を「事実」、gh-gantt の設計・ベンチマークへ適用した判断を「推論」として分離する。
+
+## 一次資料から確認できる事実
+
+### 1. 複雑化には task-fit と費用対効果が必要
+
+- **事実**: Anthropic は、まず可能な限り単純な解決策を選び、必要な場合だけ複雑性を増やすことを推奨している。agentic system は一般に、より良い task performance と引き換えに latency と cost を増やす。[A1]
+- **事実**: Anthropic は parallelization の適用条件を、独立して分割できる subtask を速度向上のため並列実行できる場合、または複数の独立観点・試行により信頼度を上げたい場合としている。[A1]
+- **事実**: Anthropic の orchestrator-workers pattern は、必要な subtask を事前に予測できない複雑な仕事に適する。一方、固定された小さな subtask へ容易に分割できる場合には、より単純な prompt chaining が候補になる。[A1]
+- **事実**: Anthropic の multi-agent research system は breadth-first で互いに独立した調査方向に強く、同社の内部 research eval では特定構成が single-agent 構成を 90.2% 上回った。ただしこれは研究 task と特定モデル構成に関する社内評価である。[A2]
+- **事実**: 同じ記事は、multi-agent system が chat interaction の約 15 倍の token を使ったという同社データを示し、価値が追加費用を正当化する task が必要だとしている。また、共有 context や agent 間依存が多い領域は不向きで、多くの coding task は research より並列化可能部分が少ないと述べている。[A2]
+
+**推論**:
+
+- 90.2% と 15 倍を gh-gantt の期待値や合格閾値へ転用してはならない。前者は research 内部評価、後者は chat interaction 比であり、「同一 coding task の single-loop 対 Graph Engineering」という比較ではない。
+- Graph Engineering の採用判断は graph の存在自体ではなく、独立 frontier、権限分離、独立 verification、長時間実行の checkpoint/recovery のどれが必要かで行う。
+- 一直線で短く、共有 context が大きく、独立検証も外部副作用もない task は single-loop を標準候補にする。graph 化の固定費を正当化する一次資料上の根拠がないためである。
+
+### 2. coordination は性能要因であると同時に failure surface でもある
+
+- **事実**: Anthropic は multi-agent system で coordination complexity が急増し、単純な問い合わせへの過剰な subagent 生成、重複作業、調査漏れ、過剰な相互更新を実際の failure mode として報告している。[A2]
+- **事実**: 同社は delegation に objective、output format、使用する tool/source、task boundary を明示し、task complexity に応じて agent 数と tool call 数を調整する規則を設けている。[A2]
+- **事実**: 同期的な subagent 実行は coordination を単純化する一方、一つの遅い subagent が全体を止める。非同期化は並列性を増やすが、結果の coordination、state consistency、error propagation を難しくする。[A2]
+- **事実**: Anthropic は automated evaluation だけでは見落とす edge case があるため manual testing を必須としており、agent interaction の非決定性に対して tracing と interaction structure の観測が重要だとしている。[A2]
+
+**推論**:
+
+- ベンチマークでは最終成功だけでなく、重複 node、待ち合わせ時間、stale owner、再試行、human intervention を coordination cost として独立に記録する。
+- 並列 arm は「同時に開始した agent 数」ではなく、依存関係を満たした ready frontier と claim の証拠で定義する。偶然重なった process だけでは graph orchestration の証拠にならない。
+- output と evidence は typed かつ bounded にし、欠落を空値や成功として扱わない。これは Anthropic の明確な delegation boundary と、このリポジトリの bounded projection を組み合わせた設計判断である。
+
+### 3. issue tracker は scheduling/reconciliation の control-plane input になり得る
+
+- **事実**: OpenAI Symphony 仕様は、issue tracker を継続的に読み、issue ごとの隔離 workspace で coding agent を実行する長時間 service を定義する。repository-owned `WORKFLOW.md`、bounded concurrency、単一 authoritative orchestrator state、retry、reconciliation、operator-visible observability を目標に含む。[O1]
+- **事実**: 同仕様は policy、configuration、coordination、execution、integration、observability を別 layer として扱う。orchestrator は poll、dispatch、retry、stop/release を所有し、workspace manager と agent runner が実行環境を担う。[O1]
+- **事実**: Symphony は dispatch 前に reconciliation を行い、worker 起動前に `claimed` と `running` の重複を確認する。異常終了は exponential backoff retry へ、stall は worker 停止と retry へ送る。[O1]
+- **事実**: Symphony における tracker ticket の書き込みは scheduler 自身の組み込み業務ロジックではなく、通常は agent が利用可能な provider-native tool を通じて行う。成功した run は `Done` ではなく `Human Review` のような workflow-defined handoff で終えてよい。[O1]
+- **事実**: Symphony の scheduler state は意図的に memory-only である。process restart 後は retry timer や running session を復元せず、tracker の再 poll と保存済み workspace から eligible work を再 dispatch する。[O1]
+
+**推論**:
+
+- Work Graph の tracker state と、Run Graph の attempt/checkpoint/claim state を同一視しない。tracker は「何を実行可能か」の外部正本になり得るが、「どの副作用まで完了したか」を単独では証明しない。
+- gh-gantt の durable Run Graph は Symphony の必須要件ではなく、restart 後に retry/attempt lineage と side-effect ambiguity を保持するための、より強いリポジトリ固有保証である。
+- issue state が変わったときに実行を停止できること、停止後に同じ task を二重 dispatch しないこと、human handoff を完了と誤認しないことを運用 smoke の独立 assertion にする。
+
+### 4. recovery は「再起動した」ではなく、失敗分類と再調停の証拠が必要
+
+- **事実**: Anthropic は長時間 agent では error が累積し、先頭からの restart は高価であるため、checkpoint と deterministic retry safeguard を組み合わせて途中から再開できる仕組みを構築したと説明している。[A2]
+- **事実**: Symphony は workflow/config、workspace、agent session、tracker、observability を failure class として分ける。dispatch validation failure は新規 dispatch だけを止め、tracker fetch failure は次 tick へ、worker failure は bounded backoff retry へ送る。[O1]
+- **事実**: Symphony の runtime snapshot は running/retrying、turn count、token total、runtime、rate-limit 情報を含めることを推奨している。また logs には outcome と簡潔な failure reason を含め、大きな raw payload は避けるとしている。[O1]
+- **事実**: GitHub は API の concurrent request を避け、mutative request の間隔を空け、rate-limit 時は `retry-after` または reset 時刻を尊重し、継続失敗時は exponential backoff と有限回での停止を行うよう公式に案内している。[G1][G2]
+
+**推論**:
+
+- 一時的 GitHub API failure の smoke で、意図的に大量 request を送り実 rate-limit や障害を発生させてはならない。専用 smoke 環境で transport boundary に fail-once/timeout を注入し、その前後に実 GitHub 読み取りまたは限定 mutation の postcondition を照合する。これは real integration を保ちつつ GitHub の利用規律を破らない方法である。
+- recovery success は、再 process が立ち上がったことではなく、次をすべて満たした場合に限る。
+  1. fault 前の accepted checkpoint と authority/claim lineage を再観測できる。
+  2. stale owner の event または mutation publish が拒否される。
+  3. `committed`、`not_started`、`reconciled`、`unknown` を混同せず、unknown side effect を自動再送しない。
+  4. 同じ acceptance criteria の verifier が回復後に合格するか、fail-closed な human handoff に到達する。
+- raw conversation、raw provider response、secret、絶対 path を公開 evidence に含めず、schema-valid summary、hash、件数、duration、outcome、sanitized failure class だけを残す。欠落した値は `0` ではなく理由付き `unknown` にする。
+
+## gh-gantt ベンチマークへの適用案（推論）
+
+以下は一次資料の直接要件ではなく、Issue #332 の比較を再現可能にするための実験設計案である。
+
+### 比較単位
+
+- 同一 acceptance criteria、同一 repository revision、同一 verifier、同等の model/tool permission、同一外部環境を paired trial にする。
+- control arm は単一 agent/context/workspace の single-loop とする。Graph arm は Graph Contract、ready frontier、authority、Run Graph evidence、human gate を使う。
+- 順序効果を減らすため arm の実行順を交互にし、各 scenario を複数回行う。最小反復数や信頼区間は実装時に明示し、単発の成功を一般化しない。
+- provider prompt/session/run の識別子や raw prompt は公開しない。公開 evidence では trial ordinal、repository revision、sanitized environment profile、prompt/verifier の content hash を使う。
+
+### 再現対象 scenario
+
+| scenario                       | single-loop control                  | Graph Engineering arm                                        | 主な判定                                              |
+| ------------------------------ | ------------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------- |
+| 固定直列 workflow              | 一つの loop で plan→implement→verify | fixed Run Graph の role node を順に遷移                      | graph 固定費、独立 verify の差                        |
+| 独立 ready frontier            | 独立 task を順次処理                 | bounded claim で並列処理し fan-in                            | verified success、wall-clock、coordination failure    |
+| verify failure recovery        | 同じ loop が修正・再検証             | terminal attempt を保持し、budget 内で新 attempt/node へ遷移 | retry 数、再現性、recovery time                       |
+| human gate と承認済み mutation | human 判断まで停止し手動変更         | proposal→独立承認→apply/reconcile→replan acceptance          | principal separation、unknown side effect、audit 完備 |
+| 運用 recovery                  | process ごと再開                     | checkpoint/claim/fencing/reconciliation から継続             | 二重実行なし、stale event 拒否、AC 再合格             |
+
+recovery scenario は少なくとも runner/agent 停止、orchestrator process restart、stale lease、制御された GitHub transport failure、同期 conflict を別々に測る。一つの障害で他の回復経路も検証済みとは扱わない。
+
+### metric の最小契約
+
+各 metric は `known(value)` または `unknown(reason)` の排他的な形にし、未取得を数値 `0` に正規化しない。
+
+| metric               | 記録する意味                                                                 |
+| -------------------- | ---------------------------------------------------------------------------- |
+| verified success     | acceptance verifier の pass/fail/inconclusive。agent の自己申告とは分ける    |
+| wall-clock           | trial 開始から verified terminal/handoff まで。human 待機時間も別列で保持    |
+| token                | input/output/total。cumulative と delta の意味を混在させない                 |
+| cost                 | 同じ時点の価格表で算出できる場合だけ記録。算出不能は unknown                 |
+| node/agent/tool call | graph node attempt、agent invocation、tool call を別々に数える               |
+| retry                | continuation、retryable failure、review improvement を区別する               |
+| human intervention   | 回数、待機時間、decision 種別、principal separation の成否                   |
+| recovery time        | fault 注入から verifier 合格または fail-closed handoff まで                  |
+| coordination failure | duplicate work、claim conflict、stale result、join wait、evidence 欠落を分類 |
+
+Anthropic の結果が token/tool call と performance の関連を示していても、token を品質の代替指標にはしない。最上位判定は verified success と safety invariant であり、その後に wall-clock と resource cost を比較する。
+
+### 採用・縮退・停止の判断
+
+- **採用候補**: Graph arm が safety invariant を維持し、同じ verifier に対する成功率、独立検証、または recovery のいずれかを改善し、その価値が追加 latency/token/tool call/human burden を上回る。
+- **single-loop へ縮退**: 独立 frontier がなく、Graph arm の verified outcome が同等以下で、追加 overhead だけが測定された場合。
+- **並列度を下げる**: rate-limit、claim contention、join wait、重複作業、context 再構成が増え、wall-clock または成功率を悪化させた場合。
+- **自動 retry を止める**: side effect が unknown、authority が不明、budget 上限到達、同じ failure class が反復、または GitHub の retry 指示を満たせない場合。
+- **human gate へ送る**: destructive mutation、principal separation 未証明、contract/version 不一致、stale lease の競合、reconciliation 不能の場合。
+
+一次資料から安全な concurrency、retry 回数、output budget の固定値は導けない。Symphony の既定値や Anthropic の research 向け agent/tool-call 目安をそのまま採用せず、候補値ごとの paired trial から成功率優先で選ぶ。測定前の fallback は concurrency 1、暗黙 retry なし、危険な mutation は human-only とするのが保守的だが、これは外部標準ではなく運用上の初期仮説である。
+
+## 既存 ADR との整合性確認
+
+| 既存判断                                                                             | 一次資料との関係                                                                                                                                    | 結論                                                             |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| ADR-008: unit/fixture だけでなく実環境 smoke を使う                                  | Anthropic は manual test と production tracing、Symphony は Real Integration Profile を重視する。一方、fixture を採用しない判断自体は gh-gantt 固有 | 矛盾なし。controlled fault と実 postcondition を組み合わせる     |
+| ADR-020: task/PR/evidence を bounded projection する                                 | Anthropic の effort scaling と明確な output boundary、Symphony の bounded status/簡潔な log に整合                                                  | 矛盾なし。raw evidence の無制限公開は避ける                      |
+| ADR-021: Plan/Org/Work/Run Graph を分離し、Graph Engineering を固有用語とする        | Symphony の layer 分離は参考になるが 4 graph は定義しない                                                                                           | 矛盾なし。外部標準という表現は禁止                               |
+| ADR-022: accepted event journal から durable Run Graph を復元する                    | Symphony の restart は tracker/filesystem driven で exact scheduler state を復元しない                                                              | 矛盾ではなく保証強化。Symphony 準拠の必須要件とは主張しない      |
+| ADR-023: Work Graph Cache と Run Graph/coordination store を分け、lease を閉じ込める | Symphony の workspace isolation と single orchestrator authority に方向性は近いが、storage layout/lease は gh-gantt 固有                            | 矛盾なし。実 smoke で crash/lock recovery を検証する             |
+| ADR-024: ready frontier、bounded concurrency、claim、heartbeat、reclaim、fencing     | Symphony の bounded dispatch、claimed/running check、reconciliation と整合。durable claim/fencing はより強い固有保証                                | 矛盾なし。外部仕様の要請とは書かない                             |
+| ADR-025: Work Graph mutation を human approval と reconciliation で gate する        | Symphony は単一の approval policy を規定せず、ticket write を agent tool 側へ委ねる                                                                 | 矛盾なし。gh-gantt 独自の authority/safety policy として維持する |
+
+注意すべき差分は、Symphony の memory-only scheduler state を gh-gantt の recovery proof と取り違えないこと、Symphony の concurrency default を gh-gantt の安全値として流用しないこと、Anthropic の research benchmark を coding task の効果量として一般化しないことである。
+
+## 一次資料
+
+- [A1] Anthropic, [Building effective agents](https://www.anthropic.com/engineering/building-effective-agents), 参照日 2026-08-03。
+- [A2] Anthropic, [How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system), 公開日 2025-06-13、参照日 2026-08-03。
+- [O1] OpenAI, [Symphony Service Specification（commit `f8e8b8a` 固定）](https://github.com/openai/symphony/blob/f8e8b8a670c799f6e0ade7a8c25c4bf4a4a56ec7/SPEC.md), Draft v1、参照日 2026-08-03。
+- [G1] GitHub Docs, [Best practices for using the REST API](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api), 参照日 2026-08-03。
+- [G2] GitHub Docs, [Rate limits and query limits for the GraphQL API](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api), 参照日 2026-08-03。

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "pnpm -r typecheck",
     "smoke:personal": "pnpm --filter @gh-gantt/smoke smoke:personal",
     "smoke:org": "pnpm --filter @gh-gantt/smoke smoke:org",
+    "benchmark:graph": "pnpm --filter @gh-gantt/smoke benchmark:graph",
     "docs:gen": "tsx scripts/docs-gen.ts",
     "req:trace": "tsx scripts/req-trace.ts",
     "req:validate": "tsx scripts/req-validate.ts"

--- a/packages/smoke/README.md
+++ b/packages/smoke/README.md
@@ -142,7 +142,10 @@ pnpm benchmark:graph -- --input benchmark-record.json --require-qualified
 
 入力JSONは公開artifactではない。strict schemaは未定義のraw fieldと危険なevidence URIを拒否するが、
 suite / task shape / pair IDは非公開入力として扱う。reportはこれらを再出力せずpair ordinalだけを返す。
-公開evidenceはrepository相対pathまたはHTTPS URL、SHA-256、byte length、種別だけを記録する。
+benchmark入力と公開 recovery pack の `evidence` envelope は、`kind`、repository相対pathまたは
+HTTPS `uri`、`sha256`、`byteLength` だけを記録する。recovery observation の外側には
+`scenario`、`status`、`recoveryTimeMs` だけを許可し、command、fault injection、postcondition本文は
+非公開の実行記録へ分離する。
 いずれかのmetricを取得できない場合は0ではなく`unknown(reason)`を使い、Graph候補へ昇格しない。
 
 benchmarkはagent、provider SDK、任意shell command、GitHub mutationを実行しない。実環境faultは専用smoke環境で

--- a/packages/smoke/README.md
+++ b/packages/smoke/README.md
@@ -119,8 +119,40 @@ Actions タブから手動で起動する。
 3. `.github/workflows/smoke.yml` の `on:` に `pull_request` / `push` / `schedule` を追加
 4. `smoke-personal` / `smoke-org` の `if:` 条件を自動トリガー対応に戻す
 
+## Graph Engineering benchmark
+
+Graph Engineering は既定ではない。同一受入基準の`single_loop`と`graph_orchestration`を比較し、
+5 scenario / 5 recovery smoke、verified success、resource metricが揃ったtask shapeだけを候補にする。
+詳細な導入・停止・復旧手順は
+[graph-engineering.md](../../skills/gh-gantt-workflow/references/graph-engineering.md)を参照する。
+
+```bash
+# reportを標準出力へ表示
+pnpm benchmark:graph -- --input benchmark-record.json
+
+# sanitized reportを保存
+pnpm benchmark:graph -- --input benchmark-record.json --output benchmark-report.json
+
+# graph_candidate以外をexit 1にする明示gate
+pnpm benchmark:graph -- --input benchmark-record.json --require-qualified
+```
+
+通常の分析は`single_loop`でも成功する。`--require-qualified`は、全gateを満たす
+`graph_candidate`をCIや外部runnerが明示的に要求するときだけ使う。
+
+入力JSONは公開artifactではない。strict schemaは未定義のraw fieldと危険なevidence URIを拒否するが、
+suite / task shape / pair IDは非公開入力として扱う。reportはこれらを再出力せずpair ordinalだけを返す。
+公開evidenceはrepository相対pathまたはHTTPS URL、SHA-256、byte length、種別だけを記録する。
+いずれかのmetricを取得できない場合は0ではなく`unknown(reason)`を使い、Graph候補へ昇格しない。
+
+benchmarkはagent、provider SDK、任意shell command、GitHub mutationを実行しない。実環境faultは専用smoke環境で
+安全に注入し、外部runnerがbounded observationを作る。自動GitHub Actions triggerはPAT security reviewが
+完了するまで従来どおり無効である。
+
 ## 関連
 
 - [ADR-008: 実環境スモークテストによる Org/個人環境差異の検証](../../docs/adr/ADR-008-real-environment-smoke-testing.md)
 - NFR-STABILITY-003: Org 環境と個人環境の両方で主要 CLI コマンドが動作する
 - NFR-STABILITY-004: スモークテストの継続実行による回帰検知
+- [ADR-026: Graph Engineering の採用を実測と recovery evidence で gate する](../../docs/adr/ADR-026-measured-graph-engineering-adoption.md)
+- [Issue #332 pre-adoption benchmark](../../docs/benchmarks/graph-engineering-2026-08-03.md)

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -8,11 +8,13 @@
     "typecheck": "tsc --noEmit",
     "smoke:personal": "tsx src/run.ts --env personal",
     "smoke:org": "tsx src/run.ts --env org",
+    "benchmark:graph": "tsx src/graph-benchmark-run.ts",
     "test": "vp test run",
     "test:json": "vp test run --reporter=default --reporter=json --outputFile=../../test-results-smoke.json"
   },
   "dependencies": {
-    "@gh-gantt/cli": "workspace:*"
+    "@gh-gantt/cli": "workspace:*",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/smoke/src/__tests__/graph-benchmark.test.ts
+++ b/packages/smoke/src/__tests__/graph-benchmark.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeGraphBenchmark,
+  GRAPH_BENCHMARK_SCENARIOS,
+  GraphBenchmarkSuiteSchema,
+  RECOVERY_SMOKE_SCENARIOS,
+} from "../graph-benchmark.js";
+import { runGraphBenchmarkCli } from "../graph-benchmark-run.js";
+
+const HASH_A = `sha256:${"a".repeat(64)}`;
+const HASH_B = `sha256:${"b".repeat(64)}`;
+const HASH_C = `sha256:${"c".repeat(64)}`;
+const REVISION = "d".repeat(40);
+
+const known = <T>(value: T) => ({ status: "known" as const, value });
+const unknown = (reason = "provider_not_exposed") => ({
+  status: "unknown" as const,
+  reason,
+});
+
+function metrics(
+  strategy: "single_loop" | "graph_orchestration",
+  options: { resourceKnown?: boolean; success?: "passed" | "failed" } = {},
+) {
+  const graph = strategy === "graph_orchestration";
+  const resourceKnown = options.resourceKnown ?? true;
+  return {
+    verifiedSuccess: known(options.success ?? "passed"),
+    wallClockMs: known(graph ? 600 : 1_000),
+    inputTokens: resourceKnown ? known(graph ? 1_200 : 1_000) : unknown(),
+    outputTokens: resourceKnown ? known(graph ? 300 : 250) : unknown(),
+    costUsd: resourceKnown ? known(graph ? 1.5 : 1) : unknown(),
+    runNodeCount: known(graph ? 5 : 1),
+    agentInvocationCount: known(graph ? 3 : 1),
+    toolCallCount: known(graph ? 8 : 5),
+    retryCount: known(0),
+    humanInterventionCount: known(graph ? 1 : 0),
+    humanWaitMs: known(0),
+    recoveryTimeMs: known(0),
+    coordinationFailureCount: known(0),
+  };
+}
+
+function trial(
+  scenario: (typeof GRAPH_BENCHMARK_SCENARIOS)[number],
+  pairIndex: number,
+  strategy: "single_loop" | "graph_orchestration",
+  sequence: 1 | 2,
+  options: { resourceKnown?: boolean; success?: "passed" | "failed" } = {},
+) {
+  return {
+    id: `trial-${pairIndex}-${strategy}`,
+    pairId: `pair-${pairIndex}`,
+    sequence,
+    strategy,
+    scenario,
+    acceptanceCriteriaHash: HASH_A,
+    repositoryRevision: REVISION,
+    verifierHash: HASH_B,
+    environmentHash: HASH_C,
+    startedAt: "2026-08-03T00:00:00.000Z",
+    finishedAt: graphFinish(strategy),
+    metrics: metrics(strategy, options),
+    evidence: [
+      {
+        kind: "verifier" as const,
+        uri: `evidence/${scenario}-${strategy}.json`,
+        sha256: HASH_B,
+        byteLength: 128,
+      },
+    ],
+  };
+}
+
+function graphFinish(strategy: "single_loop" | "graph_orchestration") {
+  return strategy === "graph_orchestration"
+    ? "2026-08-03T00:00:00.600Z"
+    : "2026-08-03T00:00:01.000Z";
+}
+
+function completeSuite(options: { resourceKnown?: boolean } = {}) {
+  const trials = GRAPH_BENCHMARK_SCENARIOS.flatMap((scenario, index) => {
+    const graphFirst = index % 2 === 1;
+    return graphFirst
+      ? [
+          trial(scenario, index + 1, "graph_orchestration", 1, options),
+          trial(scenario, index + 1, "single_loop", 2, options),
+        ]
+      : [
+          trial(scenario, index + 1, "single_loop", 1, options),
+          trial(scenario, index + 1, "graph_orchestration", 2, options),
+        ];
+  });
+
+  return {
+    schemaVersion: "1" as const,
+    suiteId: "issue-332-pilot",
+    recordedAt: "2026-08-03T00:10:00.000Z",
+    taskShape: "独立 frontier と外部副作用 gate を持つ bounded coding task",
+    trials,
+    recoverySmoke: RECOVERY_SMOKE_SCENARIOS.map((scenario) => ({
+      scenario,
+      status: "passed" as const,
+      recoveryTimeMs: known(250),
+      evidence: [
+        {
+          kind: "recovery" as const,
+          uri: `https://github.com/stanah/gh-gantt/issues/332#${scenario}`,
+          sha256: HASH_C,
+          byteLength: 96,
+        },
+      ],
+    })),
+  };
+}
+
+describe("[NFR-STABILITY-016-AC1] Graph Engineering benchmark の strict metric 契約", () => {
+  it("既知の0と理由付きunknownを別の値として保持する", () => {
+    const input = completeSuite({ resourceKnown: false });
+    const parsed = GraphBenchmarkSuiteSchema.parse(input);
+    const graph = parsed.trials.find((entry) => entry.strategy === "graph_orchestration")!;
+
+    expect(graph.metrics.retryCount).toEqual({ status: "known", value: 0 });
+    expect(graph.metrics.inputTokens).toEqual({
+      status: "unknown",
+      reason: "provider_not_exposed",
+    });
+  });
+
+  it("unknownへ0を混入する入力と未定義のraw fieldを拒否する", () => {
+    const input = completeSuite();
+    const first = input.trials[0]!;
+    const invalid = {
+      ...input,
+      trials: [
+        {
+          ...first,
+          rawPrompt: "公開してはいけない本文",
+          metrics: {
+            ...first.metrics,
+            inputTokens: { status: "unknown", reason: "not_collected", value: 0 },
+          },
+        },
+        ...input.trials.slice(1),
+      ],
+    };
+
+    expect(GraphBenchmarkSuiteSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it("絶対path、credential付きURL、query付きURLをpublic evidenceとして拒否する", () => {
+    const input = completeSuite();
+    const first = input.trials[0]!;
+    for (const uri of [
+      "/private/tmp/raw.json",
+      "file:///tmp/raw.json",
+      "../secret.json",
+      "\\\\server\\share\\raw.json",
+      "https://token@example.com/evidence.json",
+      "https://example.com/evidence.json?signature=secret",
+      "https://localhost/evidence.json",
+    ]) {
+      const result = GraphBenchmarkSuiteSchema.safeParse({
+        ...input,
+        trials: [
+          {
+            ...first,
+            evidence: [{ ...first.evidence[0]!, uri }],
+          },
+          ...input.trials.slice(1),
+        ],
+      });
+      expect(result.success, uri).toBe(false);
+    }
+  });
+
+  it("reportから入力由来のsuite、task shape、pair識別子を除外する", () => {
+    const input = completeSuite();
+    input.suiteId = "run-internal-session";
+    input.taskShape = "/Users/example/raw-prompt.txt";
+    input.trials = input.trials.map((entry) => ({
+      ...entry,
+      pairId: entry.pairId.replace("pair-", "claim-internal-"),
+    }));
+
+    const report = analyzeGraphBenchmark(input);
+    const serialized = JSON.stringify(report);
+
+    expect(serialized).not.toContain("run-internal-session");
+    expect(serialized).not.toContain("/Users/example/raw-prompt.txt");
+    expect(serialized).not.toContain("claim-internal");
+    expect(report.comparisons.map((entry) => entry.pairOrdinal)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("[NFR-STABILITY-016-AC2] 同一条件の paired trial 比較", () => {
+  it("pair内のrevision、AC、verifier、environment不一致を拒否する", () => {
+    const input = completeSuite();
+    const targetIndex = input.trials.findIndex(
+      (entry) => entry.pairId === "pair-1" && entry.sequence === 2,
+    );
+    const target = input.trials[targetIndex]!;
+    const trials = [...input.trials];
+    trials[targetIndex] = { ...target, repositoryRevision: "e".repeat(40) };
+
+    expect(GraphBenchmarkSuiteSchema.safeParse({ ...input, trials }).success).toBe(false);
+  });
+
+  it("5 scenario、5 recovery、交互順序を満たすsuiteを比較する", () => {
+    const report = analyzeGraphBenchmark(completeSuite());
+
+    expect(report.coverage.missingScenarios).toEqual([]);
+    expect(report.coverage.missingRecoveryScenarios).toEqual([]);
+    expect(report.coverage.completePairCount).toBe(5);
+    expect(report.coverage.firstStrategyCounts).toEqual({ singleLoop: 3, graphOrchestration: 2 });
+    expect(report.comparisons).toHaveLength(5);
+  });
+});
+
+describe("[NFR-STABILITY-016-AC3] 実測不足時のfail-closed policy", () => {
+  it("token/costがunknownならgraphを昇格せず保守的な初期値を返す", () => {
+    const report = analyzeGraphBenchmark(completeSuite({ resourceKnown: false }));
+
+    expect(report.qualification.mode).toBe("single_loop");
+    expect(report.qualification.reasons).toContain("resource_metrics_unknown");
+    expect(report.initialPolicy).toEqual({
+      defaultStrategy: "single_loop",
+      dispatchConcurrency: 1,
+      automaticRetryBudget: 0,
+      humanGate: "required_for_remote_side_effects",
+      outputReferenceLimit: 20,
+      inlineEvidenceByteLimit: 0,
+    });
+  });
+
+  it("recoveryが1件でも失敗すればgraphを昇格しない", () => {
+    const input = completeSuite();
+    input.recoverySmoke[0] = { ...input.recoverySmoke[0]!, status: "failed" };
+    const report = analyzeGraphBenchmark(input);
+
+    expect(report.qualification.mode).toBe("single_loop");
+    expect(report.qualification.reasons).toContain("recovery_failed");
+  });
+
+  it("operational metricが1項目でもunknownならgraphを昇格しない", () => {
+    const metricKeys = [
+      "wallClockMs",
+      "runNodeCount",
+      "agentInvocationCount",
+      "toolCallCount",
+      "retryCount",
+      "humanInterventionCount",
+      "humanWaitMs",
+      "recoveryTimeMs",
+    ] as const;
+
+    for (const key of metricKeys) {
+      const input = completeSuite();
+      const target = input.trials[0]!;
+      input.trials[0] = {
+        ...target,
+        metrics: { ...target.metrics, [key]: unknown() },
+      };
+
+      const report = analyzeGraphBenchmark(input);
+      expect(report.qualification.mode, key).toBe("single_loop");
+      expect(report.qualification.reasons, key).toContain("operational_metrics_unknown");
+    }
+  });
+
+  it("successまたはcoordinationがunknownならgraphを昇格しない", () => {
+    const successInput = completeSuite();
+    const successTarget = successInput.trials[0]!;
+    successInput.trials[0] = {
+      ...successTarget,
+      metrics: { ...successTarget.metrics, verifiedSuccess: unknown() },
+    };
+    expect(analyzeGraphBenchmark(successInput).qualification.reasons).toContain(
+      "verified_success_unknown",
+    );
+
+    const coordinationInput = completeSuite();
+    const coordinationTarget = coordinationInput.trials[0]!;
+    coordinationInput.trials[0] = {
+      ...coordinationTarget,
+      metrics: { ...coordinationTarget.metrics, coordinationFailureCount: unknown() },
+    };
+    expect(analyzeGraphBenchmark(coordinationInput).qualification.reasons).toContain(
+      "coordination_metrics_unknown",
+    );
+  });
+
+  it("全gateを満たすtask shapeだけgraph候補とし並列度2・自動retry1を上限にする", () => {
+    const report = analyzeGraphBenchmark(completeSuite());
+
+    expect(report.qualification).toEqual({ mode: "graph_candidate", reasons: [] });
+    expect(report.initialPolicy).toEqual({
+      defaultStrategy: "graph_orchestration",
+      dispatchConcurrency: 2,
+      automaticRetryBudget: 1,
+      humanGate: "required_for_remote_side_effects",
+      outputReferenceLimit: 20,
+      inlineEvidenceByteLimit: 0,
+    });
+  });
+});
+
+describe("[NFR-STABILITY-016-AC4] Graph Engineering benchmark CLI", () => {
+  it("output未指定時のstdoutを単一JSON documentにする", async () => {
+    const stdout: string[] = [];
+    const code = await runGraphBenchmarkCli(["--input", "records/issue-332.json"], {
+      readText: async () => JSON.stringify(completeSuite({ resourceKnown: false })),
+      writeText: async () => undefined,
+      stdout: (value) => stdout.push(value),
+      stderr: () => undefined,
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveLength(1);
+    expect(JSON.parse(stdout[0]!).qualification.mode).toBe("single_loop");
+  });
+
+  it("strict inputからraw evidenceを含まないreportを書き出す", async () => {
+    let output = "";
+    const stdout: string[] = [];
+    const code = await runGraphBenchmarkCli(
+      ["--input", "records/issue-332.json", "--output", "reports/issue-332.json"],
+      {
+        readText: async () => JSON.stringify(completeSuite({ resourceKnown: false })),
+        writeText: async (_path, value) => {
+          output = value;
+        },
+        stdout: (value) => stdout.push(value),
+        stderr: () => undefined,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(JSON.parse(output).qualification.mode).toBe("single_loop");
+    expect(output).not.toContain("rawPrompt");
+    expect(stdout.join("\n")).toContain("single_loop");
+  });
+
+  it("--require-qualifiedではunknownを含むsuiteを失敗させる", async () => {
+    const stderr: string[] = [];
+    const code = await runGraphBenchmarkCli(
+      ["--input", "records/issue-332.json", "--require-qualified"],
+      {
+        readText: async () => JSON.stringify(completeSuite({ resourceKnown: false })),
+        writeText: async () => undefined,
+        stdout: () => undefined,
+        stderr: (value) => stderr.push(value),
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr.join("\n")).toContain("resource_metrics_unknown");
+  });
+});

--- a/packages/smoke/src/__tests__/graph-benchmark.test.ts
+++ b/packages/smoke/src/__tests__/graph-benchmark.test.ts
@@ -106,7 +106,7 @@ function completeSuite(options: { resourceKnown?: boolean } = {}) {
       evidence: [
         {
           kind: "recovery" as const,
-          uri: `https://github.com/stanah/gh-gantt/issues/332#${scenario}`,
+          uri: "docs/benchmarks/graph-engineering-recovery-evidence.json",
           sha256: HASH_C,
           byteLength: 96,
         },
@@ -149,7 +149,7 @@ describe("[NFR-STABILITY-016-AC1] Graph Engineering benchmark の strict metric 
     expect(GraphBenchmarkSuiteSchema.safeParse(invalid).success).toBe(false);
   });
 
-  it("絶対path、credential付きURL、query付きURLをpublic evidenceとして拒否する", () => {
+  it("絶対path、credential、query、fragmentをpublic evidenceとして拒否する", () => {
     const input = completeSuite();
     const first = input.trials[0]!;
     for (const uri of [
@@ -159,6 +159,9 @@ describe("[NFR-STABILITY-016-AC1] Graph Engineering benchmark の strict metric 
       "\\\\server\\share\\raw.json",
       "https://token@example.com/evidence.json",
       "https://example.com/evidence.json?signature=secret",
+      "https://example.com/evidence.json#internal-id",
+      "evidence/result.json?signature=secret",
+      "evidence/result.json#internal-id",
       "https://localhost/evidence.json",
     ]) {
       const result = GraphBenchmarkSuiteSchema.safeParse({
@@ -215,6 +218,53 @@ describe("[NFR-STABILITY-016-AC2] 同一条件の paired trial 比較", () => {
     expect(report.coverage.completePairCount).toBe(5);
     expect(report.coverage.firstStrategyCounts).toEqual({ singleLoop: 3, graphOrchestration: 2 });
     expect(report.comparisons).toHaveLength(5);
+  });
+
+  it("先行strategyの件数が均衡していてもsuite順が非交互なら昇格しない", () => {
+    const input = completeSuite();
+    input.trials = GRAPH_BENCHMARK_SCENARIOS.flatMap((scenario, index) => {
+      const pair = input.trials.filter((entry) => entry.scenario === scenario);
+      const firstStrategy = index < 3 ? "single_loop" : "graph_orchestration";
+      return pair.map((entry) => ({
+        ...entry,
+        sequence: entry.strategy === firstStrategy ? (1 as const) : (2 as const),
+      }));
+    });
+
+    const report = analyzeGraphBenchmark(input);
+
+    expect(report.coverage.firstStrategyCounts).toEqual({ singleLoop: 3, graphOrchestration: 2 });
+    expect(report.qualification.mode).toBe("single_loop");
+    expect(report.qualification.reasons).toContain("trial_order_unbalanced");
+  });
+
+  it("派生比率でunknown reasonを保持し0除算をunknownとして扱う", () => {
+    const input = completeSuite();
+    const graphIndex = input.trials.findIndex(
+      (entry) => entry.pairId === "pair-1" && entry.strategy === "graph_orchestration",
+    );
+    const singleIndex = input.trials.findIndex(
+      (entry) => entry.pairId === "pair-1" && entry.strategy === "single_loop",
+    );
+    const graph = input.trials[graphIndex]!;
+    const single = input.trials[singleIndex]!;
+    input.trials[graphIndex] = {
+      ...graph,
+      metrics: {
+        ...graph.metrics,
+        inputTokens: unknown("redacted"),
+        costUsd: known(0),
+      },
+    };
+    input.trials[singleIndex] = {
+      ...single,
+      metrics: { ...single.metrics, costUsd: known(0) },
+    };
+
+    const comparison = analyzeGraphBenchmark(input).comparisons[0]!;
+
+    expect(comparison.totalTokenRatio).toEqual({ status: "unknown", reason: "redacted" });
+    expect(comparison.costRatio).toEqual({ status: "unknown", reason: "not_applicable" });
   });
 });
 

--- a/packages/smoke/src/graph-benchmark-run.ts
+++ b/packages/smoke/src/graph-benchmark-run.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { analyzeGraphBenchmark } from "./graph-benchmark.js";
+
+export interface GraphBenchmarkCliIo {
+  readText(path: string): Promise<string>;
+  writeText(path: string, value: string): Promise<void>;
+  stdout(value: string): void;
+  stderr(value: string): void;
+}
+
+interface GraphBenchmarkCliOptions {
+  input: string;
+  output: string | null;
+  requireQualified: boolean;
+}
+
+const USAGE = [
+  "使い方: pnpm benchmark:graph -- --input <record.json> [--output <report.json>] [--require-qualified]",
+  "",
+  "外部 runner の bounded observation を検証・比較する。agent や任意 shell command は実行しない。",
+].join("\n");
+
+function parseArgs(argv: string[]): GraphBenchmarkCliOptions | "help" {
+  let input: string | null = null;
+  let output: string | null = null;
+  let requireQualified = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") return "help";
+    if (argument === "--require-qualified") {
+      requireQualified = true;
+      continue;
+    }
+    if (argument === "--input" || argument === "--output") {
+      const value = argv[index + 1]?.trim();
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${argument} には path が必要です`);
+      }
+      if (argument === "--input") input = value;
+      else output = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`未対応の引数です: ${argument}`);
+  }
+
+  if (input === null) throw new Error("--input は必須です");
+  return { input, output, requireQualified };
+}
+
+const defaultIo: GraphBenchmarkCliIo = {
+  readText: (path) => readFile(resolve(path), "utf8"),
+  writeText: (path, value) => writeFile(resolve(path), value, "utf8"),
+  stdout: (value) => console.log(value),
+  stderr: (value) => console.error(value),
+};
+
+/**
+ * benchmark CLI の副作用を file I/O と表示だけに限定する。
+ * 成功 report には入力 evidence の本文や URI を含めない。
+ */
+export async function runGraphBenchmarkCli(
+  argv: string[],
+  io: GraphBenchmarkCliIo = defaultIo,
+): Promise<number> {
+  let options: GraphBenchmarkCliOptions | "help";
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    io.stderr(error instanceof Error ? error.message : String(error));
+    io.stderr(USAGE);
+    return 2;
+  }
+
+  if (options === "help") {
+    io.stdout(USAGE);
+    return 0;
+  }
+
+  try {
+    const input = JSON.parse(await io.readText(options.input)) as unknown;
+    const report = analyzeGraphBenchmark(input);
+    const serialized = `${JSON.stringify(report, null, 2)}\n`;
+    if (options.output === null) {
+      io.stdout(serialized.trimEnd());
+    } else {
+      await io.writeText(options.output, serialized);
+      io.stdout(
+        `Graph benchmark: mode=${report.qualification.mode} pairs=${report.coverage.completePairCount}`,
+      );
+    }
+    if (options.requireQualified && report.qualification.mode !== "graph_candidate") {
+      io.stderr(`Graph qualification failed: ${report.qualification.reasons.join(", ")}`);
+      return 1;
+    }
+    return 0;
+  } catch (error) {
+    io.stderr(`Graph benchmark failed: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  void runGraphBenchmarkCli(process.argv.slice(2)).then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/packages/smoke/src/graph-benchmark.ts
+++ b/packages/smoke/src/graph-benchmark.ts
@@ -128,6 +128,7 @@ function isPublicEvidenceUri(value: string): boolean {
         url.username === "" &&
         url.password === "" &&
         url.search === "" &&
+        url.hash === "" &&
         !localHostname
       );
     } catch {
@@ -136,6 +137,7 @@ function isPublicEvidenceUri(value: string): boolean {
   }
   if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(value)) return false;
   if (/^(?:[\\/]|~|[A-Za-z]:[\\/])/.test(value)) return false;
+  if (/[?#]/.test(value)) return false;
   const segments = value.split(/[\\/]/);
   return value.length > 0 && !segments.includes("..");
 }
@@ -386,22 +388,18 @@ export interface GraphBenchmarkReport {
 }
 
 function knownRatio(numerator: NumericMetric, denominator: NumericMetric): NumericMetric {
-  if (numerator.status === "unknown" || denominator.status === "unknown") {
-    return { status: "unknown", reason: "not_collected" };
-  }
+  if (numerator.status === "unknown") return numerator;
+  if (denominator.status === "unknown") return denominator;
   if (denominator.value === 0) {
-    return numerator.value === 0
-      ? { status: "known", value: 1 }
-      : { status: "unknown", reason: "not_applicable" };
+    return { status: "unknown", reason: "not_applicable" };
   }
   return { status: "known", value: numerator.value / denominator.value };
 }
 
 function totalTokens(trial: Trial): NumericMetric {
   const { inputTokens, outputTokens } = trial.metrics;
-  if (inputTokens.status === "unknown" || outputTokens.status === "unknown") {
-    return { status: "unknown", reason: "not_collected" };
-  }
+  if (inputTokens.status === "unknown") return inputTokens;
+  if (outputTokens.status === "unknown") return outputTokens;
   return { status: "known", value: inputTokens.value + outputTokens.value };
 }
 
@@ -442,9 +440,7 @@ export function analyzeGraphBenchmark(input: unknown): GraphBenchmarkReport {
     pair.push(trial);
     pairs.set(trial.pairId, pair);
   }
-  const comparisons = [...pairs.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([, pair], index) => comparePair(pair, index + 1));
+  const comparisons = [...pairs.values()].map((pair, index) => comparePair(pair, index + 1));
 
   const scenarioSet = new Set(suite.trials.map((trial) => trial.scenario));
   const recoverySet = new Set(suite.recoverySmoke.map((entry) => entry.scenario));
@@ -464,7 +460,13 @@ export function analyzeGraphBenchmark(input: unknown): GraphBenchmarkReport {
   if (comparisons.length < GRAPH_BENCHMARK_SCENARIOS.length) {
     pushReason(reasons, "paired_trial_count_insufficient");
   }
-  if (Math.abs(firstStrategyCounts.singleLoop - firstStrategyCounts.graphOrchestration) > 1) {
+  const trialOrderAlternates = comparisons.every(
+    (entry, index) => index === 0 || entry.firstStrategy !== comparisons[index - 1]!.firstStrategy,
+  );
+  if (
+    Math.abs(firstStrategyCounts.singleLoop - firstStrategyCounts.graphOrchestration) > 1 ||
+    !trialOrderAlternates
+  ) {
     pushReason(reasons, "trial_order_unbalanced");
   }
 

--- a/packages/smoke/src/graph-benchmark.ts
+++ b/packages/smoke/src/graph-benchmark.ts
@@ -217,29 +217,16 @@ const RecoverySmokeSchema = z
     }
   });
 
-const PublicEvidenceTextSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .max(500)
-  .refine(
-    (value) =>
-      !/(?:file:\/\/|(?:^|[\s="'(])(?:\/(?!\/)|~[\\/]|[A-Za-z]:[\\/]|\\\\)|(?:run|claim)-[0-9a-f]{8}-[0-9a-f-]{27,})/i.test(
-        value,
-      ),
-    { message: "公開evidenceへ絶対pathまたは内部opaque IDを含められません" },
-  );
+const RecoveryEvidenceReferenceSchema = EvidenceReferenceSchema.extend({
+  kind: z.literal("recovery"),
+});
 
 const RecoveryEvidenceObservationSchema = z
   .object({
     scenario: z.enum(RECOVERY_SMOKE_SCENARIOS),
-    faultInjection: PublicEvidenceTextSchema,
-    commands: z.array(PublicEvidenceTextSchema).min(1).max(10),
-    expectedPostconditions: z.array(PublicEvidenceTextSchema).min(1).max(20),
-    observedPostconditions: z.array(PublicEvidenceTextSchema).min(1).max(20),
     recoveryTimeMs: NumberMetricSchema,
     status: z.enum(["passed", "failed"]),
-    digest: SHA256_SCHEMA,
+    evidence: z.array(RecoveryEvidenceReferenceSchema).min(1).max(20),
   })
   .strict();
 
@@ -248,8 +235,6 @@ export const GraphRecoveryEvidencePackSchema = z
     schemaVersion: z.literal("1"),
     recordedAt: z.string().datetime(),
     baseRevision: REVISION_SCHEMA,
-    configSummary: PublicEvidenceTextSchema,
-    configFingerprint: SHA256_SCHEMA,
     observations: z
       .array(RecoveryEvidenceObservationSchema)
       .length(RECOVERY_SMOKE_SCENARIOS.length),

--- a/packages/smoke/src/graph-benchmark.ts
+++ b/packages/smoke/src/graph-benchmark.ts
@@ -1,0 +1,577 @@
+import { z } from "zod";
+
+export const GRAPH_BENCHMARK_SCENARIOS = [
+  "fixed_run_graph",
+  "ready_frontier",
+  "verify_failure_recovery",
+  "human_gate",
+  "approved_work_graph_mutation",
+] as const;
+
+export const RECOVERY_SMOKE_SCENARIOS = [
+  "runner_failure",
+  "process_restart",
+  "stale_lease",
+  "github_api_transient",
+  "sync_conflict",
+] as const;
+
+const UNKNOWN_REASONS = [
+  "provider_not_exposed",
+  "not_collected",
+  "not_applicable",
+  "redacted",
+] as const;
+
+const QUALIFICATION_REASONS = [
+  "scenario_coverage_incomplete",
+  "recovery_coverage_incomplete",
+  "recovery_failed",
+  "paired_trial_count_insufficient",
+  "trial_order_unbalanced",
+  "verified_success_unknown",
+  "verified_success_regression",
+  "ready_frontier_speedup_insufficient",
+  "resource_metrics_unknown",
+  "resource_inflation_exceeded",
+  "operational_metrics_unknown",
+  "coordination_metrics_unknown",
+  "coordination_failure_observed",
+  "recovery_time_unknown",
+] as const;
+
+const SHA256_SCHEMA = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+const REVISION_SCHEMA = z.string().regex(/^[0-9a-f]{40}$/);
+const OPAQUE_ID_SCHEMA = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+const UnknownReasonSchema = z.enum(UNKNOWN_REASONS);
+
+const UnknownMetricSchema = z
+  .object({
+    status: z.literal("unknown"),
+    reason: UnknownReasonSchema,
+  })
+  .strict();
+
+const KnownNumberMetricSchema = z
+  .object({
+    status: z.literal("known"),
+    value: z.number().finite().nonnegative(),
+  })
+  .strict();
+
+const KnownIntegerMetricSchema = z
+  .object({
+    status: z.literal("known"),
+    value: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const KnownVerifiedSuccessMetricSchema = z
+  .object({
+    status: z.literal("known"),
+    value: z.enum(["passed", "failed"]),
+  })
+  .strict();
+
+const NumberMetricSchema = z.discriminatedUnion("status", [
+  KnownNumberMetricSchema,
+  UnknownMetricSchema,
+]);
+
+const IntegerMetricSchema = z.discriminatedUnion("status", [
+  KnownIntegerMetricSchema,
+  UnknownMetricSchema,
+]);
+
+const VerifiedSuccessMetricSchema = z.discriminatedUnion("status", [
+  KnownVerifiedSuccessMetricSchema,
+  UnknownMetricSchema,
+]);
+
+const TrialMetricsSchema = z
+  .object({
+    verifiedSuccess: VerifiedSuccessMetricSchema,
+    wallClockMs: NumberMetricSchema,
+    inputTokens: IntegerMetricSchema,
+    outputTokens: IntegerMetricSchema,
+    costUsd: NumberMetricSchema,
+    runNodeCount: IntegerMetricSchema,
+    agentInvocationCount: IntegerMetricSchema,
+    toolCallCount: IntegerMetricSchema,
+    retryCount: IntegerMetricSchema,
+    humanInterventionCount: IntegerMetricSchema,
+    humanWaitMs: NumberMetricSchema,
+    recoveryTimeMs: NumberMetricSchema,
+    coordinationFailureCount: IntegerMetricSchema,
+  })
+  .strict();
+
+/** 公開 evidence は repository 相対 path または HTTPS URL に限定する。 */
+function isPublicEvidenceUri(value: string): boolean {
+  if (value.startsWith("https://")) {
+    try {
+      const url = new URL(value);
+      const hostname = url.hostname.toLowerCase();
+      const localHostname =
+        hostname === "localhost" ||
+        hostname.endsWith(".localhost") ||
+        hostname.endsWith(".local") ||
+        /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) ||
+        hostname.startsWith("[");
+      return (
+        url.protocol === "https:" &&
+        url.username === "" &&
+        url.password === "" &&
+        url.search === "" &&
+        !localHostname
+      );
+    } catch {
+      return false;
+    }
+  }
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(value)) return false;
+  if (/^(?:[\\/]|~|[A-Za-z]:[\\/])/.test(value)) return false;
+  const segments = value.split(/[\\/]/);
+  return value.length > 0 && !segments.includes("..");
+}
+
+const EvidenceReferenceSchema = z
+  .object({
+    kind: z.enum([
+      "verifier",
+      "run_graph",
+      "dispatch_claim",
+      "human_decision",
+      "mutation_receipt",
+      "recovery",
+    ]),
+    uri: z.string().trim().min(1).max(500).refine(isPublicEvidenceUri, {
+      message: "evidence uri は repository 相対 path または HTTPS URL が必要です",
+    }),
+    sha256: SHA256_SCHEMA,
+    byteLength: z.number().int().nonnegative().max(65_536),
+  })
+  .strict();
+
+const TrialSchema = z
+  .object({
+    id: OPAQUE_ID_SCHEMA,
+    pairId: OPAQUE_ID_SCHEMA,
+    sequence: z.union([z.literal(1), z.literal(2)]),
+    strategy: z.enum(["single_loop", "graph_orchestration"]),
+    scenario: z.enum(GRAPH_BENCHMARK_SCENARIOS),
+    acceptanceCriteriaHash: SHA256_SCHEMA,
+    repositoryRevision: REVISION_SCHEMA,
+    verifierHash: SHA256_SCHEMA,
+    environmentHash: SHA256_SCHEMA,
+    startedAt: z.string().datetime(),
+    finishedAt: z.string().datetime(),
+    metrics: TrialMetricsSchema,
+    evidence: z.array(EvidenceReferenceSchema).min(1).max(20),
+  })
+  .strict()
+  .superRefine((trial, context) => {
+    const started = Date.parse(trial.startedAt);
+    const finished = Date.parse(trial.finishedAt);
+    if (finished < started) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["finishedAt"],
+        message: "finishedAt は startedAt 以後である必要があります",
+      });
+    }
+    if (
+      trial.metrics.wallClockMs.status === "known" &&
+      trial.metrics.wallClockMs.value !== finished - started
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["metrics", "wallClockMs"],
+        message: "wallClockMs は startedAt と finishedAt の差に一致する必要があります",
+      });
+    }
+  });
+
+const RecoverySmokeSchema = z
+  .object({
+    scenario: z.enum(RECOVERY_SMOKE_SCENARIOS),
+    status: z.enum(["passed", "failed", "not_run"]),
+    recoveryTimeMs: NumberMetricSchema,
+    evidence: z.array(EvidenceReferenceSchema).max(20),
+  })
+  .strict()
+  .superRefine((entry, context) => {
+    if (entry.status === "passed" && entry.evidence.length === 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["evidence"],
+        message: "passed recovery smoke には evidence が必要です",
+      });
+    }
+  });
+
+const PublicEvidenceTextSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(500)
+  .refine(
+    (value) =>
+      !/(?:file:\/\/|(?:^|[\s="'(])(?:\/(?!\/)|~[\\/]|[A-Za-z]:[\\/]|\\\\)|(?:run|claim)-[0-9a-f]{8}-[0-9a-f-]{27,})/i.test(
+        value,
+      ),
+    { message: "公開evidenceへ絶対pathまたは内部opaque IDを含められません" },
+  );
+
+const RecoveryEvidenceObservationSchema = z
+  .object({
+    scenario: z.enum(RECOVERY_SMOKE_SCENARIOS),
+    faultInjection: PublicEvidenceTextSchema,
+    commands: z.array(PublicEvidenceTextSchema).min(1).max(10),
+    expectedPostconditions: z.array(PublicEvidenceTextSchema).min(1).max(20),
+    observedPostconditions: z.array(PublicEvidenceTextSchema).min(1).max(20),
+    recoveryTimeMs: NumberMetricSchema,
+    status: z.enum(["passed", "failed"]),
+    digest: SHA256_SCHEMA,
+  })
+  .strict();
+
+export const GraphRecoveryEvidencePackSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    recordedAt: z.string().datetime(),
+    baseRevision: REVISION_SCHEMA,
+    configSummary: PublicEvidenceTextSchema,
+    configFingerprint: SHA256_SCHEMA,
+    observations: z
+      .array(RecoveryEvidenceObservationSchema)
+      .length(RECOVERY_SMOKE_SCENARIOS.length),
+  })
+  .strict()
+  .superRefine((pack, context) => {
+    const scenarios = new Set(pack.observations.map((entry) => entry.scenario));
+    if (scenarios.size !== RECOVERY_SMOKE_SCENARIOS.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["observations"],
+        message: "recovery evidenceは5 scenarioを重複なく必要とします",
+      });
+    }
+  });
+
+export const GraphBenchmarkSuiteSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    suiteId: OPAQUE_ID_SCHEMA,
+    recordedAt: z.string().datetime(),
+    taskShape: z.string().trim().min(1).max(500),
+    trials: z.array(TrialSchema).min(2).max(200),
+    recoverySmoke: z.array(RecoverySmokeSchema).max(RECOVERY_SMOKE_SCENARIOS.length),
+  })
+  .strict()
+  .superRefine((suite, context) => {
+    const trialIds = new Set<string>();
+    const pairs = new Map<string, Array<(typeof suite.trials)[number]>>();
+    for (const [index, trial] of suite.trials.entries()) {
+      if (trialIds.has(trial.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trials", index, "id"],
+          message: "trial id が重複しています",
+        });
+      }
+      trialIds.add(trial.id);
+      const pair = pairs.get(trial.pairId) ?? [];
+      pair.push(trial);
+      pairs.set(trial.pairId, pair);
+    }
+
+    for (const pair of pairs.values()) {
+      if (pair.length !== 2) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trials"],
+          message: "pair は2 trialである必要があります",
+        });
+        continue;
+      }
+      const [left, right] = pair as [(typeof pair)[number], (typeof pair)[number]];
+      if (
+        new Set(pair.map((entry) => entry.sequence)).size !== 2 ||
+        new Set(pair.map((entry) => entry.strategy)).size !== 2
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trials"],
+          message: "pair はsequence 1/2と両strategyを1件ずつ必要とします",
+        });
+      }
+      const comparable = [
+        "scenario",
+        "acceptanceCriteriaHash",
+        "repositoryRevision",
+        "verifierHash",
+        "environmentHash",
+      ] as const;
+      if (comparable.some((key) => left[key] !== right[key])) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trials"],
+          message: "pair の比較条件が一致しません",
+        });
+      }
+    }
+
+    const recoveryIds = new Set<string>();
+    for (const [index, entry] of suite.recoverySmoke.entries()) {
+      if (recoveryIds.has(entry.scenario)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["recoverySmoke", index, "scenario"],
+          message: `recovery scenario が重複しています: ${entry.scenario}`,
+        });
+      }
+      recoveryIds.add(entry.scenario);
+    }
+  });
+
+export type GraphBenchmarkSuite = z.infer<typeof GraphBenchmarkSuiteSchema>;
+export type GraphRecoveryEvidencePack = z.infer<typeof GraphRecoveryEvidencePackSchema>;
+export type GraphBenchmarkScenario = (typeof GRAPH_BENCHMARK_SCENARIOS)[number];
+export type RecoverySmokeScenario = (typeof RECOVERY_SMOKE_SCENARIOS)[number];
+export type GraphBenchmarkQualificationReason = (typeof QUALIFICATION_REASONS)[number];
+
+type Trial = GraphBenchmarkSuite["trials"][number];
+type NumericMetric = z.infer<typeof NumberMetricSchema>;
+
+export interface GraphBenchmarkComparison {
+  pairOrdinal: number;
+  scenario: GraphBenchmarkScenario;
+  firstStrategy: Trial["strategy"];
+  verifiedSuccess: {
+    singleLoop: Trial["metrics"]["verifiedSuccess"];
+    graphOrchestration: Trial["metrics"]["verifiedSuccess"];
+  };
+  wallClockRatio: NumericMetric;
+  totalTokenRatio: NumericMetric;
+  costRatio: NumericMetric;
+}
+
+export interface GraphBenchmarkReport {
+  schemaVersion: "1";
+  coverage: {
+    completePairCount: number;
+    missingScenarios: GraphBenchmarkScenario[];
+    missingRecoveryScenarios: RecoverySmokeScenario[];
+    firstStrategyCounts: { singleLoop: number; graphOrchestration: number };
+  };
+  comparisons: GraphBenchmarkComparison[];
+  qualification: {
+    mode: "single_loop" | "graph_candidate";
+    reasons: GraphBenchmarkQualificationReason[];
+  };
+  initialPolicy: {
+    defaultStrategy: "single_loop" | "graph_orchestration";
+    dispatchConcurrency: 1 | 2;
+    automaticRetryBudget: 0 | 1;
+    humanGate: "required_for_remote_side_effects";
+    outputReferenceLimit: 20;
+    inlineEvidenceByteLimit: 0;
+  };
+}
+
+function knownRatio(numerator: NumericMetric, denominator: NumericMetric): NumericMetric {
+  if (numerator.status === "unknown" || denominator.status === "unknown") {
+    return { status: "unknown", reason: "not_collected" };
+  }
+  if (denominator.value === 0) {
+    return numerator.value === 0
+      ? { status: "known", value: 1 }
+      : { status: "unknown", reason: "not_applicable" };
+  }
+  return { status: "known", value: numerator.value / denominator.value };
+}
+
+function totalTokens(trial: Trial): NumericMetric {
+  const { inputTokens, outputTokens } = trial.metrics;
+  if (inputTokens.status === "unknown" || outputTokens.status === "unknown") {
+    return { status: "unknown", reason: "not_collected" };
+  }
+  return { status: "known", value: inputTokens.value + outputTokens.value };
+}
+
+function comparePair(pair: Trial[], pairOrdinal: number): GraphBenchmarkComparison {
+  const singleLoop = pair.find((entry) => entry.strategy === "single_loop")!;
+  const graph = pair.find((entry) => entry.strategy === "graph_orchestration")!;
+  const first = pair.find((entry) => entry.sequence === 1)!;
+  return {
+    pairOrdinal,
+    scenario: singleLoop.scenario,
+    firstStrategy: first.strategy,
+    verifiedSuccess: {
+      singleLoop: singleLoop.metrics.verifiedSuccess,
+      graphOrchestration: graph.metrics.verifiedSuccess,
+    },
+    wallClockRatio: knownRatio(graph.metrics.wallClockMs, singleLoop.metrics.wallClockMs),
+    totalTokenRatio: knownRatio(totalTokens(graph), totalTokens(singleLoop)),
+    costRatio: knownRatio(graph.metrics.costUsd, singleLoop.metrics.costUsd),
+  };
+}
+
+function pushReason(
+  reasons: GraphBenchmarkQualificationReason[],
+  reason: GraphBenchmarkQualificationReason,
+): void {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+/**
+ * 同一条件の観測だけを比較し、証拠不足時は single-loop へ縮退する。
+ * report は raw prompt/log/evidence 本文を返さない。
+ */
+export function analyzeGraphBenchmark(input: unknown): GraphBenchmarkReport {
+  const suite = GraphBenchmarkSuiteSchema.parse(input);
+  const pairs = new Map<string, Trial[]>();
+  for (const trial of suite.trials) {
+    const pair = pairs.get(trial.pairId) ?? [];
+    pair.push(trial);
+    pairs.set(trial.pairId, pair);
+  }
+  const comparisons = [...pairs.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, pair], index) => comparePair(pair, index + 1));
+
+  const scenarioSet = new Set(suite.trials.map((trial) => trial.scenario));
+  const recoverySet = new Set(suite.recoverySmoke.map((entry) => entry.scenario));
+  const missingScenarios = GRAPH_BENCHMARK_SCENARIOS.filter((id) => !scenarioSet.has(id));
+  const missingRecoveryScenarios = RECOVERY_SMOKE_SCENARIOS.filter((id) => !recoverySet.has(id));
+  const firstStrategyCounts = {
+    singleLoop: comparisons.filter((entry) => entry.firstStrategy === "single_loop").length,
+    graphOrchestration: comparisons.filter((entry) => entry.firstStrategy === "graph_orchestration")
+      .length,
+  };
+
+  const reasons: GraphBenchmarkQualificationReason[] = [];
+  if (missingScenarios.length > 0) pushReason(reasons, "scenario_coverage_incomplete");
+  if (missingRecoveryScenarios.length > 0) {
+    pushReason(reasons, "recovery_coverage_incomplete");
+  }
+  if (comparisons.length < GRAPH_BENCHMARK_SCENARIOS.length) {
+    pushReason(reasons, "paired_trial_count_insufficient");
+  }
+  if (Math.abs(firstStrategyCounts.singleLoop - firstStrategyCounts.graphOrchestration) > 1) {
+    pushReason(reasons, "trial_order_unbalanced");
+  }
+
+  if (suite.recoverySmoke.some((entry) => entry.status !== "passed")) {
+    pushReason(reasons, "recovery_failed");
+  }
+  if (
+    suite.recoverySmoke.some(
+      (entry) => entry.status === "passed" && entry.recoveryTimeMs.status === "unknown",
+    )
+  ) {
+    pushReason(reasons, "recovery_time_unknown");
+  }
+
+  const allSuccessMetrics = suite.trials.map((trial) => trial.metrics.verifiedSuccess);
+  if (allSuccessMetrics.some((metric) => metric.status === "unknown")) {
+    pushReason(reasons, "verified_success_unknown");
+  } else {
+    const singleFailures = suite.trials.filter(
+      (trial) =>
+        trial.strategy === "single_loop" &&
+        trial.metrics.verifiedSuccess.status === "known" &&
+        trial.metrics.verifiedSuccess.value === "failed",
+    ).length;
+    const graphFailures = suite.trials.filter(
+      (trial) =>
+        trial.strategy === "graph_orchestration" &&
+        trial.metrics.verifiedSuccess.status === "known" &&
+        trial.metrics.verifiedSuccess.value === "failed",
+    ).length;
+    if (graphFailures > singleFailures || graphFailures > 0) {
+      pushReason(reasons, "verified_success_regression");
+    }
+  }
+
+  const frontierComparisons = comparisons.filter((entry) => entry.scenario === "ready_frontier");
+  if (
+    frontierComparisons.length === 0 ||
+    frontierComparisons.some(
+      (entry) => entry.wallClockRatio.status === "unknown" || entry.wallClockRatio.value > 0.8,
+    )
+  ) {
+    pushReason(reasons, "ready_frontier_speedup_insufficient");
+  }
+
+  if (
+    comparisons.some(
+      (entry) => entry.totalTokenRatio.status === "unknown" || entry.costRatio.status === "unknown",
+    )
+  ) {
+    pushReason(reasons, "resource_metrics_unknown");
+  } else if (
+    comparisons.some(
+      (entry) =>
+        (entry.totalTokenRatio.status === "known" && entry.totalTokenRatio.value > 2) ||
+        (entry.costRatio.status === "known" && entry.costRatio.value > 2),
+    )
+  ) {
+    pushReason(reasons, "resource_inflation_exceeded");
+  }
+
+  const operationalMetricKeys = [
+    "wallClockMs",
+    "runNodeCount",
+    "agentInvocationCount",
+    "toolCallCount",
+    "retryCount",
+    "humanInterventionCount",
+    "humanWaitMs",
+    "recoveryTimeMs",
+  ] as const;
+  if (
+    suite.trials.some((trial) =>
+      operationalMetricKeys.some((key) => trial.metrics[key].status === "unknown"),
+    )
+  ) {
+    pushReason(reasons, "operational_metrics_unknown");
+  }
+
+  const coordinationMetrics = suite.trials.map((trial) => trial.metrics.coordinationFailureCount);
+  if (coordinationMetrics.some((metric) => metric.status === "unknown")) {
+    pushReason(reasons, "coordination_metrics_unknown");
+  } else if (coordinationMetrics.some((metric) => metric.status === "known" && metric.value > 0)) {
+    pushReason(reasons, "coordination_failure_observed");
+  }
+
+  const qualified = reasons.length === 0;
+  return {
+    schemaVersion: "1",
+    coverage: {
+      completePairCount: comparisons.length,
+      missingScenarios,
+      missingRecoveryScenarios,
+      firstStrategyCounts,
+    },
+    comparisons,
+    qualification: {
+      mode: qualified ? "graph_candidate" : "single_loop",
+      reasons,
+    },
+    initialPolicy: {
+      defaultStrategy: qualified ? "graph_orchestration" : "single_loop",
+      dispatchConcurrency: qualified ? 2 : 1,
+      automaticRetryBudget: qualified ? 1 : 0,
+      humanGate: "required_for_remote_side_effects",
+      outputReferenceLimit: 20,
+      inlineEvidenceByteLimit: 0,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@gh-gantt/cli':
         specifier: workspace:*
         version: link:../cli
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^24.0.0

--- a/scripts/req-validate.ts
+++ b/scripts/req-validate.ts
@@ -41,6 +41,7 @@ async function collectTestReqIds(): Promise<Set<string>> {
     "packages/cli/src/__tests__",
     "packages/shared/src/__tests__",
     "packages/ui/src/__tests__",
+    "packages/smoke/src/__tests__",
     "tests",
   ];
 

--- a/skills/gh-gantt-workflow/SKILL.md
+++ b/skills/gh-gantt-workflow/SKILL.md
@@ -155,6 +155,16 @@ proposal/revision/fingerprint/expiry binding済みcanonical machine blockを取�
 default viewはbounded summaryであり、coverage列挙の省略には使わない。cancelは常にhuman-only、
 ordered `sub_tasks` reorderはGitHub sub-issue priorityだけを変更する。
 
+## Graph Engineering の採用判断
+
+Graph Engineering は既定ではない。独立 ready frontier、独立 verifier、権限分離、長時間 recovery の
+いずれかが必要で、同一受入基準の paired trial が追加 overhead を正当化する場合だけ opt-in する。
+計測、導入、停止、復旧、public-safe evidence は
+[references/graph-engineering.md](references/graph-engineering.md) に従う。
+
+metric または recovery evidence が不足する場合は single-loop へ縮退する。benchmark の runner 初期値と
+Graph Contract / repository Config の contract ceiling を混同せず、human gate を性能結果から解除しない。
+
 ## 自律ループモード
 
 人間との対話なしで複数タスクを連続処理する場合（Claude Code の /loop 等）は、
@@ -198,3 +208,4 @@ ordered `sub_tasks` reorderはGitHub sub-issue priorityだけを変更する。
 ## リファレンス
 
 - コマンド詳細: [references/commands.md](references/commands.md)
+- Graph Engineering: [references/graph-engineering.md](references/graph-engineering.md)

--- a/skills/gh-gantt-workflow/references/graph-engineering.md
+++ b/skills/gh-gantt-workflow/references/graph-engineering.md
@@ -1,0 +1,128 @@
+# Graph Engineering の計測・導入・停止・復旧
+
+Graph Engineering は graph を作ることではなく、Plan / Work / Org / Run Graph を version、authority、evidence、
+budget、human gate で安全に結ぶ gh-gantt 固有の運用である。外部標準や品質保証として扱わない。
+設計判断は [ADR-026](../../../docs/adr/ADR-026-measured-graph-engineering-adoption.md)、一次資料は
+[調査ノート](../../../docs/research/graph-engineering-primary-sources.md)、導入前の実測結果は
+[Issue #332 benchmark](../../../docs/benchmarks/graph-engineering-2026-08-03.md)を参照する。
+machine-verifiable な recovery summary は
+[versioned evidence](../../../docs/benchmarks/graph-engineering-recovery-evidence.json)を正本とする。
+
+## 使う条件 / 使わない条件
+
+次のいずれかに実価値があり、追加 cost を paired trial で説明できる場合だけ opt-in する。
+
+- 依存のない ready frontier を2本以上、isolated workspace と claim で安全に並列化できる。
+- implementer と verifier、runner と human authority など、独立検証または権限分離が必要である。
+- 長時間実行を checkpoint、fencing、reconciliation から復旧する必要がある。
+- 承認付き Work Graph mutation を audit し、実行中 plan を暗黙変更せず新 versionへ進める必要がある。
+
+次は single-loop を使う。
+
+- 短い直列 task、単純な文言・設定変更、低価値 task。
+- 共有 context が大きく、subtask の独立性が低い coding task。
+- ready frontier、独立 verifier、remote side effect、recovery のどれも必要ない task。
+- token / cost / verified success が unknown のままで、追加 overhead を説明できない task。
+
+## 導入
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm benchmark:graph -- --input benchmark-record.json --output benchmark-report.json
+```
+
+`benchmark-record.json` は公開対象にしない作業用入力である。strict schemaは未定義のraw fieldと危険なevidence URIを
+拒否するが、suite / task shape / pair IDを公開可能とは保証しない。`benchmark-report.json` はこれらの入力値と
+元evidenceの本文・URIを再出力せず、pairを1始まりのordinalへ変換したqualification summaryである。
+
+CIや採用gateで Graph候補を必須にする場合だけ次を使う。
+
+```bash
+pnpm benchmark:graph -- --input benchmark-record.json --require-qualified
+```
+
+通常の分析は `single_loop` 判定でも exit 0、`--require-qualified` は `graph_candidate` 以外を exit 1 にする。
+
+## 評価 scenario と paired trial
+
+各 suite は次の5 scenarioに最低1 pairを持つ。
+
+| ID                             | 再現するもの                                                         |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `fixed_run_graph`              | fixed dev-role の plan → implement → verify → review → human handoff |
+| `ready_frontier`               | 独立 task の bounded claim、parallel execution、fan-in               |
+| `verify_failure_recovery`      | terminal attemptを保持した新 attempt / nodeでの再検証                |
+| `human_gate`                   | human decisionまでの停止、authority、principal separation            |
+| `approved_work_graph_mutation` | proposal、承認、apply / reconcile、新 plan version                   |
+
+pair は acceptance criteria hash、repository revision、verifier hash、environment hashを完全一致させる。
+`single_loop` と `graph_orchestration` の先行順を交互にし、単発の成功を全taskへ一般化しない。
+
+metric は `known` と `unknown` を混同しない。特に token / costを取得できないときに0を入れてはならない。
+verified success は agent の自己申告ではなく、同じ verifier の結果を使う。
+
+## 初期 policy と contract ceiling
+
+measurement gateが揃うまでのrunner初期値は次のとおり。
+
+- default: single-loop
+- dispatch: concurrency 1
+- automatic retry: 0（暗黙retryなし）
+- remote side effect / mutation: human gate 必須
+- output: `outputReferenceLimit: 20`、inline evidence 0 byte
+
+全5 scenario / recoveryと全metricがknownで揃い、ready frontierが20%以上短く、token / costが2倍以下、
+両armのcoordination failureがknown 0のtask shapeだけ、concurrency 2・automatic retry 1へ進める。
+
+これはrunner初期値であり、repositoryの`max_concurrency: 2`とGraph Contractの`maxExecutorRetries: 2`は
+contract ceilingである。benchmarkはcontract ceilingを変更・緩和しない。
+
+## 実環境 recovery smoke
+
+failure classをまとめて「復旧済み」としない。専用smoke環境で1件ずつ注入し、fault前のaccepted state、
+stale owner拒否、side-effect state、同一verifierのpostconditionを別々に残す。
+
+| ID                     | 安全な注入                                                             | 必須 postcondition                                                 |
+| ---------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `runner_failure`       | attemptを`failed`または`stalled`でterminal化しrunnerを停止             | 旧attemptを再開せず、新attemptまたはfail-closed handoffへ進む      |
+| `process_restart`      | commandごとにCLI processを終了し、別processで`run show` / `run resume` | checkpoint、attempt lineage、wait reasonを再観測できる             |
+| `stale_lease`          | 短いleaseを期限切れにして別ownerが`run reclaim --reason expired`       | 旧ownerのheartbeat / event / releaseが拒否される                   |
+| `github_api_transient` | transport seamで1回だけtimeout / unavailableを返す                     | retry指示とbudgetを守り、次の実read postconditionが一致する        |
+| `sync_conflict`        | 専用scratch taskの同一fieldをlocal / remoteで別変更する                | `gh-gantt conflicts`で検出し、明示resolve後に`No conflicts.`となる |
+
+`github_api_transient` では実 rate-limit や GitHub 障害を発生させない。大量requestや意図的な二次rate-limitは
+禁止し、fail-once / timeoutと回復後の実postconditionを組み合わせる。mutationを使う場合は専用repository、
+明示execute gate、最小scope、後処理を必須にする。
+
+## 停止
+
+次のいずれかで新規dispatchとautomatic retryを停止する。
+
+- verified success、authority、contract version、side-effect stateのいずれかがunknown。
+- 同じfailure classが反復、retry budget超過、claim contention、join wait、重複作業が増加。
+- GitHubの`retry-after` / rate-limit resetを守れない。
+- human gate、review gate、sync conflict、open iterationが残る。
+- Graph armがsingle-loopより遅い、またはtoken / costが2倍を超える。
+
+停止時はRun Graphの現在node、attempt、claim、checkpointをbounded viewで確認する。raw runner logから状態を
+推測せず、unknown side effectは自動再送しない。
+
+## 復旧
+
+1. `gh-gantt pull`、`gh-gantt status`、`gh-gantt conflicts`でWork Graphと同期gateを再確認する。
+2. `gh-gantt run show <run-id> --json`でcheckpoint、wait reason、claim auditを確認する。
+3. current ownerが停止済み、またはlease期限切れであることをevidence化してから`run reclaim`する。
+4. side effectが`not_started`なら再開可能。`committed` / `reconciled`はreconciliation evidenceを要求する。
+   `unknown`はhuman gateへ送り、自動再送しない。
+5. 同じacceptance verifierを再実行し、recovery timeとpostconditionをrecordへ追加する。
+6. benchmarkを再実行し、`graph_candidate`でなければsingle-loopのままにする。
+
+## public-safe evidence
+
+コミットまたはPRへ残せるのは、trial ordinal、scenario、sanitized task shape、repository revision、hash、件数、
+duration、outcome、failure class、repository相対path / HTTPS URLである。
+
+raw prompt、conversation、provider response、API token、private key、header、cookie、hostname、ユーザーの絶対 path、
+provider session / run ID、raw API responseは残さない。秘密をredactしても本文全体は保存せず、bounded summaryと
+SHA-256へ変換する。判断に迷う値は公開せず`unknown(reason)`にする。

--- a/skills/gh-gantt-workflow/references/graph-engineering.md
+++ b/skills/gh-gantt-workflow/references/graph-engineering.md
@@ -126,3 +126,7 @@ duration、outcome、failure class、repository相対path / HTTPS URLである�
 raw prompt、conversation、provider response、API token、private key、header、cookie、hostname、ユーザーの絶対 path、
 provider session / run ID、raw API responseは残さない。秘密をredactしても本文全体は保存せず、bounded summaryと
 SHA-256へ変換する。判断に迷う値は公開せず`unknown(reason)`にする。
+
+公開 recovery pack の observation は scenario、status、recovery time と evidence reference だけを持つ。
+reference の allowlist は kind、repository相対path / HTTPS URI、SHA-256、byte length とし、command、
+fault injection、postcondition本文は非公開の実行記録へ分離する。

--- a/tests/workflow/graph-engineering-benchmark.test.ts
+++ b/tests/workflow/graph-engineering-benchmark.test.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { GraphRecoveryEvidencePackSchema } from "../../packages/smoke/src/graph-benchmark.js";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(resolve(ROOT, path), "utf8");
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+describe("[NFR-STABILITY-016-AC4] Graph Engineering benchmark CLI", () => {
+  it("smoke packageの要件タグをreq:validateの走査対象にする", async () => {
+    const validator = await readRepoFile("scripts/req-validate.ts");
+
+    expect(validator).toContain('"packages/smoke/src/__tests__"');
+  });
+});
+
+describe("[NFR-STABILITY-016-AC5] Graph Engineering の実環境 recovery smoke", () => {
+  it("5つのfailure classを別々のpostconditionとevidenceで検証する", async () => {
+    const [reference, benchmark, evidenceText] = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/references/graph-engineering.md"),
+      readRepoFile("docs/benchmarks/graph-engineering-2026-08-03.md"),
+      readRepoFile("docs/benchmarks/graph-engineering-recovery-evidence.json"),
+    ]);
+    const evidence = GraphRecoveryEvidencePackSchema.parse(JSON.parse(evidenceText));
+
+    const scenarios = [
+      "runner_failure",
+      "process_restart",
+      "stale_lease",
+      "github_api_transient",
+      "sync_conflict",
+    ];
+    expect(evidence.schemaVersion).toBe("1");
+    expect(evidence.baseRevision).toMatch(/^[0-9a-f]{40}$/);
+    expect(evidence.configFingerprint).toBe(
+      `sha256:${createHash("sha256").update(evidence.configSummary).digest("hex")}`,
+    );
+    expect(evidence.observations.map((entry) => entry.scenario).sort()).toEqual(
+      [...scenarios].sort(),
+    );
+
+    for (const scenario of scenarios) {
+      expect(reference).toContain(`\`${scenario}\``);
+      expect(benchmark).toContain(`\`${scenario}\``);
+      const observation = evidence.observations.find((entry) => entry.scenario === scenario)!;
+      const { digest, ...payload } = observation;
+      expect(observation.status).toBe("passed");
+      expect(observation.commands.length).toBeGreaterThan(0);
+      expect(observation.expectedPostconditions.length).toBeGreaterThan(0);
+      expect(observation.observedPostconditions).toEqual(observation.expectedPostconditions);
+      expect(digest).toBe(
+        `sha256:${createHash("sha256").update(canonicalJson(payload)).digest("hex")}`,
+      );
+    }
+    expect(evidenceText).not.toMatch(/(?:\/Users\/|\/private\/tmp\/|file:\/\/)/);
+    expect(evidenceText).not.toMatch(/(?:run|claim)-[0-9a-f]{8}-[0-9a-f-]{27,}/);
+    expect(
+      GraphRecoveryEvidencePackSchema.safeParse({ ...evidence, rawRunnerLog: "非公開" }).success,
+    ).toBe(false);
+    for (const configSummary of [
+      "/etc/passwd",
+      "command /home/user/evidence.json",
+      "~/private/evidence.json",
+      "C:\\temp\\evidence.json",
+      "\\\\server\\share\\evidence.json",
+      "file:///tmp/evidence.json",
+    ]) {
+      expect(
+        GraphRecoveryEvidencePackSchema.safeParse({ ...evidence, configSummary }).success,
+        configSummary,
+      ).toBe(false);
+    }
+    expect(reference).toContain("実 rate-limit や GitHub 障害を発生させない");
+    expect(reference).toContain("postcondition");
+    expect(reference).toContain("raw prompt");
+    expect(reference).toContain("絶対 path");
+    expect(benchmark).toContain("single_loop");
+    expect(benchmark).toContain("paired_trial_count_insufficient");
+    expect(benchmark).toContain("resource_metrics_unknown");
+    expect(benchmark).toContain("operational_metrics_unknown");
+    expect(benchmark).toContain("recovery_time_unknown");
+    expect(benchmark).toContain("unknown (`not_collected`)");
+    expect(benchmark).toContain("graph-engineering-recovery-evidence.json");
+  });
+});
+
+describe("[NFR-STABILITY-016-AC6] Graph Engineering の導入・停止・復旧導線", () => {
+  it("root script、README、workflow、Project Mapを同じ運用referenceへ結ぶ", async () => {
+    const rootPackage = JSON.parse(await readRepoFile("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const [readme, workflow, projectMap, smokeReadme] = await Promise.all([
+      readRepoFile("README.md"),
+      readRepoFile("skills/gh-gantt-workflow/SKILL.md"),
+      readRepoFile("docs/project-map.md"),
+      readRepoFile("packages/smoke/README.md"),
+    ]);
+
+    expect(rootPackage.scripts["benchmark:graph"]).toBe(
+      "pnpm --filter @gh-gantt/smoke benchmark:graph",
+    );
+    for (const content of [readme, workflow, projectMap, smokeReadme]) {
+      expect(content).toContain("graph-engineering.md");
+    }
+    expect(smokeReadme).toContain("--require-qualified");
+    expect(smokeReadme).toContain("single_loop");
+    expect(smokeReadme).toContain("graph_candidate");
+  });
+
+  it("single-loop既定とcontract ceilingをbenchmark推奨から分離する", async () => {
+    const [reference, adr] = await Promise.all([
+      readRepoFile("skills/gh-gantt-workflow/references/graph-engineering.md"),
+      readRepoFile("docs/adr/ADR-026-measured-graph-engineering-adoption.md"),
+    ]);
+
+    for (const content of [reference, adr]) {
+      expect(content).toContain("single-loop");
+      expect(content).toContain("concurrency 1");
+      expect(content).toContain("contract ceiling");
+      expect(content).toContain("human gate");
+      expect(content).toContain("outputReferenceLimit: 20");
+    }
+  });
+});
+
+describe("[NFR-STABILITY-016-AC7] Graph Engineering の一次資料境界", () => {
+  it("外部一次資料の事実とgh-gantt固有の推論を混同しない", async () => {
+    const [research, adr] = await Promise.all([
+      readRepoFile("docs/research/graph-engineering-primary-sources.md"),
+      readRepoFile("docs/adr/ADR-026-measured-graph-engineering-adoption.md"),
+    ]);
+
+    expect(research).toContain("事実");
+    expect(research).toContain("推論");
+    expect(research).toContain("90.2%");
+    expect(research).toContain("約 15 倍");
+    expect(research).toContain("coding task");
+    expect(research).toContain("memory-only");
+    expect(adr).toContain("Graph Engineering は外部標準ではない");
+    expect(adr).toContain("Symphony");
+  });
+});

--- a/tests/workflow/graph-engineering-benchmark.test.ts
+++ b/tests/workflow/graph-engineering-benchmark.test.ts
@@ -2,23 +2,15 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { GraphRecoveryEvidencePackSchema } from "../../packages/smoke/src/graph-benchmark.js";
 
 const ROOT = resolve(import.meta.dirname, "../..");
+const RootPackageSchema = z.object({ scripts: z.record(z.string()) });
 
 async function readRepoFile(path: string): Promise<string> {
   return readFile(resolve(ROOT, path), "utf8");
-}
-
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
-    .join(",")}}`;
 }
 
 describe("[NFR-STABILITY-016-AC4] Graph Engineering benchmark CLI", () => {
@@ -47,42 +39,61 @@ describe("[NFR-STABILITY-016-AC5] Graph Engineering の実環境 recovery smoke"
     ];
     expect(evidence.schemaVersion).toBe("1");
     expect(evidence.baseRevision).toMatch(/^[0-9a-f]{40}$/);
-    expect(evidence.configFingerprint).toBe(
-      `sha256:${createHash("sha256").update(evidence.configSummary).digest("hex")}`,
-    );
     expect(evidence.observations.map((entry) => entry.scenario).sort()).toEqual(
       [...scenarios].sort(),
     );
+    const benchmarkDigest = `sha256:${createHash("sha256").update(benchmark).digest("hex")}`;
+    const benchmarkByteLength = Buffer.byteLength(benchmark);
 
     for (const scenario of scenarios) {
       expect(reference).toContain(`\`${scenario}\``);
       expect(benchmark).toContain(`\`${scenario}\``);
       const observation = evidence.observations.find((entry) => entry.scenario === scenario)!;
-      const { digest, ...payload } = observation;
       expect(observation.status).toBe("passed");
-      expect(observation.commands.length).toBeGreaterThan(0);
-      expect(observation.expectedPostconditions.length).toBeGreaterThan(0);
-      expect(observation.observedPostconditions).toEqual(observation.expectedPostconditions);
-      expect(digest).toBe(
-        `sha256:${createHash("sha256").update(canonicalJson(payload)).digest("hex")}`,
-      );
+      expect(observation.evidence).toEqual([
+        {
+          kind: "recovery",
+          uri: "docs/benchmarks/graph-engineering-2026-08-03.md",
+          sha256: benchmarkDigest,
+          byteLength: benchmarkByteLength,
+        },
+      ]);
     }
     expect(evidenceText).not.toMatch(/(?:\/Users\/|\/private\/tmp\/|file:\/\/)/);
     expect(evidenceText).not.toMatch(/(?:run|claim)-[0-9a-f]{8}-[0-9a-f-]{27,}/);
     expect(
       GraphRecoveryEvidencePackSchema.safeParse({ ...evidence, rawRunnerLog: "非公開" }).success,
     ).toBe(false);
-    for (const configSummary of [
+    const firstObservation = evidence.observations[0]!;
+    expect(
+      GraphRecoveryEvidencePackSchema.safeParse({
+        ...evidence,
+        observations: [
+          { ...firstObservation, commands: ["gh-gantt run show <run-id> --json"] },
+          ...evidence.observations.slice(1),
+        ],
+      }).success,
+    ).toBe(false);
+    for (const uri of [
       "/etc/passwd",
-      "command /home/user/evidence.json",
+      "/home/user/evidence.json",
       "~/private/evidence.json",
       "C:\\temp\\evidence.json",
       "\\\\server\\share\\evidence.json",
       "file:///tmp/evidence.json",
     ]) {
       expect(
-        GraphRecoveryEvidencePackSchema.safeParse({ ...evidence, configSummary }).success,
-        configSummary,
+        GraphRecoveryEvidencePackSchema.safeParse({
+          ...evidence,
+          observations: [
+            {
+              ...firstObservation,
+              evidence: [{ ...firstObservation.evidence[0]!, uri }],
+            },
+            ...evidence.observations.slice(1),
+          ],
+        }).success,
+        uri,
       ).toBe(false);
     }
     expect(reference).toContain("実 rate-limit や GitHub 障害を発生させない");
@@ -101,9 +112,7 @@ describe("[NFR-STABILITY-016-AC5] Graph Engineering の実環境 recovery smoke"
 
 describe("[NFR-STABILITY-016-AC6] Graph Engineering の導入・停止・復旧導線", () => {
   it("root script、README、workflow、Project Mapを同じ運用referenceへ結ぶ", async () => {
-    const rootPackage = JSON.parse(await readRepoFile("package.json")) as {
-      scripts: Record<string, string>;
-    };
+    const rootPackage = RootPackageSchema.parse(JSON.parse(await readRepoFile("package.json")));
     const [readme, workflow, projectMap, smokeReadme] = await Promise.all([
       readRepoFile("README.md"),
       readRepoFile("skills/gh-gantt-workflow/SKILL.md"),


### PR DESCRIPTION
## Summary

- Graph Engineering を single loop と同一受入基準で比較するため、既知値と unknown を区別する厳格な benchmark report schema と判定 CLI を追加しました
- agent / runner 障害、process restart、stale lease、GitHub API 一時障害、同期 conflict の5種類について、公開可能で digest-bound な recovery evidence と検証テストを追加しました
- 実測値が不足する場合は graph orchestration を昇格させず、single loop・concurrency 1・retry 0・human gate・output refs 20 を安全側の既定値とする ADR と運用ガイドを追加しました
- README、Project Map、workflow skill、requirements のトレーサビリティを更新しました
- 公開 evidence から credential、query、fragment、絶対パス、raw ID を拒否し、入力識別子を report に出力しない境界をテストで固定しました
- 公開 recovery pack は scenario / status / recovery time と、kind / URI / SHA-256 / byte length の strict reference envelope だけに限定し、command・fault injection・postcondition 本文を非公開実行記録へ分離しました
- suite 順で先行 strategy が実際に交互であることを検証し、件数だけ均衡した grouped 順序を fail-closed にしました

Closes #332

## Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:json`（workflow 79、shared 252、ui 229、cli 941、smoke 31）
- `pnpm build`
- `pnpm req:trace`（covered 219、uncovered 19、failing 0）
- `git diff --exit-code docs/requirements.yaml`
- `pnpm req:validate`（合格。既存の orphan warning 19 件）
- `pnpm docs:gen`
- 実環境 recovery smoke 5 種類（runner failure、process restart、stale lease、GitHub API 一時障害、sync conflict）
- betterleaks v1.1.2 pinned digest による staged 差分と `main...HEAD` 全差分の scan（漏洩なし）

## Evidence boundary

- recovery smoke は5種類すべて成功しています
- 同条件の single loop / graph ペア、token・cost・一部 resource metric は未収集です。このため graph orchestration は既定化せず、判定は fail-closed のままです
- evidence は要約と digest のみを保存し、秘密情報、raw API response、raw run/claim ID、ローカル絶対パスは含めていません
